### PR TITLE
Add demoapp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ cds-feature-attachments/src/test/resources/schema.sql
 event.json
 
 # CAP Notebook
-cap-notebook/demoapp
+cap-notebook/demoapp/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ cds-feature-attachments/src/test/resources/schema.sql
 .env
 .secrets
 event.json
+
+# CAP Notebook
+cap-notebook/demoapp


### PR DESCRIPTION
During the run of the CAP Notebook a demo application is created in folder cap-notebook/demoapp which has to be ignored by git.