### PR TITLE
add approval step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,25 @@ env:
   DEPLOYMENT_PASS: ${{ secrets.DEPLOYMENT_PASS }}
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ "main" ]
-  pull_request:
+    branches: [main]
+  pull_request_target:
+    branches: [main]
+    types: [reopened, synchronize, opened]
 
 jobs:
+  requires-approval:
+    runs-on: ubuntu-latest
+    name: "Waiting for PR approval as this workflow runs on pull_request_target"
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.base.user.login != 'cap-js'
+    environment: pr-approval
+    steps:
+      - name: Approval Step
+        run: echo "This job has been approved!"
   build:
     name: Build
+    needs: requires-approval
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
# Add Manual Approval Step for External Pull Requests

### New Features

🔒 Introduced a manual approval gate for external pull requests to enhance security when running workflows with elevated permissions.

### Changes

* `.github/workflows/ci.yml`: 
  - Added `workflow_dispatch` trigger to enable manual workflow execution
  - Changed trigger from `pull_request` to `pull_request_target` for handling external contributions with write permissions
  - Added PR event types filter (reopened, synchronize, opened) for more precise workflow triggering
  - Created new `requires-approval` job that acts as a gatekeeper before running the build
  - Configured the approval job to only trigger for external PRs (excluding PRs from 'cap-js' organization)
  - Added environment-based approval mechanism using `pr-approval` environment
  - Updated `build` job to depend on successful completion of `requires-approval` job

- [ ] 🔄 Regenerate and Update Summary

