### PR TITLE
Run dependabot also in integration-tests directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: maven
-    directory: "/"
+    directories:
+      - "/"
+      - "/integration-tests"
     schedule:
       interval: daily
     open-pull-requests-limit: 10


### PR DESCRIPTION
Currently dependabot doesn't bump the spring-boot version in `integration-tests/pom.xml`. This PR will make dependabot aware of this directory.

See also here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files