### PR TITLE
Increase timeout of HTTP connection to malware scanner

### DIFF
--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -127,12 +127,11 @@ public class Registration implements CdsRuntimeConfiguration {
 		// the common prefix for the connection pool configuration
 		final String prefix = "cds.attachments.malware.http.%s";
 		CdsEnvironment env = runtime.getEnvironment();
-		Duration timeout = Duration.ofSeconds(env.getProperty(prefix.formatted("timeout"), Integer.class, Integer.valueOf(120)));
-		int maxConnectionsPerRoute = env.getProperty(prefix.formatted("maxConnectionsPerRoute"), Integer.class, 2);
+		Duration timeout = Duration
+				.ofSeconds(env.getProperty(prefix.formatted("timeout"), Integer.class, Integer.valueOf(120)));
 		int maxConnections = env.getProperty(prefix.formatted("maxConnections"), Integer.class, 20);
-		logger.debug("Connection pool configuration: timeout={}, maxConnectionsPerRoute={}, maxConnections={}", timeout,
-				maxConnectionsPerRoute, maxConnections);
-		return new ConnectionPool(timeout, maxConnectionsPerRoute, maxConnections);
+		logger.debug("Connection pool configuration: timeout={}, maxConnections={}", timeout, maxConnections);
+		return new ConnectionPool(timeout, maxConnections, maxConnections);
 	}
 
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -128,7 +128,7 @@ public class Registration implements CdsRuntimeConfiguration {
 		final String prefix = "cds.attachments.malware.http.%s";
 		CdsEnvironment env = runtime.getEnvironment();
 		Duration timeout = Duration
-				.ofSeconds(env.getProperty(prefix.formatted("timeout"), Integer.class, Integer.valueOf(120)));
+				.ofSeconds(env.getProperty(prefix.formatted("timeout"), Integer.class, 120));
 		int maxConnections = env.getProperty(prefix.formatted("maxConnections"), Integer.class, 20);
 		logger.debug("Connection pool configuration: timeout={}, maxConnections={}", timeout, maxConnections);
 		return new ConnectionPool(timeout, maxConnections, maxConnections);

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -73,7 +73,7 @@ public class Registration implements CdsRuntimeConfiguration {
 		List<ServiceBinding> bindings = configurer.getCdsRuntime().getEnvironment().getServiceBindings().filter(
 				b -> ServiceBindingUtils.matches(b, MalwareScanConstants.MALWARE_SCAN_SERVICE_LABEL)).toList();
 		var binding = !bindings.isEmpty() ? bindings.get(0) : null;
-		var connectionPoll = new ConnectionPool(Duration.ofSeconds(60), 2, 20);
+		var connectionPoll = new ConnectionPool(Duration.ofSeconds(300), 2, 20);
 		var clientProviderFactory = new MalwareScanClientProviderFactory(binding, configurer.getCdsRuntime(), connectionPoll);
 		var malwareStatusMapper = new DefaultMalwareClientStatusMapper();
 		var malwareScanner = new DefaultAttachmentMalwareScanner(persistenceService, attachmentService,

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -73,7 +73,7 @@ public class Registration implements CdsRuntimeConfiguration {
 		List<ServiceBinding> bindings = configurer.getCdsRuntime().getEnvironment().getServiceBindings().filter(
 				b -> ServiceBindingUtils.matches(b, MalwareScanConstants.MALWARE_SCAN_SERVICE_LABEL)).toList();
 		var binding = !bindings.isEmpty() ? bindings.get(0) : null;
-		var connectionPoll = new ConnectionPool(Duration.ofSeconds(300), 2, 20);
+		var connectionPoll = new ConnectionPool(Duration.ofSeconds(120), 2, 20);
 		var clientProviderFactory = new MalwareScanClientProviderFactory(binding, configurer.getCdsRuntime(), connectionPoll);
 		var malwareStatusMapper = new DefaultMalwareClientStatusMapper();
 		var malwareScanner = new DefaultAttachmentMalwareScanner(persistenceService, attachmentService,

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -126,7 +126,7 @@ public class Registration implements CdsRuntimeConfiguration {
 
 	private static ConnectionPool getConnectionPool(CdsEnvironment env) {
 		// the common prefix for the connection pool configuration
-		final String prefix = "cds.attachments.malware.http.%s";
+		final String prefix = "cds.attachments.malwareScanner.http.%s";
 		Duration timeout = Duration
 				.ofSeconds(env.getProperty(prefix.formatted("timeout"), Integer.class, 120));
 		int maxConnections = env.getProperty(prefix.formatted("maxConnections"), Integer.class, 20);

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -88,7 +88,8 @@ public class Registration implements CdsRuntimeConfiguration {
 		var malwareStatusMapper = new DefaultMalwareClientStatusMapper();
 		var malwareScanner = new DefaultAttachmentMalwareScanner(persistenceService, attachmentService,
 				new DefaultMalwareScanClient(clientProviderFactory), malwareStatusMapper, Objects.nonNull(binding));
-		var malwareScanEndTransactionListener = createEndTransactionMalwareScanListener(malwareScanner, configurer);
+		EndTransactionMalwareScanProvider malwareScanEndTransactionListener = (attachmentEntity,
+				contentId) -> new EndTransactionMalwareScanRunner(attachmentEntity, contentId, malwareScanner, runtime);
 
 		// register event handlers for attachment service
 		configurer.eventHandler(new DefaultAttachmentsServiceHandler(malwareScanEndTransactionListener));
@@ -110,12 +111,6 @@ public class Registration implements CdsRuntimeConfiguration {
 		configurer.eventHandler(
 				new DraftCancelAttachmentsHandler(attachmentsReader, deleteContentEvent, ActiveEntityModifier::new));
 		configurer.eventHandler(new DraftActiveAttachmentsHandler(storage));
-	}
-
-	private EndTransactionMalwareScanProvider createEndTransactionMalwareScanListener(
-			DefaultAttachmentMalwareScanner malwareScanner, CdsRuntimeConfigurer configurer) {
-		return (attachmentEntity, contentId) -> new EndTransactionMalwareScanRunner(attachmentEntity, contentId,
-				malwareScanner, configurer.getCdsRuntime());
 	}
 
 	private DefaultModifyAttachmentEventFactory buildAttachmentEventFactory(AttachmentService attachmentService,

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/configuration/RegistrationTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/configuration/RegistrationTest.java
@@ -1,7 +1,11 @@
 package com.sap.cds.feature.attachments.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -48,6 +52,7 @@ class RegistrationTest {
 		serviceCatalog = mock(ServiceCatalog.class);
 		when(cdsRuntime.getServiceCatalog()).thenReturn(serviceCatalog);
 		CdsEnvironment environment = mock(CdsEnvironment.class);
+		when(environment.getProperty(any(), any(), any())).thenAnswer(invocation -> invocation.getArgument(2));
 		when(cdsRuntime.getEnvironment()).thenReturn(environment);
 		persistenceService = mock(PersistenceService.class);
 		attachmentService = mock(AttachmentService.class);

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,9 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- [Added support to configure the HTTP client pool](https://github.com/cap-java/cds-feature-attachments/pull/276) to the malware scanner service. Supported configuration  properties are:
+- [Added support to configure the HTTP client pool](https://github.com/cap-java/cds-feature-attachments/pull/276) to Malware Scanning Service. Supported configuration properties are:
   - `cds.attachments.malware.http.timeout`: The HTTP request timeout in seconds, defaults to 120s
-  - `cds.attachments.malware.http.maxConnections`: The max. number of parallel HTTP connections to malware scan service, defaults to 20 connections
+  - `cds.attachments.malware.http.maxConnections`: The max. number of parallel HTTP connections to Malware Scanning Service, defaults to 20 connections
 
 
 ### Changed
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- [Fixed a bug](https://github.com/cap-java/cds-feature-attachments/pull/270) that caused malware scanning to fail if the content was stored in a HANA DB.
+- [Fixed a bug](https://github.com/cap-java/cds-feature-attachments/pull/270) that caused malware scanning to fail, if the content was stored in a HANA DB.
 
 ## Version 1.0.4 - 2024-10-22
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,9 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
+- [Added support to configure the HTTP client](https://github.com/cap-java/cds-feature-attachments/pull/276) to the malware scanner service to 120s.
+
 ### Changed
 
-- [Increased the HTTP client timeout](https://github.com/cap-java/cds-feature-attachments/pull/276) to the malware scanner service to 120s.
 - [Simplified logging markers](https://github.com/cap-java/cds-feature-attachments/pull/178)
 - [Improved Javadoc](https://github.com/cap-java/cds-feature-attachments/pull/256)
 - Updated some dependencies to latest versions.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
+- [Increased the HTTP client timeout](https://github.com/cap-java/cds-feature-attachments/pull/276) to the malware scanner service to 120s.
 - [Simplified logging markers](https://github.com/cap-java/cds-feature-attachments/pull/178)
 - [Improved Javadoc](https://github.com/cap-java/cds-feature-attachments/pull/256)
 - Updated some dependencies to latest versions.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,7 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- [Added support to configure the HTTP client](https://github.com/cap-java/cds-feature-attachments/pull/276) to the malware scanner service to 120s.
+- [Added support to configure the HTTP client pool](https://github.com/cap-java/cds-feature-attachments/pull/276) to the malware scanner service. Supported configuration  properties are:
+  - `cds.attachments.malware.http.timeout`: The HTTP request timeout in seconds, defaults to 120s
+  - `cds.attachments.malware.http.maxConnections`: The max. number of parallel HTTP connections to malware scan service, defaults to 20 connections
+
 
 ### Changed
 


### PR DESCRIPTION
- [Added support to configure the HTTP client pool](https://github.com/cap-java/cds-feature-attachments/pull/276) to Malware Scanning Service. Supported configuration properties are:
  - `cds.attachments.malwareScanner.http.timeout`: The HTTP request timeout in seconds, defaults to 120s
  - `cds.attachments.malwareScanner.http.maxConnections`: The max. number of parallel HTTP connections to Malware Scanning Service, defaults to 20 connections
