### PR TITLE
CAP #409: Add support to restrict @Core.AcceptableMediaTypes

### DIFF
--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
@@ -7,6 +7,7 @@ annotate MediaData with @UI.MediaResource: {Stream: content} {
     content   @(
         title                           : '{i18n>attachment_content}',
         Core.MediaType                  : mimeType,
+        Core.AcceptableMediaTypes       : ['image/jpeg'],
         Core.ContentDisposition.Filename: fileName,
         Core.ContentDisposition.Type    : 'inline'
     );


### PR DESCRIPTION
It now supports only jpeg images as per the requirement in the example mentioned in the issue: https://github.com/cap-js/attachments/blob/main/tests/incidents-app/db/attachments.cds#L21C11-L21C37

**Screenshot:**
While selecting media, you would see only the accepted media type (in this case, jpeg images) available.
<img width="582" height="235" alt="image" src="https://github.com/user-attachments/assets/1c3c67b0-cefa-448b-ba12-3c593e94996d" />
 