### PR TITLE
Bump CAP Java and cds-dk to latest avaiable versions and disable draft messages in integration tests

### DIFF
--- a/integration-tests/.cdsrc.json
+++ b/integration-tests/.cdsrc.json
@@ -4,6 +4,9 @@
       "outbox": {
         "kind": "persistent-outbox"
       }
+    },
+    "fiori": {
+      "draft_messages": false
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,10 @@
     <software.amazon.awssdk-crt-version>0.38.13</software.amazon.awssdk-crt-version>
 
     <!-- Versions of CAP Java and cds-dk used for build and integrations tests -->
-    <cds.services.version>3.10.4</cds.services.version>
     <!-- https://central.sonatype.com/artifact/com.sap.cds/cds-services-api/versions -->
-    <cds.cdsdk-version>8.9.8</cds.cdsdk-version>
+    <cds.services.version>3.10.4</cds.services.version>
     <!-- https://www.npmjs.com/package/@sap/cds-dk?activeTab=versions -->
+    <cds.cdsdk-version>8.9.8</cds.cdsdk-version>
 
     <!-- Latest versions of CAP Java and cds-dk used for integrations tests only -->
     <cds.services.latest-test-version>4.3.1</cds.services.latest-test-version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
     <!-- https://www.npmjs.com/package/@sap/cds-dk?activeTab=versions -->
 
     <!-- Latest versions of CAP Java and cds-dk used for integrations tests only -->
-    <cds.services.latest-test-version>4.2.0</cds.services.latest-test-version>
-    <cds.cdsdk.latest-test-version>9.2.1</cds.cdsdk.latest-test-version>
+    <cds.services.latest-test-version>4.3.1</cds.services.latest-test-version>
+    <cds.cdsdk.latest-test-version>9.3.2</cds.cdsdk.latest-test-version>
 
     <spotless.check.skip>true</spotless.check.skip>
   </properties>


### PR DESCRIPTION
By default the cds-dk 9.3.0 enables draft messages. In this case the tests behave different and are failing. To ensure that in both version of the cds-dk (8.9.x and 9.3.x) the tests behave the same, the draft messages needs to be disabled.