### PR TITLE
Add HTML5 CSS annotations containing column width

### DIFF
--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
@@ -27,11 +27,11 @@ annotate Attachments with @UI: {
         TypeNamePlural: '{i18n>attachments}',
     },
     LineItem  : [
-        {Value: content},
-        {Value: status},
-        {Value: createdAt},
-        {Value: createdBy},
-        {Value: note}
+        {Value: content,   @HTML5.CssDefaults: {width: '30%'}},
+        {Value: status,    @HTML5.CssDefaults: {width: '10%'}},
+        {Value: createdAt, @HTML5.CssDefaults: {width: '20%'}},
+        {Value: createdBy, @HTML5.CssDefaults: {width: '15%'}},
+        {Value: note,      @HTML5.CssDefaults: {width: '25%'}}
     ]
 } {
     note       @(title: '{i18n>attachment_note}');


### PR DESCRIPTION
Add HTML5 CSS annotations to specify column width to be in sync with the Node.js Attachment plugin:

https://github.com/cap-js/attachments/blob/1da65f97d4d358bba5e37acd57682d0375e6f729/index.cds#L36C1-L41C1
