### PR TITLE
Use directly Cloud SDK instead of cds-integration-cloud-sdk

### DIFF
--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -45,7 +45,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>com.sap.cds</groupId>
-                    <artifactId>cds4-core</artifactId>
+                    <artifactId>cds4j-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency> 

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -24,16 +24,30 @@
         <dependency>
             <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
             <artifactId>cloudplatform-core</artifactId>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                    </exclusion>
-                </exclusions>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.vavr</groupId>
+                    <artifactId>vavr</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.sap.cds</groupId>
             <artifactId>cds-services-utils</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sap.cds</groupId>
+                    <artifactId>cds-adapter-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sap.cds</groupId>
+                    <artifactId>cds4-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency> 
 
         <!-- TESTS -->

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -47,6 +47,10 @@
                     <groupId>com.sap.cds</groupId>
                     <artifactId>cds4j-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.sap.cloud.mt</groupId>
+                    <artifactId>tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency> 
 

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -30,37 +30,6 @@
             <artifactId>cds-services-utils</artifactId>
         </dependency> 
 
-        <dependency>
-            <groupId>com.sap.cds</groupId>
-            <artifactId>cds-integration-cloud-sdk</artifactId>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.commons</groupId>
-                        <artifactId>commons-lang3</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-io</groupId>
-                        <artifactId>commons-io</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sap.cloud.mt</groupId>
-                        <artifactId>tools</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sap.cds</groupId>
-                        <artifactId>cds-adapter-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sap.cds</groupId>
-                        <artifactId>cds4j-core</artifactId>
-                    </exclusion>
-                </exclusions>
-        </dependency>
-
         <!-- TESTS -->
         <dependency>
             <groupId>com.sap.cds</groupId>

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -22,6 +22,15 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
+            <artifactId>cloudplatform-connectivity</artifactId>
+        </dependency> 
+        <dependency>
+            <groupId>com.sap.cds</groupId>
+            <artifactId>cds-services-utils</artifactId>
+        </dependency> 
+
+        <dependency>
             <groupId>com.sap.cds</groupId>
             <artifactId>cds-integration-cloud-sdk</artifactId>
                 <exclusions>

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -23,8 +23,14 @@
     <dependencies>
         <dependency>
             <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
-            <artifactId>cloudplatform-connectivity</artifactId>
-        </dependency> 
+            <artifactId>cloudplatform-core</artifactId>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
+        </dependency>
         <dependency>
             <groupId>com.sap.cds</groupId>
             <artifactId>cds-services-utils</artifactId>

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -39,13 +39,11 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.17.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.18.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -84,7 +84,7 @@ public class Registration implements CdsRuntimeConfiguration {
 
 		// get HTTP connection pool configuration
 		var connectionPool = getConnectionPool(environment);
-		var clientProviderFactory = new MalwareScanClientProviderFactory(binding, runtime, connectionPool);
+		var clientProviderFactory = new MalwareScanClientProviderFactory(binding, connectionPool);
 		var malwareStatusMapper = new DefaultMalwareClientStatusMapper();
 		var malwareScanner = new DefaultAttachmentMalwareScanner(persistenceService, attachmentService,
 				new DefaultMalwareScanClient(clientProviderFactory), malwareStatusMapper, Objects.nonNull(binding));

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/DefaultMalwareScanClient.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/DefaultMalwareScanClient.java
@@ -22,7 +22,6 @@ import com.sap.cds.feature.attachments.service.malware.client.httpclient.HttpCli
 import com.sap.cds.feature.attachments.service.malware.client.model.MalwareScanResult;
 import com.sap.cds.feature.attachments.service.malware.client.model.MalwareScanResultStatus;
 import com.sap.cds.feature.attachments.utilities.LoggingMarker;
-import com.sap.cds.integration.cloudsdk.rest.client.JsonRestClientResponseException;
 import com.sap.cds.services.ServiceException;
 
 /**
@@ -62,7 +61,7 @@ public class DefaultMalwareScanClient implements MalwareScanClient {
 	}
 
 	private MalwareScanResultStatus scanContentWithClient(InputStream content) {
-		var httpClient = clientProviderFactory.getHttpClientProvider().get();
+		var httpClient = clientProviderFactory.getHttpClient();
 		var request = buildHttpRequest(content);
 		return executeRequest(httpClient, request);
 	}
@@ -108,7 +107,7 @@ public class DefaultMalwareScanClient implements MalwareScanClient {
 			}
 		} else {
 			String reason = response.getStatusLine().getReasonPhrase();
-			throw new JsonRestClientResponseException(code, "Unexpected request HTTP response (" + code + ") " + reason);
+			throw new IOException("Unexpected request HTTP response (" + code + ") " + reason);
 		}
 	}
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/HttpClientProviderFactory.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/HttpClientProviderFactory.java
@@ -5,10 +5,23 @@ package com.sap.cds.feature.attachments.service.malware.client.httpclient;
 
 import org.apache.http.client.HttpClient;
 
+/**
+ * Factory for creating a {@link HttpClient} for the malware scan service.
+ */
 public interface HttpClientProviderFactory {
 
+	/**
+	 * Returns an {@link HttpClient} to send HTTP requests to the malware scan service.
+	 * 
+	 * @return an {@link HttpClient} to send HTTP requests to the malware scan or {@code null} if the service is not bound
+	 */
 	HttpClient getHttpClient();
 
+	/**
+	 * Returns {@code true}, if a binding to the malware scan service is available.
+	 * 
+	 * @return {@code true} if a binding to the malware scan service is available.
+	 */
 	boolean isServiceBound();
 
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/HttpClientProviderFactory.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/HttpClientProviderFactory.java
@@ -3,11 +3,11 @@
  **************************************************************************/
 package com.sap.cds.feature.attachments.service.malware.client.httpclient;
 
-import com.sap.cds.integration.cloudsdk.destination.HttpClientProvider;
+import org.apache.http.client.HttpClient;
 
 public interface HttpClientProviderFactory {
 
-	HttpClientProvider getHttpClientProvider();
+	HttpClient getHttpClient();
 
 	boolean isServiceBound();
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactory.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactory.java
@@ -16,9 +16,9 @@ import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination;
 import com.sap.cloud.sdk.cloudplatform.security.BasicCredentials;
 
 /**
- * Factory for creating a {@link HttpClientProvider} for the malware scan service.
+ * Factory for creating a {@link HttpClient} for the malware scan service.
  */
-public class MalwareScanClientProviderFactory implements HttpClientProviderFactory {
+public final class MalwareScanClientProviderFactory implements HttpClientProviderFactory {
 
 	private static final String SCAN_ENDPOINT = "/scan";
 	private static final String VALUE_URL = "url";

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactory.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactory.java
@@ -6,11 +6,12 @@ package com.sap.cds.feature.attachments.service.malware.client.httpclient;
 import java.net.URI;
 import java.util.Objects;
 
+import org.apache.http.client.HttpClient;
+
 import com.sap.cds.feature.attachments.service.malware.constants.MalwareScanConstants;
-import com.sap.cds.integration.cloudsdk.destination.HttpClientProvider;
 import com.sap.cds.services.environment.CdsProperties.ConnectionPool;
-import com.sap.cds.services.runtime.CdsRuntime;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpClientFactory;
 import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination;
 import com.sap.cloud.sdk.cloudplatform.security.BasicCredentials;
 
@@ -24,14 +25,11 @@ public class MalwareScanClientProviderFactory implements HttpClientProviderFacto
 	private static final String VALUE_USERNAME = "username";
 	private static final String VALUE_PASSWORD = "password";
 
-	private final HttpClientProvider clientProvider;
-	private final boolean serviceBound;
+	private final HttpClient httpClient;
 
-	public MalwareScanClientProviderFactory(ServiceBinding binding, CdsRuntime runtime,
-			ConnectionPool connectionPoolConfig) {
+	public MalwareScanClientProviderFactory(ServiceBinding binding, ConnectionPool connectionPoolConfig) {
 		if (Objects.isNull(binding)) {
-			serviceBound = false;
-			clientProvider = null;
+			this.httpClient = null;
 		} else {
 			var credentials = binding.getCredentials();
 			var url = (String) credentials.get(VALUE_URL);
@@ -39,18 +37,24 @@ public class MalwareScanClientProviderFactory implements HttpClientProviderFacto
 			var basic = new BasicCredentials((String) credentials.get(VALUE_USERNAME), (String) credentials.get(VALUE_PASSWORD));
 			var destination = DefaultHttpDestination.builder(serviceUrl).name(MalwareScanConstants.MALWARE_SCAN_SERVICE_LABEL)
 					.basicCredentials(basic).build();
-			clientProvider = new HttpClientProvider(destination, connectionPoolConfig, runtime);
-			serviceBound = true;
+			
+			DefaultHttpClientFactory.DefaultHttpClientFactoryBuilder builder = DefaultHttpClientFactory.builder();
+			builder.timeoutMilliseconds((int)connectionPoolConfig.getTimeout().toMillis());
+			builder.maxConnectionsPerRoute(connectionPoolConfig.getMaxConnectionsPerRoute());
+			builder.maxConnectionsTotal(connectionPoolConfig.getMaxConnections());
+			DefaultHttpClientFactory factory = builder.build();
+
+			this.httpClient = factory.createHttpClient(destination);
 		}
 	}
 
 	@Override
-	public HttpClientProvider getHttpClientProvider() {
-		return clientProvider;
+	public HttpClient getHttpClient() {
+		return this.httpClient;
 	}
 
 	@Override
 	public boolean isServiceBound() {
-		return serviceBound;
+		return this.httpClient != null;
 	}
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactory.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactory.java
@@ -16,7 +16,7 @@ import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination;
 import com.sap.cloud.sdk.cloudplatform.security.BasicCredentials;
 
 /**
- * Factory for creating a {@link HttpClient} for the malware scan service.
+ * The default factory for creating a {@link HttpClient} for the malware scan service.
  */
 public final class MalwareScanClientProviderFactory implements HttpClientProviderFactory {
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactory.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactory.java
@@ -12,6 +12,7 @@ import com.sap.cds.feature.attachments.service.malware.constants.MalwareScanCons
 import com.sap.cds.services.environment.CdsProperties.ConnectionPool;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpClientFactory;
+import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpClientFactory.DefaultHttpClientFactoryBuilder;
 import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination;
 import com.sap.cloud.sdk.cloudplatform.security.BasicCredentials;
 
@@ -38,7 +39,7 @@ public final class MalwareScanClientProviderFactory implements HttpClientProvide
 			var destination = DefaultHttpDestination.builder(serviceUrl).name(MalwareScanConstants.MALWARE_SCAN_SERVICE_LABEL)
 					.basicCredentials(basic).build();
 			
-			DefaultHttpClientFactory.DefaultHttpClientFactoryBuilder builder = DefaultHttpClientFactory.builder();
+			DefaultHttpClientFactoryBuilder builder = DefaultHttpClientFactory.builder();
 			builder.timeoutMilliseconds((int)connectionPoolConfig.getTimeout().toMillis());
 			builder.maxConnectionsPerRoute(connectionPoolConfig.getMaxConnectionsPerRoute());
 			builder.maxConnectionsTotal(connectionPoolConfig.getMaxConnections());

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/client/DefaultMalwareScanClientTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/client/DefaultMalwareScanClientTest.java
@@ -32,7 +32,6 @@ import org.mockito.ArgumentCaptor;
 
 import com.sap.cds.feature.attachments.service.malware.client.httpclient.HttpClientProviderFactory;
 import com.sap.cds.feature.attachments.service.malware.client.model.MalwareScanResultStatus;
-import com.sap.cds.integration.cloudsdk.destination.HttpClientProvider;
 import com.sap.cds.services.ServiceException;
 
 class DefaultMalwareScanClientTest {
@@ -56,7 +55,7 @@ class DefaultMalwareScanClientTest {
 		var result = cut.scanContent(mock(InputStream.class));
 
 		assertThat(result).isEqualTo(MalwareScanResultStatus.NO_SCANNER);
-		verify(clientProviderFactory, never()).getHttpClientProvider();
+		verify(clientProviderFactory, never()).getHttpClient();
 	}
 
 	@Test
@@ -106,9 +105,7 @@ class DefaultMalwareScanClientTest {
 	void exceptionIsThrownIfRequestRespondWithException() throws IOException {
 		when(clientProviderFactory.isServiceBound()).thenReturn(true);
 		var httpClient = mock(HttpClient.class);
-		var httpClientProvider = mock(HttpClientProvider.class);
-		when(httpClientProvider.get()).thenReturn(httpClient);
-		when(clientProviderFactory.getHttpClientProvider()).thenReturn(httpClientProvider);
+		when(clientProviderFactory.getHttpClient()).thenReturn(httpClient);
 		when(httpClient.execute(any())).thenThrow(new IOException());
 
 		var inputStream = mock(InputStream.class);
@@ -158,9 +155,7 @@ class DefaultMalwareScanClientTest {
 			String contentTypeString, boolean responseEntityExists) throws IOException {
 		when(clientProviderFactory.isServiceBound()).thenReturn(true);
 		var httpClient = mock(HttpClient.class);
-		var httpClientProvider = mock(HttpClientProvider.class);
-		when(httpClientProvider.get()).thenReturn(httpClient);
-		when(clientProviderFactory.getHttpClientProvider()).thenReturn(httpClientProvider);
+		when(clientProviderFactory.getHttpClient()).thenReturn(httpClient);
 		var response = mock(CloseableHttpResponse.class);
 		when(httpClient.execute(any())).thenReturn(response);
 		var statusLine = mock(StatusLine.class);

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactoryTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactoryTest.java
@@ -66,6 +66,8 @@ class MalwareScanClientProviderFactoryTest {
 		when(binding.getCredentials()).thenReturn(credentials);
 		var enabled = mock(CdsProperties.Enabled.class);
 		when(connectionPoolConfig.getCombinePools()).thenReturn(enabled);
+		when(connectionPoolConfig.getMaxConnections()).thenReturn(20);
+		when(connectionPoolConfig.getMaxConnectionsPerRoute()).thenReturn(20);
 	}
 
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactoryTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactoryTest.java
@@ -1,7 +1,8 @@
 package com.sap.cds.feature.attachments.service.malware.client.httpclient;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
 
@@ -29,17 +30,17 @@ class MalwareScanClientProviderFactoryTest {
 
 	@Test
 	void serviceNotBound() {
-		cut = new MalwareScanClientProviderFactory(null, runtime, connectionPoolConfig);
+		cut = new MalwareScanClientProviderFactory(null, connectionPoolConfig);
 
 		assertThat(cut.isServiceBound()).isFalse();
-		assertThat(cut.getHttpClientProvider()).isNull();
+		assertThat(cut.getHttpClient()).isNull();
 	}
 
 	@Test
 	void serviceBound() {
 		mockInput();
 
-		cut = new MalwareScanClientProviderFactory(binding, runtime, connectionPoolConfig);
+		cut = new MalwareScanClientProviderFactory(binding, connectionPoolConfig);
 
 		assertThat(cut.isServiceBound()).isTrue();
 	}
@@ -52,12 +53,12 @@ class MalwareScanClientProviderFactoryTest {
 		when(connectionPoolConfig.getMaxConnections()).thenReturn(10);
 		when(connectionPoolConfig.getMaxConnectionsPerRoute()).thenReturn(1);
 
-		cut = new MalwareScanClientProviderFactory(binding, runtime, connectionPoolConfig);
+		cut = new MalwareScanClientProviderFactory(binding, connectionPoolConfig);
 
-		var clientProvider = cut.getHttpClientProvider();
+		var clientProvider = cut.getHttpClient();
 		assertThat(clientProvider).isNotNull();
-		var client = clientProvider.get();
-		assertThat(client).isNotNull();
+//		var client = clientProvider.get();
+//		assertThat(client).isNotNull();
 	}
 
 	private void mockInput() {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactoryTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/client/httpclient/MalwareScanClientProviderFactoryTest.java
@@ -55,10 +55,8 @@ class MalwareScanClientProviderFactoryTest {
 
 		cut = new MalwareScanClientProviderFactory(binding, connectionPoolConfig);
 
-		var clientProvider = cut.getHttpClient();
-		assertThat(clientProvider).isNotNull();
-//		var client = clientProvider.get();
-//		assertThat(client).isNotNull();
+		var client = cut.getHttpClient();
+		assertThat(client).isNotNull();
 	}
 
 	private void mockInput() {

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,17 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.0.6 - tbd.
+
+### Added
+
+### Changed
+
+- [Removal of unneeded transitive dependencies](https://github.com/cap-java/cds-feature-attachments/pull/290)
+- [Replaced the dependency](https://github.com/cap-java/cds-feature-attachments/pull/292) on `com.sap.cds:cds-integration-cloud-sdk` with `com.sap.cloud.sdk.cloudplatform:cloudplatform-core` to use the Cloud SDK directly.
+
+### Fixed
+
 ## Version 1.0.5 - 2024-11-06
 
 ### Added
@@ -13,7 +24,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - [Added support to configure the HTTP client pool](https://github.com/cap-java/cds-feature-attachments/pull/276) to Malware Scanning Service. Supported configuration properties are:
   - `cds.attachments.malwareScanner.http.timeout`: The HTTP request timeout in seconds, defaults to 120s
   - `cds.attachments.malwareScanner.http.maxConnections`: The max. number of parallel HTTP connections to Malware Scanning Service, defaults to 20 connections
-
 
 ### Changed
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,14 @@
             </dependency>
 
             <dependency>
+                <groupId>com.sap.cloud.sdk</groupId>
+                <artifactId>sdk-bom</artifactId>
+                <version>5.14.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-bom</artifactId>
                 <version>5.14.2</version>


### PR DESCRIPTION
The MalwareScannerService is not tenant aware, so there is no need to use a tenant aware HTTP client pool provided by cds-integration-cloud-sdk.
