### PR TITLE
Version bump plugins and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.7.0</version>
+                    <version>0.8.0</version>
                     <extensions>true</extensions>
                 </plugin>
                 <plugin>
@@ -285,7 +285,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
-                    <version>1.7.0</version>
+                    <version>1.7.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
@@ -295,7 +295,7 @@
                 <plugin>
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>
-                    <version>1.19.5</version>
+                    <version>1.20.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
Bump plugins:
- org.codehaus.mojo:flatten-maven-plugin ............. 1.7.0 -> 1.7.1
- org.pitest:pitest-maven .......................... 1.19.5 -> 1.20.0 
- org.sonatype.central:central-publishing-maven-plugin  0.7.0 -> 0.8.0