### PR TITLE
Added generated stuff to gitignore, will be generated each build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ node_modules
 ## PMD
 .pmd
 .pmdruleset.xml
+
+## Generated classes and resources
+cds-feature-attachments/src/gen/
+cds-feature-attachments/src/test/gen/
+cds-feature-attachments/src/test/resources/gen/
+cds-feature-attachments/src/test/resources/schema.sql


### PR DESCRIPTION
A lot of classes and resources are generated during Maven build. There is no need to put them under version control and they can be ignored.