### PR TITLE
Cleanup transitive dependencies

### DIFF
--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -30,6 +30,10 @@
                         <artifactId>commons-lang3</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>com.sap.cloud.mt</groupId>
                         <artifactId>tools</artifactId>
                     </exclusion>

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -30,6 +30,10 @@
                         <artifactId>commons-lang3</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-io</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>com.google.guava</groupId>
                         <artifactId>guava</artifactId>
                     </exclusion>

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -33,6 +33,10 @@
                         <groupId>com.sap.cloud.mt</groupId>
                         <artifactId>tools</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.sap.cds</groupId>
+                        <artifactId>cds-adapter-api</artifactId>
+                    </exclusion>
                 </exclusions>
         </dependency>
 

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -34,6 +34,10 @@
                         <artifactId>guava</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>com.fasterxml.jackson</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>com.sap.cloud.mt</groupId>
                         <artifactId>tools</artifactId>
                     </exclusion>

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -24,12 +24,24 @@
         <dependency>
             <groupId>com.sap.cds</groupId>
             <artifactId>cds-integration-cloud-sdk</artifactId>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                </exclusions>
         </dependency>
 
         <!-- TESTS -->
         <dependency>
             <groupId>com.sap.cds</groupId>
             <artifactId>cds-services-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.17.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -30,7 +30,7 @@
                         <artifactId>commons-lang3</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>org.apache.commons</groupId>
+                        <groupId>commons-io</groupId>
                         <artifactId>commons-io</artifactId>
                     </exclusion>
                     <exclusion>

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -65,6 +65,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.18.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
             <version>4.8.6</version>

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -34,7 +34,7 @@
                         <artifactId>guava</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>com.fasterxml.jackson</groupId>
+                        <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>jackson-databind</artifactId>
                     </exclusion>
                     <exclusion>

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -29,6 +29,10 @@
                         <groupId>org.apache.commons</groupId>
                         <artifactId>commons-lang3</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.sap.cloud.mt</groupId>
+                        <artifactId>tools</artifactId>
+                    </exclusion>
                 </exclusions>
         </dependency>
 

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -34,16 +34,16 @@
                         <artifactId>guava</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-databind</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>com.sap.cloud.mt</groupId>
                         <artifactId>tools</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>com.sap.cds</groupId>
                         <artifactId>cds-adapter-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sap.cds</groupId>
+                        <artifactId>cds4j-core</artifactId>
                     </exclusion>
                 </exclusions>
         </dependency>


### PR DESCRIPTION
The dependency `cds-integration-cloud-sdk` brings a lot transitive dependencies to `cds-feature-attachments`. This PR tries to reduce the number of transitive dependencies as much as possible.