### PR TITLE
Add annotation @Core.ContentDisposition to get fileName on creation

### DIFF
--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
@@ -34,6 +34,7 @@ annotate Attachments with @UI: {
         {Value: note}
     ]
 } {
+    content    @Core.ContentDisposition: { Filename: fileName, Type: 'inline' };
     note       @(title: '{i18n>attachment_note}');
     modifiedAt @(odata.etag);
 }


### PR DESCRIPTION
Add annotation @Core.ContentDisposition to get fileName on creation of attachment.

With this annotation added, the Fiori UI sends a request containing the fileName to create the attachments:

```
--batch_id-1729000376682-418
Content-Type:application/http
Content-Transfer-Encoding:binary
 
POST Books(ID=4a519e61-3c3a-4bd9-ab12-d7e0c5329933,IsActiveEntity=false)/covers HTTP/1.1
Accept:application/json;odata.metadata=minimal;IEEE754Compatible=true
Accept-Language:en-US
Content-Type:application/json;charset=UTF-8;IEEE754Compatible=true
 
{"fileName":"catweazle.jpg"}
--batch_id-1729000376682-418--
Group ID: $auto
```

See also: https://github.com/cap-js/attachments/blob/898eca7a89a84f15c59ce5a85bea117df19952d2/index.cds#L44