### PR TITLE
Register event handlers on draft service, only if at least one draft service is available

### DIFF
--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -117,13 +117,15 @@ public class Registration implements CdsRuntimeConfiguration {
 		var scanRunner = new EndTransactionMalwareScanRunner(null, null, malwareScanner, runtime);
 		configurer.eventHandler(new ReadAttachmentsHandler(attachmentService, new DefaultAttachmentStatusValidator(), scanRunner));
 
-		// register event handlers on draft service, only if at least one draft service is available
+		// register event handlers on draft service, if at least one draft service is available
 		boolean hasDraftServices = serviceCatalog.getServices(DraftService.class).findFirst().isPresent();
 		if (hasDraftServices) {
 			configurer.eventHandler(new DraftPatchAttachmentsHandler(persistenceService, eventFactory));
 			configurer.eventHandler(new DraftCancelAttachmentsHandler(attachmentsReader, deleteContentEvent,
 					ActiveEntityModifier::new));
 			configurer.eventHandler(new DraftActiveAttachmentsHandler(storage));
+		} else {
+			logger.debug("No draft service is available. Draft event handlers will not be registered.");
 		}
 	}
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -41,6 +41,7 @@ import com.sap.cds.feature.attachments.service.malware.client.httpclient.Malware
 import com.sap.cds.feature.attachments.service.malware.client.mapper.DefaultMalwareClientStatusMapper;
 import com.sap.cds.feature.attachments.service.malware.constants.MalwareScanConstants;
 import com.sap.cds.services.ServiceCatalog;
+import com.sap.cds.services.draft.DraftService;
 import com.sap.cds.services.environment.CdsEnvironment;
 import com.sap.cds.services.environment.CdsProperties.ConnectionPool;
 import com.sap.cds.services.outbox.OutboxService;
@@ -106,11 +107,14 @@ public class Registration implements CdsRuntimeConfiguration {
 		var scanRunner = new EndTransactionMalwareScanRunner(null, null, malwareScanner, runtime);
 		configurer.eventHandler(new ReadAttachmentsHandler(attachmentService, new DefaultAttachmentStatusValidator(), scanRunner));
 
-		// register event handlers for draft service
-		configurer.eventHandler(new DraftPatchAttachmentsHandler(persistenceService, eventFactory));
-		configurer.eventHandler(
-				new DraftCancelAttachmentsHandler(attachmentsReader, deleteContentEvent, ActiveEntityModifier::new));
-		configurer.eventHandler(new DraftActiveAttachmentsHandler(storage));
+		// register event handlers on draft service, only if at least one draft service is available
+		boolean hasDraftServices = serviceCatalog.getServices(DraftService.class).findFirst().isPresent();
+		if (!hasDraftServices) {
+			configurer.eventHandler(new DraftPatchAttachmentsHandler(persistenceService, eventFactory));
+			configurer.eventHandler(new DraftCancelAttachmentsHandler(attachmentsReader, deleteContentEvent,
+					ActiveEntityModifier::new));
+			configurer.eventHandler(new DraftActiveAttachmentsHandler(storage));
+		}
 	}
 
 	private DefaultModifyAttachmentEventFactory buildAttachmentEventFactory(AttachmentService attachmentService,

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -119,7 +119,7 @@ public class Registration implements CdsRuntimeConfiguration {
 
 		// register event handlers on draft service, only if at least one draft service is available
 		boolean hasDraftServices = serviceCatalog.getServices(DraftService.class).findFirst().isPresent();
-		if (!hasDraftServices) {
+		if (hasDraftServices) {
 			configurer.eventHandler(new DraftPatchAttachmentsHandler(persistenceService, eventFactory));
 			configurer.eventHandler(new DraftCancelAttachmentsHandler(attachmentsReader, deleteContentEvent,
 					ActiveEntityModifier::new));

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/configuration/RegistrationTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/configuration/RegistrationTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.handler.DefaultAttachmentsServiceHandler;
 import com.sap.cds.services.Service;
 import com.sap.cds.services.ServiceCatalog;
+import com.sap.cds.services.draft.DraftService;
 import com.sap.cds.services.environment.CdsEnvironment;
 import com.sap.cds.services.handler.EventHandler;
 import com.sap.cds.services.outbox.OutboxService;
@@ -39,6 +41,7 @@ class RegistrationTest {
 	private PersistenceService persistenceService;
 	private AttachmentService attachmentService;
 	private OutboxService outboxService;
+	private DraftService draftService;
 	private ArgumentCaptor<Service> serviceArgumentCaptor;
 	private ArgumentCaptor<EventHandler> handlerArgumentCaptor;
 
@@ -57,6 +60,7 @@ class RegistrationTest {
 		persistenceService = mock(PersistenceService.class);
 		attachmentService = mock(AttachmentService.class);
 		outboxService = mock(OutboxService.class);
+		draftService = mock(DraftService.class);
 		serviceArgumentCaptor = ArgumentCaptor.forClass(Service.class);
 		handlerArgumentCaptor = ArgumentCaptor.forClass(EventHandler.class);
 	}
@@ -82,6 +86,7 @@ class RegistrationTest {
 				attachmentService);
 		when(serviceCatalog.getService(OutboxService.class, OutboxService.PERSISTENT_UNORDERED_NAME)).thenReturn(
 				outboxService);
+		when(serviceCatalog.getServices(DraftService.class)).thenReturn(Stream.of(draftService));
 
 		cut.eventHandlers(configurer);
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.0.7 - tbd
+
+### Added
+
+### Changed
+
+- [Register draft related event handlers](https://github.com/cap-java/cds-feature-attachments/pull/386) on DraftService, if there is at least one DraftService instance available.
+
+### Fixed
+
+- [Fixed a potentially thrown NullPointerExcpetion](https://github.com/cap-java/cds-feature-attachments/pull/385), when the cds-feature-attachments is added to an CAP Java application and the Persistent Outbox is not available.
+
 ## Version 1.0.6 - 2025-02-17
 
 ### Added

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- [Fixed a potentially thrown NullPointerExcpetion](https://github.com/cap-java/cds-feature-attachments/pull/385), when the cds-feature-attachments is added to an CAP Java application and the Persistent Outbox is not available.
+- [Fixed a potentially thrown NullPointerExcpetion](https://github.com/cap-java/cds-feature-attachments/pull/385), when the `cds-feature-attachments` is added to a CAP Java application and the Persistent Outbox is not available.
 
 ## Version 1.0.6 - 2025-02-17
 


### PR DESCRIPTION
Register event handlers on draft service, only if at least one draft service is available. This avoids warning on application startup:

```
WARN 44101 --- [  restartedMain] c.s.c.s.i.h.HandlerRegistryTools         : Failed to register handler method 'public void com.sap.cds.feature.attachments.handler.draftservice.DraftPatchAttachmentsHandler.processBeforeDraftPatch(com.sap.cds.services.draft.DraftPatchEventContext,java.util.List)': Could not find any matching service.
WARN 44101 --- [  restartedMain] c.s.c.s.i.h.HandlerRegistryTools         : Failed to register handler method 'public void com.sap.cds.feature.attachments.handler.draftservice.DraftCancelAttachmentsHandler.processBeforeDraftCancel(com.sap.cds.services.draft.DraftCancelEventContext)': Could not find any matching service.
WARN 44101 --- [  restartedMain] c.s.c.s.i.h.HandlerRegistryTools         : Failed to register handler method 'public void com.sap.cds.feature.attachments.handler.draftservice.DraftActiveAttachmentsHandler.processDraftSave(com.sap.cds.services.draft.DraftSaveEventContext)': Could not find any matching service.
```