### PR TITLE
Change PR approval condition for cap-java user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
   requires-approval:
     runs-on: ubuntu-latest
     name: "Waiting for PR approval as this workflow runs on pull_request_target"
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.base.user.login != 'cap-java'
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.owner.login != 'cap-java'
     environment: pr-approval
     steps:
       - name: Approval Step


### PR DESCRIPTION
Fixing that review is not always required, but only from users that are not part of the cap-java organisation