### PR TITLE
Removed no longer existing directory from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,6 @@ updates:
   - package-ecosystem: maven
     directories:
       - "/"
-      - "/deploy-oss"
     schedule:
       interval: daily
     open-pull-requests-limit: 10


### PR DESCRIPTION
This PR fixes this error in dependabot:

```
updater | 2025/06/20 15:43:05 ERROR <job_1038064978> Error during file fetching; aborting: /deploy-oss/pom.xml not found
```