### PR TITLE
Removed not required parameter contentIdExist

### DIFF
--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -301,12 +301,12 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.95</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.95</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>CLASS</counter>

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -301,12 +301,12 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>CLASS</counter>

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
@@ -45,11 +45,10 @@ public final class ModifyApplicationHandlerHelper {
 		var keys = ApplicationHandlerHelper.removeDraftKeys(path.target().keys());
 		ReadonlyDataContextEnhancer.fillReadonlyInContext((CdsData) path.target().values());
 		var existingData = getExistingData(keys, existingDataList);
-		var contentIdExists = path.target().values().containsKey(Attachments.CONTENT_ID);
 		var contentId = (String) path.target().values().get(Attachments.CONTENT_ID);
 
 		// for the current request find the event to process
-		ModifyAttachmentEvent eventToProcess = eventFactory.getEvent(content, contentId, contentIdExists, existingData);
+		ModifyAttachmentEvent eventToProcess = eventFactory.getEvent(content, contentId, existingData);
 
 		// process the event
 		return eventToProcess.processEvent(path, content, existingData, eventContext);

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/DefaultModifyAttachmentEventFactory.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/DefaultModifyAttachmentEventFactory.java
@@ -12,10 +12,9 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachmen
 import com.sap.cds.feature.attachments.service.AttachmentService;
 
 /**
- * The class {@link DefaultModifyAttachmentEventFactory} is a factory class
- * that creates the corresponding event for the attachment service {@link AttachmentService}.
- * The class is used to determine the event that should be executed based on the content,
- * the contentId and the existingData.<br>
+ * The class {@link DefaultModifyAttachmentEventFactory} is a factory class that creates the corresponding event for the
+ * attachment service {@link AttachmentService}. The class is used to determine the event that should be executed based
+ * on the content, the contentId and the existingData.<br>
  * The events could be:
  * <ul>
  * <li>create</li>
@@ -40,15 +39,15 @@ public class DefaultModifyAttachmentEventFactory implements ModifyAttachmentEven
 	}
 
 	@Override
-	public ModifyAttachmentEvent getEvent(InputStream content, String contentId, boolean contentIdExist, CdsData existingData) {
+	public ModifyAttachmentEvent getEvent(InputStream content, String contentId, CdsData existingData) {
 		var existingContentId = existingData.get(Attachments.CONTENT_ID);
-		var event = contentIdExist ? handleExistingContentId(content, contentId,
-				existingContentId) : handleNonExistingContentId(content, existingContentId);
+		var event = contentId != null ? handleExistingContentId(content, contentId, (String) existingContentId)
+				: handleNonExistingContentId(content, existingContentId);
 		return event.orElse(doNothingEvent);
 	}
 
 	private Optional<ModifyAttachmentEvent> handleExistingContentId(Object content, String contentId,
-			Object existingContentId) {
+			String existingContentId) {
 		ModifyAttachmentEvent event = null;
 		if (Objects.isNull(contentId) && Objects.isNull(existingContentId) && Objects.nonNull(content)) {
 			event = createEvent;
@@ -63,12 +62,12 @@ public class DefaultModifyAttachmentEventFactory implements ModifyAttachmentEven
 		if (Objects.nonNull(contentId) && contentId.equals(existingContentId) && Objects.nonNull(content)) {
 			event = updateEvent;
 		}
-		if (Objects.nonNull(contentId) && Objects.nonNull(existingContentId) && !contentId.equals(
-				existingContentId) && Objects.isNull(content)) {
+		if (Objects.nonNull(contentId) && Objects.nonNull(existingContentId) && !contentId.equals(existingContentId)
+				&& Objects.isNull(content)) {
 			event = deleteContentEvent;
 		}
-		if (Objects.nonNull(contentId) && Objects.nonNull(existingContentId) && !contentId.equals(
-				existingContentId) && Objects.nonNull(content)) {
+		if (Objects.nonNull(contentId) && Objects.nonNull(existingContentId) && !contentId.equals(existingContentId)
+				&& Objects.nonNull(content)) {
 			event = updateEvent;
 		}
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/DefaultModifyAttachmentEventFactory.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/DefaultModifyAttachmentEventFactory.java
@@ -46,7 +46,7 @@ public class DefaultModifyAttachmentEventFactory implements ModifyAttachmentEven
 		return event.orElse(doNothingEvent);
 	}
 
-	private Optional<ModifyAttachmentEvent> handleExistingContentId(Object content, String contentId,
+	private Optional<ModifyAttachmentEvent> handleExistingContentId(InputStream content, String contentId,
 			String existingContentId) {
 		ModifyAttachmentEvent event = null;
 		if (contentId.equals(existingContentId) && Objects.nonNull(content)) {

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/DefaultModifyAttachmentEventFactory.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/DefaultModifyAttachmentEventFactory.java
@@ -49,25 +49,13 @@ public class DefaultModifyAttachmentEventFactory implements ModifyAttachmentEven
 	private Optional<ModifyAttachmentEvent> handleExistingContentId(Object content, String contentId,
 			String existingContentId) {
 		ModifyAttachmentEvent event = null;
-		if (Objects.isNull(contentId) && Objects.isNull(existingContentId) && Objects.nonNull(content)) {
-			event = createEvent;
-		}
-		if (Objects.isNull(contentId) && Objects.nonNull(existingContentId)) {
-			if (Objects.nonNull(content)) {
-				event = updateEvent;
-			} else {
-				event = deleteContentEvent;
-			}
-		}
-		if (Objects.nonNull(contentId) && contentId.equals(existingContentId) && Objects.nonNull(content)) {
+		if (contentId.equals(existingContentId) && Objects.nonNull(content)) {
 			event = updateEvent;
 		}
-		if (Objects.nonNull(contentId) && Objects.nonNull(existingContentId) && !contentId.equals(existingContentId)
-				&& Objects.isNull(content)) {
+		if (Objects.nonNull(existingContentId) && !contentId.equals(existingContentId) && Objects.isNull(content)) {
 			event = deleteContentEvent;
 		}
-		if (Objects.nonNull(contentId) && Objects.nonNull(existingContentId) && !contentId.equals(existingContentId)
-				&& Objects.nonNull(content)) {
+		if (Objects.nonNull(existingContentId) && !contentId.equals(existingContentId) && Objects.nonNull(content)) {
 			event = updateEvent;
 		}
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/ModifyAttachmentEventFactory.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/ModifyAttachmentEventFactory.java
@@ -21,10 +21,9 @@ public interface ModifyAttachmentEventFactory {
 	 * 
 	 * @param content        the optional content as {@link InputStream}
 	 * @param contentId      the optional content id
-	 * @param contentIdExist the flag if the content id exists
 	 * @param existingData   the existing {@link CdsData data}
 	 * @return the corresponding {@link ModifyAttachmentEvent} that should be executed
 	 */
-	ModifyAttachmentEvent getEvent(InputStream content, String contentId, boolean contentIdExist, CdsData existingData);
+	ModifyAttachmentEvent getEvent(InputStream content, String contentId, CdsData existingData);
 
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
@@ -3,7 +3,6 @@ package com.sap.cds.feature.attachments.handler.applicationservice;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -87,7 +86,7 @@ class CreateAttachmentsHandlerTest {
 		attachment.setContent(null);
 		attachment.put("up__ID", "test");
 		roots.setAttachments(List.of(attachment));
-		when(eventFactory.getEvent(any(), any(), anyBoolean(), any())).thenReturn(event);
+		when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 
 		cut.processBefore(createContext, List.of(roots));
 
@@ -102,11 +101,11 @@ class CreateAttachmentsHandlerTest {
 		try (var testStream = new ByteArrayInputStream("testString".getBytes(StandardCharsets.UTF_8))) {
 			var attachment = Attachments.create();
 			attachment.setContent(testStream);
-			when(eventFactory.getEvent(any(), any(), anyBoolean(), any())).thenReturn(event);
+			when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 
 			cut.processBefore(createContext, List.of(attachment));
 
-			verify(eventFactory).getEvent(testStream, null, false, CdsData.create());
+			verify(eventFactory).getEvent(testStream, null, CdsData.create());
 		}
 	}
 
@@ -178,7 +177,7 @@ class CreateAttachmentsHandlerTest {
 		try (var testStream = new ByteArrayInputStream("testString".getBytes(StandardCharsets.UTF_8))) {
 			var attachment = Attachments.create();
 			attachment.setContent(testStream);
-			when(eventFactory.getEvent(any(), any(), anyBoolean(), any())).thenReturn(event);
+			when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 			when(createContext.getService()).thenReturn(mock(ApplicationService.class));
 
 			cut.processBeforeForDraft(createContext, List.of(attachment));
@@ -193,7 +192,7 @@ class CreateAttachmentsHandlerTest {
 		var attachment = Attachments.create();
 		attachment.setFileName("test.txt");
 		attachment.setContent(null);
-		when(eventFactory.getEvent(any(), any(), anyBoolean(), any())).thenReturn(event);
+		when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 		when(event.processEvent(any(), any(), any(), any())).thenThrow(new ServiceException(""));
 
 		List<CdsData> input = List.of(attachment);
@@ -210,7 +209,7 @@ class CreateAttachmentsHandlerTest {
 		attachment.setContent(mock(InputStream.class));
 		items.setAttachments(List.of(attachment));
 		events.setItems(List.of(items));
-		when(eventFactory.getEvent(any(), any(), anyBoolean(), any())).thenReturn(event);
+		when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 
 		List<CdsData> input = List.of(events);
 		cut.processBefore(createContext, input);
@@ -232,11 +231,11 @@ class CreateAttachmentsHandlerTest {
 		attachment.setContent(testStream);
 		attachment.put("DRAFT_READONLY_CONTEXT", readonlyFields);
 
-		when(eventFactory.getEvent(any(), any(), anyBoolean(), any())).thenReturn(event);
+		when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 
 		cut.processBefore(createContext, List.of(attachment));
 
-		verify(eventFactory).getEvent(testStream, (String) readonlyFields.get(Attachment.CONTENT_ID), true, CdsData.create());
+		verify(eventFactory).getEvent(testStream, (String) readonlyFields.get(Attachment.CONTENT_ID), CdsData.create());
 		assertThat(attachment.get(DRAFT_READONLY_CONTEXT)).isNull();
 		assertThat(attachment.getContentId()).isEqualTo(readonlyFields.get(Attachment.CONTENT_ID));
 		assertThat(attachment.getStatus()).isEqualTo(readonlyFields.get(Attachment.STATUS));
@@ -253,7 +252,7 @@ class CreateAttachmentsHandlerTest {
 		attachment.setContent(mock(InputStream.class));
 		eventItems.setAttachments(List.of(attachment));
 		events.setEventItems(List.of(eventItems));
-		when(eventFactory.getEvent(any(), any(), anyBoolean(), any())).thenReturn(event);
+		when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 
 		List<CdsData> input = List.of(events);
 		cut.processBefore(createContext, input);

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandlerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -85,7 +84,7 @@ class UpdateAttachmentsHandlerTest {
 		updateContext = mock(CdsUpdateEventContext.class);
 		cdsDataArgumentCaptor = ArgumentCaptor.forClass(CdsData.class);
 		selectCaptor = ArgumentCaptor.forClass(CqnSelect.class);
-		when(eventFactory.getEvent(any(), any(), anyBoolean(), any())).thenReturn(event);
+		when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 		userInfo = mock(UserInfo.class);
 	}
 
@@ -113,7 +112,7 @@ class UpdateAttachmentsHandlerTest {
 
 		cut.processBefore(updateContext, List.of(attachment));
 
-		verify(eventFactory).getEvent(testStream, null, false, attachment);
+		verify(eventFactory).getEvent(testStream, null, attachment);
 	}
 
 	@Test
@@ -129,11 +128,11 @@ class UpdateAttachmentsHandlerTest {
 		attachment.setContent(testStream);
 		attachment.put("DRAFT_READONLY_CONTEXT", readonlyUpdateFields);
 
-		when(eventFactory.getEvent(any(), any(), anyBoolean(), any())).thenReturn(event);
+		when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 
 		cut.processBefore(updateContext, List.of(attachment));
 
-		verify(eventFactory).getEvent(testStream, (String) readonlyUpdateFields.get(Attachment.CONTENT_ID), true,
+		verify(eventFactory).getEvent(testStream, (String) readonlyUpdateFields.get(Attachment.CONTENT_ID), 
 				CdsData.create());
 		assertThat(attachment.get(DRAFT_READONLY_CONTEXT)).isNull();
 		assertThat(attachment.getContentId()).isEqualTo(readonlyUpdateFields.get(Attachment.CONTENT_ID));
@@ -242,7 +241,7 @@ class UpdateAttachmentsHandlerTest {
 
 		cut.processBefore(updateContext, List.of(root));
 
-		verify(eventFactory).getEvent(eq(testStream), eq(null), eq(false), cdsDataArgumentCaptor.capture());
+		verify(eventFactory).getEvent(eq(testStream), eq(null), cdsDataArgumentCaptor.capture());
 		assertThat(cdsDataArgumentCaptor.getValue()).isEqualTo(root.getAttachments().get(0));
 		cdsDataArgumentCaptor.getAllValues().clear();
 		verify(event).processEvent(any(), eq(testStream), cdsDataArgumentCaptor.capture(), eq(updateContext));
@@ -259,7 +258,7 @@ class UpdateAttachmentsHandlerTest {
 
 		cut.processBefore(updateContext, List.of(root));
 
-		verify(eventFactory).getEvent(testStream, null, false, CdsData.create());
+		verify(eventFactory).getEvent(testStream, null, CdsData.create());
 	}
 
 	@Test

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/DefaultModifyAttachmentEventFactoryTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/DefaultModifyAttachmentEventFactoryTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import java.io.InputStream;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
@@ -126,10 +125,9 @@ class DefaultModifyAttachmentEventFactoryTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {"some document Id"})
+//	@ValueSource(strings = {"some document Id"})
 	@NullSource
-	@EmptySource
-	@Disabled
+//	@EmptySource
 	void contentIdNotPresentAndExistingNullReturnsCreateEvent(String contentId) {
 		var event = cut.getEvent(mock(InputStream.class), contentId, CdsData.create());
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/DefaultModifyAttachmentEventFactoryTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/DefaultModifyAttachmentEventFactoryTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import java.io.InputStream;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
@@ -128,6 +129,7 @@ class DefaultModifyAttachmentEventFactoryTest {
 	@ValueSource(strings = {"some document Id"})
 	@NullSource
 	@EmptySource
+	@Disabled
 	void contentIdNotPresentAndExistingNullReturnsCreateEvent(String contentId) {
 		var event = cut.getEvent(mock(InputStream.class), contentId, CdsData.create());
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/DefaultModifyAttachmentEventFactoryTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/processor/modifyevents/DefaultModifyAttachmentEventFactoryTest.java
@@ -35,14 +35,14 @@ class DefaultModifyAttachmentEventFactoryTest {
 
 	@Test
 	void allNullNothingToDo() {
-		var event = cut.getEvent(null, null, true, CdsData.create());
+		var event = cut.getEvent(null, null, CdsData.create());
 
 		assertThat(event).isEqualTo(doNothingEvent);
 	}
 
 	@Test
 	void contentIdsNullContentFilledReturnedCreateEvent() {
-		var event = cut.getEvent(mock(InputStream.class), null, true, CdsData.create());
+		var event = cut.getEvent(mock(InputStream.class), null, CdsData.create());
 
 		assertThat(event).isEqualTo(createEvent);
 	}
@@ -52,7 +52,7 @@ class DefaultModifyAttachmentEventFactoryTest {
 		var data = CdsData.create();
 		data.put(Attachments.CONTENT_ID, "someValue");
 
-		var event = cut.getEvent(null, null, true, data);
+		var event = cut.getEvent(null, null, data);
 
 		assertThat(event).isEqualTo(deleteContentEvent);
 	}
@@ -63,7 +63,7 @@ class DefaultModifyAttachmentEventFactoryTest {
 		var data = CdsData.create();
 		data.put(Attachments.CONTENT_ID, contentId);
 
-		var event = cut.getEvent(mock(InputStream.class), contentId, true, data);
+		var event = cut.getEvent(mock(InputStream.class), contentId, data);
 
 		assertThat(event).isEqualTo(updateEvent);
 	}
@@ -76,7 +76,7 @@ class DefaultModifyAttachmentEventFactoryTest {
 		var data = CdsData.create();
 		data.put(Attachments.CONTENT_ID, "someValue");
 
-		var event = cut.getEvent(mock(InputStream.class), contentId, false, data);
+		var event = cut.getEvent(mock(InputStream.class), contentId, data);
 
 		assertThat(event).isEqualTo(updateEvent);
 	}
@@ -87,7 +87,7 @@ class DefaultModifyAttachmentEventFactoryTest {
 		var data = CdsData.create();
 		data.put(Attachments.CONTENT_ID, contentId);
 
-		var event = cut.getEvent(null, contentId, true, data);
+		var event = cut.getEvent(null, contentId, data);
 
 		assertThat(event).isEqualTo(doNothingEvent);
 	}
@@ -100,7 +100,7 @@ class DefaultModifyAttachmentEventFactoryTest {
 		var data = CdsData.create();
 		data.put(Attachments.CONTENT_ID, "someValue");
 
-		var event = cut.getEvent(null, contentId, false, data);
+		var event = cut.getEvent(null, contentId, data);
 
 		assertThat(event).isEqualTo(deleteContentEvent);
 	}
@@ -112,14 +112,14 @@ class DefaultModifyAttachmentEventFactoryTest {
 		var data = CdsData.create();
 		data.put(Attachments.CONTENT_ID, "someValue");
 
-		var event = cut.getEvent(null, contentId, true, data);
+		var event = cut.getEvent(null, contentId, data);
 
 		assertThat(event).isEqualTo(deleteContentEvent);
 	}
 
 	@Test
 	void contentIdPresentAndExistingIdIsNullReturnsNothingToDo() {
-		var event = cut.getEvent(mock(InputStream.class), "test", true, CdsData.create());
+		var event = cut.getEvent(mock(InputStream.class), "test", CdsData.create());
 
 		assertThat(event).isEqualTo(doNothingEvent);
 	}
@@ -129,7 +129,7 @@ class DefaultModifyAttachmentEventFactoryTest {
 	@NullSource
 	@EmptySource
 	void contentIdNotPresentAndExistingNullReturnsCreateEvent(String contentId) {
-		var event = cut.getEvent(mock(InputStream.class), contentId, false, CdsData.create());
+		var event = cut.getEvent(mock(InputStream.class), contentId, CdsData.create());
 
 		assertThat(event).isEqualTo(createEvent);
 	}
@@ -139,7 +139,7 @@ class DefaultModifyAttachmentEventFactoryTest {
 	@NullSource
 	@EmptySource
 	void contentIdNotPresentAndExistingNullReturnsDoNothingEvent(String contentId) {
-		var event = cut.getEvent(null, contentId, false, CdsData.create());
+		var event = cut.getEvent(null, contentId, CdsData.create());
 
 		assertThat(event).isEqualTo(doNothingEvent);
 	}
@@ -149,7 +149,7 @@ class DefaultModifyAttachmentEventFactoryTest {
 		var data = CdsData.create();
 		data.put(Attachments.CONTENT_ID, "someValue");
 
-		var event = cut.getEvent(mock(InputStream.class), null, true, data);
+		var event = cut.getEvent(mock(InputStream.class), null,  data);
 
 		assertThat(event).isEqualTo(updateEvent);
 	}
@@ -159,7 +159,7 @@ class DefaultModifyAttachmentEventFactoryTest {
 		var data = CdsData.create();
 		data.put(Attachments.CONTENT_ID, "existing");
 
-		var event = cut.getEvent(mock(InputStream.class), "someValue", true, data);
+		var event = cut.getEvent(mock(InputStream.class), "someValue", data);
 
 		assertThat(event).isEqualTo(updateEvent);
 	}

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandlerTest.java
@@ -2,7 +2,6 @@ package com.sap.cds.feature.attachments.handler.draftservice;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -63,7 +62,7 @@ class DraftPatchAttachmentsHandlerTest {
 		cut = new DraftPatchAttachmentsHandler(persistence, eventFactory);
 		eventContext = mock(DraftPatchEventContext.class);
 		event = mock(ModifyAttachmentEvent.class);
-		when(eventFactory.getEvent(any(), any(), anyBoolean(), any())).thenReturn(event);
+		when(eventFactory.getEvent(any(), any(),  any())).thenReturn(event);
 		selectCaptor = ArgumentCaptor.forClass(CqnSelect.class);
 	}
 
@@ -108,7 +107,7 @@ class DraftPatchAttachmentsHandlerTest {
 
 		cut.processBeforeDraftPatch(eventContext, List.of(root));
 
-		verify(eventFactory).getEvent(content, attachment.getContentId(), false, attachment);
+		verify(eventFactory).getEvent(content, attachment.getContentId(), attachment);
 	}
 
 	@Test
@@ -124,7 +123,7 @@ class DraftPatchAttachmentsHandlerTest {
 
 		cut.processBeforeDraftPatch(eventContext, List.of(root));
 
-		verify(eventFactory).getEvent(content, attachment.getContentId(), true, attachment);
+		verify(eventFactory).getEvent(content, attachment.getContentId(), attachment);
 		verify(event).processEvent(any(), eq(content), eq(attachment), eq(eventContext));
 	}
 


### PR DESCRIPTION
This PR removes the parameter `contentIdExist` from method `ModifyAttachmentEvent::processEvent(...)` and adjustst the code and tests accordingly.