### PR TITLE
Fix NullPointerException if OutboxService is not available.

### DIFF
--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -77,10 +77,10 @@ public class Registration implements CdsRuntimeConfiguration {
 		AttachmentService attachmentService = serviceCatalog.getService(AttachmentService.class, AttachmentService.DEFAULT_NAME);
 
 		// outbox AttachmentService if OutboxService is available
-		OutboxService outbox = serviceCatalog.getService(OutboxService.class, OutboxService.PERSISTENT_UNORDERED_NAME);
+		OutboxService outboxService = serviceCatalog.getService(OutboxService.class, OutboxService.PERSISTENT_UNORDERED_NAME);
 		AttachmentService outboxedAttachmentService;
-		if (outbox != null) {
-			outboxedAttachmentService = outbox.outboxed(attachmentService);
+		if (outboxService != null) {
+			outboxedAttachmentService = outboxService.outboxed(attachmentService);
 		} else {
 			outboxedAttachmentService = attachmentService;
 			logger.warn("OutboxService '{}' is not available. AttachmentService will not be outboxed.",

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -90,7 +90,7 @@ public class Registration implements CdsRuntimeConfiguration {
 		// retrieve the service binding for the malware scanner service
 		List<ServiceBinding> bindings = environment.getServiceBindings()
 				.filter(b -> ServiceBindingUtils.matches(b, MalwareScanConstants.MALWARE_SCAN_SERVICE_LABEL)).toList();
-		ServiceBinding binding = !bindings.isEmpty() ? bindings.get(0) : null;
+		var binding = !bindings.isEmpty() ? bindings.get(0) : null;
 
 		// get HTTP connection pool configuration
 		var connectionPool = getConnectionPool(environment);
@@ -125,8 +125,7 @@ public class Registration implements CdsRuntimeConfiguration {
 
 	private DefaultModifyAttachmentEventFactory buildAttachmentEventFactory(AttachmentService attachmentService,
 			ModifyAttachmentEvent deleteContentEvent, AttachmentService outboxedAttachmentService) {
-		ListenerProvider creationChangeSetListener = (contentId, cdsRuntime) -> new CreationChangeSetListener(contentId,
-				cdsRuntime, outboxedAttachmentService);
+		ListenerProvider creationChangeSetListener = (contentId, cdsRuntime) -> new CreationChangeSetListener(contentId, cdsRuntime, outboxedAttachmentService);
 		var createAttachmentEvent = new CreateAttachmentEvent(attachmentService, creationChangeSetListener);
 		var updateAttachmentEvent = new UpdateAttachmentEvent(createAttachmentEvent, deleteContentEvent);
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -52,8 +52,8 @@ import com.sap.cds.services.utils.environment.ServiceBindingUtils;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 
 /**
- * The class {@link Registration} is a configuration class that registers the services and event handlers for the
- * attachments feature.
+ * The class {@link Registration} is a configuration class that registers the
+ * services and event handlers for the attachments feature.
  */
 public class Registration implements CdsRuntimeConfiguration {
 
@@ -80,13 +80,19 @@ public class Registration implements CdsRuntimeConfiguration {
 
 		// outbox AttachmentService if OutboxService is available
 		OutboxService outbox = serviceCatalog.getService(OutboxService.class, OutboxService.PERSISTENT_UNORDERED_NAME);
-		AttachmentService outboxedAttachmentService = outbox != null ? outbox.outboxed(attachmentService)
-				: attachmentService;
+		AttachmentService outboxedAttachmentService;
+		if (outbox != null) {
+			outboxedAttachmentService = outbox.outboxed(attachmentService);
+		} else {
+			outboxedAttachmentService = attachmentService;
+			logger.warn("OutboxService '{}' is not available. AttachmentService will not be outboxed.",
+					OutboxService.PERSISTENT_UNORDERED_NAME);
+		}
 
 		// retrieve the service binding for the malware scanner service
 		List<ServiceBinding> bindings = environment.getServiceBindings()
 				.filter(b -> ServiceBindingUtils.matches(b, MalwareScanConstants.MALWARE_SCAN_SERVICE_LABEL)).toList();
-		var binding = !bindings.isEmpty() ? bindings.get(0) : null;
+		ServiceBinding binding = !bindings.isEmpty() ? bindings.get(0) : null;
 
 		// get HTTP connection pool configuration
 		var connectionPool = getConnectionPool(environment);

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -73,10 +73,8 @@ public class Registration implements CdsRuntimeConfiguration {
 		CdsEnvironment environment = runtime.getEnvironment();
 
 		// get required services from the service catalog
-		PersistenceService persistenceService = serviceCatalog.getService(PersistenceService.class,
-				PersistenceService.DEFAULT_NAME);
-		AttachmentService attachmentService = serviceCatalog.getService(AttachmentService.class,
-				AttachmentService.DEFAULT_NAME);
+		PersistenceService persistenceService = serviceCatalog.getService(PersistenceService.class, PersistenceService.DEFAULT_NAME);
+		AttachmentService attachmentService = serviceCatalog.getService(AttachmentService.class, AttachmentService.DEFAULT_NAME);
 
 		// outbox AttachmentService if OutboxService is available
 		OutboxService outbox = serviceCatalog.getService(OutboxService.class, OutboxService.PERSISTENT_UNORDERED_NAME);
@@ -107,19 +105,16 @@ public class Registration implements CdsRuntimeConfiguration {
 		configurer.eventHandler(new DefaultAttachmentsServiceHandler(malwareScanEndTransactionListener));
 
 		var deleteContentEvent = new MarkAsDeletedAttachmentEvent(outboxedAttachmentService);
-		var eventFactory = buildAttachmentEventFactory(attachmentService, deleteContentEvent,
-				outboxedAttachmentService);
+		var eventFactory = buildAttachmentEventFactory(attachmentService, deleteContentEvent, outboxedAttachmentService);
 		var attachmentsReader = new DefaultAttachmentsReader(new DefaultAssociationCascader(), persistenceService);
 		ThreadLocalDataStorage storage = new ThreadLocalDataStorage();
 
 		// register event handlers for application service
 		configurer.eventHandler(new CreateAttachmentsHandler(eventFactory, storage));
-		configurer.eventHandler(
-				new UpdateAttachmentsHandler(eventFactory, attachmentsReader, outboxedAttachmentService, storage));
+		configurer.eventHandler(new UpdateAttachmentsHandler(eventFactory, attachmentsReader, outboxedAttachmentService, storage));
 		configurer.eventHandler(new DeleteAttachmentsHandler(attachmentsReader, deleteContentEvent));
 		var scanRunner = new EndTransactionMalwareScanRunner(null, null, malwareScanner, runtime);
-		configurer.eventHandler(
-				new ReadAttachmentsHandler(attachmentService, new DefaultAttachmentStatusValidator(), scanRunner));
+		configurer.eventHandler(new ReadAttachmentsHandler(attachmentService, new DefaultAttachmentStatusValidator(), scanRunner));
 
 		// register event handlers for draft service
 		configurer.eventHandler(new DraftPatchAttachmentsHandler(persistenceService, eventFactory));


### PR DESCRIPTION
This PR fixes a NullPointerException that occurs, if the dependency to cds-feature-attachments is added to pom.xml, but the Outbox is not enabled yet. This happens if the Attachments CDS model is not included yet.

From the application startup log:

```
Caused by: java.lang.NullPointerException: Cannot invoke "com.sap.cds.services.outbox.OutboxService.outboxed(com.sap.cds.services.Service)" because "outbox" is null
        at com.sap.cds.feature.attachments.configuration.Registration.eventHandlers(Registration.java:78) ~[cds-feature-attachments-1.0.6.jar:na]
        at com.sap.cds.services.impl.runtime.CdsRuntimeConfigurerImpl.lambda$eventHandlerConfigurations$2(CdsRuntimeConfigurerImpl.java:142) ~[cds-services-impl-3.7.2.jar:na]
```