### PR TITLE
Version bump of some build plugins and dependencies

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -35,7 +35,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
+            <dependency>
+                <groupId>com.maciejwalkowiak.spring</groupId>
+                <artifactId>wiremock-spring-boot</artifactId>
+                <version>2.1.3</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -36,9 +36,9 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.maciejwalkowiak.spring</groupId>
+                <groupId>org.wiremock.integrations</groupId>
                 <artifactId>wiremock-spring-boot</artifactId>
-                <version>2.1.3</version>
+                <version>3.8.1</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/integration-tests/srv/pom.xml
+++ b/integration-tests/srv/pom.xml
@@ -59,7 +59,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.maciejwalkowiak.spring</groupId>
+            <groupId>org.wiremock.integrations</groupId>
             <artifactId>wiremock-spring-boot</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/srv/pom.xml
+++ b/integration-tests/srv/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
             <groupId>com.maciejwalkowiak.spring</groupId>
             <artifactId>wiremock-spring-boot</artifactId>
-            <version>2.1.3</version>
             <scope>test</scope>
         </dependency>
 

--- a/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/DraftOdataRequestValidationWithoutTestHandlerAndMalwareScannerTest.java
+++ b/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/DraftOdataRequestValidationWithoutTestHandlerAndMalwareScannerTest.java
@@ -15,11 +15,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
+import org.wiremock.spring.ConfigureWireMock;
+import org.wiremock.spring.EnableWireMock;
+import org.wiremock.spring.InjectWireMock;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.maciejwalkowiak.wiremock.spring.ConfigureWireMock;
-import com.maciejwalkowiak.wiremock.spring.EnableWireMock;
-import com.maciejwalkowiak.wiremock.spring.InjectWireMock;
 import com.sap.cds.feature.attachments.integrationtests.common.MalwareScanResultProvider;
 import com.sap.cds.feature.attachments.integrationtests.constants.Profiles;
 

--- a/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/OdataRequestValidationWithoutTestHandlerAndMalwareScannerTest.java
+++ b/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/OdataRequestValidationWithoutTestHandlerAndMalwareScannerTest.java
@@ -14,11 +14,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
+import org.wiremock.spring.ConfigureWireMock;
+import org.wiremock.spring.EnableWireMock;
+import org.wiremock.spring.InjectWireMock;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.maciejwalkowiak.wiremock.spring.ConfigureWireMock;
-import com.maciejwalkowiak.wiremock.spring.EnableWireMock;
-import com.maciejwalkowiak.wiremock.spring.InjectWireMock;
 import com.sap.cds.feature.attachments.generated.integration.test.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.integrationtests.common.MalwareScanResultProvider;
 import com.sap.cds.feature.attachments.integrationtests.constants.Profiles;

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <excluded.generation.package>com/sap/cds/feature/attachments/generated/</excluded.generation.package>
-        <cds.services.version>2.10.6</cds.services.version>
+        <cds.services.version>2.10.7</cds.services.version>
         <cds.install-cdsdk.version>7.9.9</cds.install-cdsdk.version>
 
         <generation-folder>src/gen</generation-folder>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <excluded.generation.package>com/sap/cds/feature/attachments/generated/</excluded.generation.package>
-        <cds.services.version>2.10.7</cds.services.version>
+        <cds.services.version>2.10.6</cds.services.version>
         <cds.install-cdsdk.version>7.9.9</cds.install-cdsdk.version>
 
         <generation-folder>src/gen</generation-folder>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.3</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
                 <artifactId>cds-feature-attachments</artifactId>
                 <version>${revision}</version>
             </dependency>
-            
+
             <!-- Mitigate vulnerabilities in commons-codec:commons-codec:1.11 -->
             <dependency>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
- update dependencies and build plugins
- use artifact `wiremock-spring-boot` from groupId`org.wiremock.integrations` instead of `com.maciejwalkowiak.spring`. See also: https://github.com/wiremock/wiremock-spring-boot?tab=readme-ov-file#credits
> [Maciej Walkowiak](https://github.com/maciejwalkowiak) - This was originally his project and later moved to WireMock organization