### PR TITLE
Bump min. required versions of CAP Java and SAP UI5

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following version are the minimum versions for the usage of the plugin:
 
 | Component | Minimum Version |
 |-----------|-----------------|
-| CAP Java  | 2.9.1           |
+| CAP Java  | 3.4.1           |
 | UI5       | 1.131.0         |
 
 ## Maven Central

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The following version are the minimum versions for the usage of the plugin:
 | Component | Minimum Version |
 |-----------|-----------------|
 | CAP Java  | 2.9.1           |
-| UI5       | 1.126.0         |
+| UI5       | 1.131.0         |
 
 ## Maven Central
 


### PR DESCRIPTION
The following min. required Versions are bumped:
- SAP UI5 to 1.131.0 as it contains a fix for an eTag issue. This fix is required to upload attachment content to an eTag enabled entity, which is the default behavior.
- CAP Java to 3.4.1 as it provides fixes for OData V4 content stream handling. e.g. inline support and correct filenames in case of download.