### PR TITLE
Fixed if condition to run also on skipped approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         run: echo "This job has been approved!"
   build:
     name: Build
+    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     needs: requires-approval
     runs-on: ubuntu-latest
     strategy:
@@ -60,6 +61,7 @@ jobs:
 
   integration-tests:
     name: Integration Tests (Java ${{ matrix.java-version }})
+    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     runs-on: ubuntu-latest
     needs: build
     strategy:
@@ -76,6 +78,7 @@ jobs:
 
   sonarqube-scan:
     name: SonarQube Scan
+    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -91,6 +94,7 @@ jobs:
 
   scan:
     name: Blackduck Scan
+    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 15
@@ -107,6 +111,7 @@ jobs:
 
   deploy-snapshot:
     name: Deploy snapshot to Artifactory
+    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
# Fixed Workflow Condition to Handle Skipped Approval

### Bug Fix

🐛 **Bug Fix**: Updated GitHub Actions workflow conditions to ensure dependent jobs run correctly when the approval step is skipped for internal pull requests.

### Changes

* `.github/workflows/ci.yml`: Added conditional logic to all jobs that depend on `requires-approval` to execute when the approval is either successful or skipped. This ensures that internal pull requests from the `cap-java` organization bypass the approval requirement while external pull requests still require approval before running CI jobs.

The following jobs now include the condition `if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')`:
  - `build`
  - `integration-tests`
  - `sonarqube-scan`
  - `scan`
  - `deploy-snapshot`

This change ensures the CI pipeline functions correctly for both internal and external contributors without blocking internal PRs on unnecessary approval steps.

- [ ] 🔄 Regenerate and Update Summary

