### PR TITLE
Update cds-services and cds-dk to latest LTS versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
                 <artifactId>cds-feature-attachments</artifactId>
                 <version>${revision}</version>
             </dependency>
+            
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.17.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
                 <version>${revision}</version>
             </dependency>
             
+            <!-- Mitigate vulnerabilities in commons-codec:commons-codec:1.11 -->
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <excluded.generation.package>com/sap/cds/feature/attachments/generated/</excluded.generation.package>
-        <cds.services.version>2.9.1</cds.services.version>
-        <cds.install-cdsdk.version>7.7.0</cds.install-cdsdk.version>
+        <cds.services.version>2.10.5</cds.services.version>
+        <cds.install-cdsdk.version>7.9.9</cds.install-cdsdk.version>
 
         <generation-folder>src/gen</generation-folder>
     </properties>


### PR DESCRIPTION
This PR updates the following dependencies:
- cds-services to 2.10.5
- @sap/cds-dk to 7.9.9
- commons-codec to 1.17.1

Fixes also this CAP issue: https://github.tools.sap/cap/issues/issues/17483
