### PR TITLE
OSS Plugin Cosmetics

### DIFF
--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
@@ -20,13 +20,16 @@ public class Registration implements CdsRuntimeConfiguration {
 
   @Override
   public void eventHandlers(CdsRuntimeConfigurer configurer) {
-    Optional<ServiceBinding> binding = getOSBinding(configurer.getCdsRuntime().getEnvironment());
-    ExecutorService executor =
-        Executors
-            .newCachedThreadPool(); // This might be configured by CdsProperties, if needed in the
-    // future.
-    configurer.eventHandler(new OSSAttachmentsServiceHandler(binding, executor));
-    logger.info("Registered OSS Attachments Service Handler.");
+    Optional<ServiceBinding> bindingOpt = getOSBinding(configurer.getCdsRuntime().getEnvironment());
+    if (bindingOpt.isPresent()) {
+      ExecutorService executor =
+          Executors
+              .newCachedThreadPool(); // This might be configured by CdsProperties, if needed in the
+      configurer.eventHandler(new OSSAttachmentsServiceHandler(bindingOpt.get(), executor));
+      logger.info("Registered OSS Attachments Service Handler.");
+    } else {
+      logger.warn("No service binding found, hence the attachment service is not connected!");
+    }
   }
 
   /**

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
@@ -38,11 +38,9 @@ public class Registration implements CdsRuntimeConfiguration {
    *     available, or {@link Optional#empty()} if not found
    */
   private static Optional<ServiceBinding> getOSBinding(CdsEnvironment environment) {
-    Optional<ServiceBinding> bindingOpt =
-        environment
-            .getServiceBindings()
-            .filter(b -> b.getServiceName().map(name -> name.equals("objectstore")).orElse(false))
-            .findFirst();
-    return bindingOpt;
+    return environment
+        .getServiceBindings()
+        .filter(b -> b.getServiceName().map(name -> name.equals("objectstore")).orElse(false))
+        .findFirst();
   }
 }

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
@@ -22,9 +22,8 @@ public class Registration implements CdsRuntimeConfiguration {
   public void eventHandlers(CdsRuntimeConfigurer configurer) {
     Optional<ServiceBinding> bindingOpt = getOSBinding(configurer.getCdsRuntime().getEnvironment());
     if (bindingOpt.isPresent()) {
-      ExecutorService executor =
-          Executors
-              .newCachedThreadPool(); // This might be configured by CdsProperties, if needed in the
+      ExecutorService executor = Executors.newCachedThreadPool();
+      // Thread count could be made configurable via CdsProperties if needed in the future.
       configurer.eventHandler(new OSSAttachmentsServiceHandler(bindingOpt.get(), executor));
       logger.info("Registered OSS Attachments Service Handler.");
     } else {

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
@@ -28,7 +28,8 @@ public class Registration implements CdsRuntimeConfiguration {
       configurer.eventHandler(new OSSAttachmentsServiceHandler(bindingOpt.get(), executor));
       logger.info("Registered OSS Attachments Service Handler.");
     } else {
-      logger.warn("No service binding found, hence the attachment service is not connected!");
+      logger.warn(
+          "No service binding to Object Store Service found, hence the OSS Attachments Service Handler is not connected!");
     }
   }
 

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/OSSAttachmentsServiceHandler.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/OSSAttachmentsServiceHandler.java
@@ -25,7 +25,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -57,18 +56,9 @@ public class OSSAttachmentsServiceHandler implements EventHandler {
    *       "google" or "gcp".
    * </ul>
    *
-   * @param bindingOpt the optional {@link ServiceBinding} containing credentials for the object
-   *     store service
+   * @param binding the {@link ServiceBinding} containing credentials for the object store service
    */
-  public OSSAttachmentsServiceHandler(
-      Optional<ServiceBinding> bindingOpt, ExecutorService executor) {
-    if (bindingOpt.isEmpty()) {
-      logger.error("No service binding found, hence the attachment service is not connected!");
-      this.osClient = new MockOSClient();
-      return;
-    }
-    ServiceBinding binding = bindingOpt.get();
-
+  public OSSAttachmentsServiceHandler(ServiceBinding binding, ExecutorService executor) {
     final String host = (String) binding.getCredentials().get("host"); // AWS
     final String containerUri = (String) binding.getCredentials().get("container_uri"); // Azure
     final String base64EncodedPrivateKeyData =

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/OSSAttachmentsServiceHandler.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/OSSAttachmentsServiceHandler.java
@@ -23,10 +23,13 @@ import com.sap.cds.services.handler.annotations.ServiceName;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,19 +78,17 @@ public class OSSAttachmentsServiceHandler implements EventHandler {
     // We do *not* throw exceptions here, as we want to provide a fallback to the MockOSClient if no
     // valid service binding is found.
     // Then the rest of the application still works, but without actual attachment storage.
-    if (host != null
-        && java.util.stream.Stream.of("aws", "s3", "amazon").anyMatch(s -> host.contains(s))) {
+    if (host != null && Stream.of("aws", "s3", "amazon").anyMatch(host::contains)) {
       this.osClient = new AWSClient(binding, executor);
     } else if (containerUri != null
-        && java.util.stream.Stream.of("azure", "windows").anyMatch(s -> containerUri.contains(s))) {
+        && Stream.of("azure", "windows").anyMatch(containerUri::contains)) {
       this.osClient = new AzureClient(binding, executor);
     } else if (base64EncodedPrivateKeyData != null) {
       String decoded = "";
       try {
         decoded =
             new String(
-                java.util.Base64.getDecoder().decode(base64EncodedPrivateKeyData),
-                java.nio.charset.StandardCharsets.UTF_8);
+                Base64.getDecoder().decode(base64EncodedPrivateKeyData), StandardCharsets.UTF_8);
       } catch (IllegalArgumentException e) {
         logger.error(
             "No valid base64EncodedPrivateKeyData found in Google service binding {}, hence the attachment service is not connected!",
@@ -95,7 +96,7 @@ public class OSSAttachmentsServiceHandler implements EventHandler {
       }
       // Redeclaring is needed here to make the variable effectively final for the lambda expression
       final String dec = decoded;
-      if (java.util.stream.Stream.of("google", "gcp").anyMatch(s -> dec.contains(s))) {
+      if (Stream.of("google", "gcp").anyMatch(dec::contains)) {
         this.osClient = new GoogleClient(binding, executor);
       } else {
         logger.error(

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/ObjectStoreServiceException.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/ObjectStoreServiceException.java
@@ -4,6 +4,8 @@
 package com.sap.cds.feature.attachments.oss.handler;
 
 public class ObjectStoreServiceException extends RuntimeException {
+  private static final long serialVersionUID = -360151881669215771L;
+
   public ObjectStoreServiceException(String message) {
     super(message);
   }

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AWSClientIT.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AWSClientIT.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 
-public class AWSClientIT {
+class AWSClientIT {
   // The tests in this class are intended to run against a real AWS Storage instance.
   // They require a valid ServiceBinding with credentials set up in the environment.
 

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AWSClientTest.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AWSClientTest.java
@@ -3,9 +3,13 @@
  */
 package com.sap.cds.feature.attachments.oss.client;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.sap.cds.feature.attachments.oss.handler.OSSAttachmentsServiceHandler;
 import com.sap.cds.feature.attachments.oss.handler.OSSAttachmentsServiceHandlerTestUtils;
@@ -14,7 +18,6 @@ import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.HashMap;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -39,7 +42,7 @@ class AWSClientTest {
   void testConstructorWithAwsBindingUsesAwsClient()
       throws NoSuchFieldException, IllegalAccessException {
     OSSAttachmentsServiceHandler handler =
-        new OSSAttachmentsServiceHandler(Optional.of(getDummyBinding()), executor);
+        new OSSAttachmentsServiceHandler(getDummyBinding(), executor);
     OSClient client = OSSAttachmentsServiceHandlerTestUtils.getOsClient(handler);
     assertInstanceOf(AWSClient.class, client);
   }

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AWSClientTest.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AWSClientTest.java
@@ -32,7 +32,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
-public class AWSClientTest {
+class AWSClientTest {
   ExecutorService executor = Executors.newCachedThreadPool();
 
   @Test

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AzureClientIT.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AzureClientIT.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 
-public class AzureClientIT {
+class AzureClientIT {
   // The tests in this class are intended to run against a real Azure instance.
   // They require a valid ServiceBinding with credentials set up in the environment.
 

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AzureClientTest.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AzureClientTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 
-public class AzureClientTest {
+class AzureClientTest {
   ExecutorService executor = Executors.newCachedThreadPool();
 
   @Test

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/GoogleClientIT.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/GoogleClientIT.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 
-public class GoogleClientIT {
+class GoogleClientIT {
   // The tests in this class are intended to run against a real Google Cloud Storage instance.
   // They require a valid ServiceBinding with credentials set up in the environment.
 

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/GoogleClientTest.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/GoogleClientTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 
-public class GoogleClientTest {
+class GoogleClientTest {
   ExecutorService executor = Executors.newCachedThreadPool();
 
   @Test

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/GoogleClientTest.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/GoogleClientTest.java
@@ -59,8 +59,7 @@ public class GoogleClientTest {
           IllegalArgumentException,
           IllegalAccessException,
           InterruptedException,
-          ExecutionException,
-          IOException {
+          ExecutionException {
     GoogleClient googleClient = mock(GoogleClient.class, CALLS_REAL_METHODS);
 
     String fileName = "file.txt";
@@ -156,12 +155,7 @@ public class GoogleClientTest {
 
   @Test
   void testDeleteContentDoesNotWork()
-      throws NoSuchFieldException,
-          IllegalArgumentException,
-          IllegalAccessException,
-          InterruptedException,
-          ExecutionException,
-          IOException {
+      throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
     GoogleClient googleClient = mock(GoogleClient.class, CALLS_REAL_METHODS);
 
     String fileName = "file.txt";
@@ -195,12 +189,7 @@ public class GoogleClientTest {
 
   @Test
   void testUploadContentThrowsOnIOException()
-      throws NoSuchFieldException,
-          IllegalArgumentException,
-          IllegalAccessException,
-          InterruptedException,
-          ExecutionException,
-          IOException {
+      throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException, IOException {
     GoogleClient googleClient = mock(GoogleClient.class, CALLS_REAL_METHODS);
 
     // Mock storage and writer
@@ -237,9 +226,7 @@ public class GoogleClientTest {
   void testDeleteContentThrowsOnRuntimeException()
       throws NoSuchFieldException,
           IllegalArgumentException,
-          IllegalAccessException,
-          InterruptedException,
-          ExecutionException {
+          IllegalAccessException {
     GoogleClient googleClient = mock(GoogleClient.class, CALLS_REAL_METHODS);
 
     // Mock storage and blob to throw RuntimeException on delete
@@ -264,11 +251,7 @@ public class GoogleClientTest {
 
   @Test
   void testReadContentThrowsOnRuntimeException()
-      throws NoSuchFieldException,
-          IllegalArgumentException,
-          IllegalAccessException,
-          InterruptedException,
-          ExecutionException {
+      throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
     GoogleClient googleClient = mock(GoogleClient.class, CALLS_REAL_METHODS);
 
     // Mock storage and blob to throw RuntimeException on reader

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/GoogleClientTest.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/GoogleClientTest.java
@@ -224,9 +224,7 @@ class GoogleClientTest {
 
   @Test
   void testDeleteContentThrowsOnRuntimeException()
-      throws NoSuchFieldException,
-          IllegalArgumentException,
-          IllegalAccessException {
+      throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
     GoogleClient googleClient = mock(GoogleClient.class, CALLS_REAL_METHODS);
 
     // Mock storage and blob to throw RuntimeException on delete

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/MockOSClientTest.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/MockOSClientTest.java
@@ -3,16 +3,19 @@
  */
 package com.sap.cds.feature.attachments.oss.client;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.sap.cds.feature.attachments.oss.handler.OSSAttachmentsServiceHandler;
 import com.sap.cds.feature.attachments.oss.handler.OSSAttachmentsServiceHandlerTestUtils;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class MockOSClientTest {
 
@@ -21,7 +24,7 @@ class MockOSClientTest {
       throws NoSuchFieldException, IllegalAccessException {
     ExecutorService executor = Executors.newCachedThreadPool();
     OSSAttachmentsServiceHandler handler =
-        new OSSAttachmentsServiceHandler(Optional.empty(), executor);
+        new OSSAttachmentsServiceHandler(Mockito.mock(ServiceBinding.class), executor);
     // Reflection to access private static osClient
     OSClient client = OSSAttachmentsServiceHandlerTestUtils.getOsClient(handler);
     assertInstanceOf(MockOSClient.class, client);

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/handler/OSSAttachmentsServiceHandlerTest.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/handler/OSSAttachmentsServiceHandlerTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 
-public class OSSAttachmentsServiceHandlerTest {
+class OSSAttachmentsServiceHandlerTest {
   ExecutorService executor = Executors.newCachedThreadPool();
 
   @Test

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/handler/OSSAttachmentsServiceHandlerTest.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/handler/OSSAttachmentsServiceHandlerTest.java
@@ -4,8 +4,12 @@
 package com.sap.cds.feature.attachments.oss.handler;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
 import com.sap.cds.feature.attachments.oss.client.OSClient;
@@ -18,7 +22,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Base64;
 import java.util.HashMap;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -32,8 +35,7 @@ public class OSSAttachmentsServiceHandlerTest {
   void testRestoreAttachmentCallsSetCompleted() {
     ServiceBinding binding = mock(ServiceBinding.class);
 
-    OSSAttachmentsServiceHandler handler =
-        new OSSAttachmentsServiceHandler(Optional.of(binding), executor);
+    OSSAttachmentsServiceHandler handler = new OSSAttachmentsServiceHandler(binding, executor);
     AttachmentRestoreEventContext context = mock(AttachmentRestoreEventContext.class);
     handler.restoreAttachment(context);
     verify(context).setCompleted();
@@ -178,8 +180,7 @@ public class OSSAttachmentsServiceHandlerTest {
     when(binding.getCredentials()).thenReturn(creds);
 
     // Act: Should not throw, but should use MockOSClient as fallback
-    OSSAttachmentsServiceHandler handler =
-        new OSSAttachmentsServiceHandler(Optional.of(binding), executor);
+    OSSAttachmentsServiceHandler handler = new OSSAttachmentsServiceHandler(binding, executor);
     // Optionally, check that the handler uses MockOSClient
     try {
       var field = OSSAttachmentsServiceHandler.class.getDeclaredField("osClient");
@@ -211,8 +212,7 @@ public class OSSAttachmentsServiceHandlerTest {
     creds.put("base64EncodedPrivateKeyData", base64);
     when(binding.getCredentials()).thenReturn(creds);
 
-    OSSAttachmentsServiceHandler handler =
-        new OSSAttachmentsServiceHandler(Optional.of(binding), executor);
+    OSSAttachmentsServiceHandler handler = new OSSAttachmentsServiceHandler(binding, executor);
     try {
       var field = OSSAttachmentsServiceHandler.class.getDeclaredField("osClient");
       field.setAccessible(true);

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/handler/OSSAttachmentsServiceHandlerTestUtils.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/handler/OSSAttachmentsServiceHandlerTestUtils.java
@@ -3,9 +3,14 @@
  */
 package com.sap.cds.feature.attachments.oss.handler;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
@@ -18,7 +23,6 @@ import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.HashMap;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 public class OSSAttachmentsServiceHandlerTestUtils {
@@ -31,8 +35,7 @@ public class OSSAttachmentsServiceHandlerTestUtils {
     String testFileName = "testFileName-" + System.currentTimeMillis() + ".txt";
     String testFileContent = "test";
 
-    OSSAttachmentsServiceHandler handler =
-        new OSSAttachmentsServiceHandler(Optional.of(binding), executor);
+    OSSAttachmentsServiceHandler handler = new OSSAttachmentsServiceHandler(binding, executor);
 
     // Create an AttachmentCreateEventContext with mocked data - to upload a test attachment
     MediaData createMediaData = mock(MediaData.class);


### PR DESCRIPTION
This PR contains some improvements for the OSS plugin:

- organize imports
- fixed some sonar issues
  - remove not thrown exceptions from method signatures in tests
  - reduced visibility of test classes, package private is enough
- fixed Eclipse warnings:
  - declare missing serialVersionUID field in serializable class `ObjectStoreServiceException`
- if service binding to object store service is missing, don't instantiate / register OSS handler