### PR TITLE
change to https for connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </modules>
 
   <scm>
-    <connection>scm:git:git@github.com:cap-java/cds-feature-attachments.git</connection>
+    <connection>scm:git:https://github.com/cap-java/cds-feature-attachments.git</connection>
     <developerConnection>scm:git:git@github.com:cap-java/cds-feature-attachments.git</developerConnection>
     <url>https://github.com/cap-java/cds-feature-attachments</url>
   </scm>


### PR DESCRIPTION
Found issue in maven central repository. The link redirecting to our repository is incorrect. This PR changes it from ssh to http for general connection. Dev connection remains ssh.