### PR TITLE
Add support to restrict @Core.AcceptableMediaTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It supports the [AWS, Azure, and Google object stores](storage-targets/cds-featu
   * [Storage Targets](#storage-targets)
   * [Malware Scanner](#malware-scanner)
   * [Specify the maximum file size](#specify-the-maximum-file-size)
+  * [Restrict allowed MIME types](#restrict-allowed-mime-types)
   * [Outbox](#outbox)
   * [Restore Endpoint](#restore-endpoint)
     * [Motivation](#motivation)
@@ -213,6 +214,37 @@ The @Validation.Maximum value is a size string consisting of a number followed b
 - KiB, MiB, GiB, TiB (binary units)
 
 The default is 400MB
+
+### Restrict allowed MIME types
+
+You can restrict which MIME types are allowed for attachments by annotating the content property with @Core.AcceptableMediaTypes. This validation is performed during file upload.
+
+```cds
+entity Books {
+  ...
+  attachments: Composition of many Attachments;
+}
+
+annotate Books.attachments with {
+  content @Core.AcceptableMediaTypes : ['image/jpeg', 'image/png', 'application/pdf'];
+}
+```
+
+Wildcard patterns are supported:
+
+```cds
+annotate Books.attachments with {
+  content @Core.AcceptableMediaTypes : ['image/*', 'application/pdf'];
+}
+```
+
+To allow all MIME types (default behavior), either omit the annotation or use:
+
+```cds
+annotate Books.attachments with {
+  content @Core.AcceptableMediaTypes : ['*/*'];
+}
+```
 
 ### Outbox
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandler.java
@@ -5,6 +5,8 @@ package com.sap.cds.feature.attachments.handler.applicationservice;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+
 import com.sap.cds.CdsData;
 import com.sap.cds.feature.attachments.handler.applicationservice.helper.ExtendedErrorStatuses;
 import com.sap.cds.feature.attachments.handler.applicationservice.helper.ModifyApplicationHandlerHelper;
@@ -12,6 +14,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.helper.Readonl
 import com.sap.cds.feature.attachments.handler.applicationservice.helper.ThreadDataStorageReader;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEventFactory;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.services.EventContext;
 import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.cds.ApplicationService;
@@ -24,13 +27,13 @@ import com.sap.cds.services.handler.annotations.HandlerOrder;
 import com.sap.cds.services.handler.annotations.On;
 import com.sap.cds.services.handler.annotations.ServiceName;
 import com.sap.cds.services.utils.OrderConstants;
-import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The class {@link CreateAttachmentsHandler} is an event handler that is responsible for creating
+ * The class {@link CreateAttachmentsHandler} is an event handler that is
+ * responsible for creating
  * attachments for entities. It is called before a create event is executed.
  */
 @ServiceName(value = "*", type = ApplicationService.class)
@@ -61,6 +64,13 @@ public class CreateAttachmentsHandler implements EventHandler {
         context.getTarget(), data, storageReader.get());
   }
 
+  @Before(event = { CqnService.EVENT_CREATE, DraftService.EVENT_DRAFT_NEW })
+  @HandlerOrder(HandlerOrder.BEFORE)
+  void processBeforeForMetadata(EventContext context, List<CdsData> data) {
+    CdsEntity target = context.getTarget();
+    ApplicationHandlerHelper.validateAcceptableMediaTypes(target, data);
+  }
+
   @Before
   @HandlerOrder(HandlerOrder.LATE)
   void processBefore(CdsCreateEventContext context, List<CdsData> data) {
@@ -72,7 +82,7 @@ public class CreateAttachmentsHandler implements EventHandler {
     }
   }
 
-  @On(event = {CqnService.EVENT_CREATE, CqnService.EVENT_UPDATE, DraftService.EVENT_DRAFT_PATCH})
+  @On(event = { CqnService.EVENT_CREATE, CqnService.EVENT_UPDATE, DraftService.EVENT_DRAFT_PATCH })
   @HandlerOrder(HandlerOrder.EARLY)
   void restoreError(EventContext context) {
     try {

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/AttachmentValidationHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/AttachmentValidationHelper.java
@@ -1,0 +1,152 @@
+/*
+* © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+*/
+package com.sap.cds.feature.attachments.handler.applicationservice.helper;
+
+import java.net.URLConnection;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sap.cds.services.ServiceException;
+import com.sap.cds.services.ErrorStatuses;
+
+public class AttachmentValidationHelper {
+
+    public static final String DEFAULT_MEDIA_TYPE = "application/octet-stream";
+    public static final Map<String, String> EXT_TO_MEDIA_TYPE = Map.ofEntries(
+            Map.entry("aac", "audio/aac"),
+            Map.entry("abw", "application/x-abiword"),
+            Map.entry("arc", "application/octet-stream"),
+            Map.entry("avi", "video/x-msvideo"),
+            Map.entry("azw", "application/vnd.amazon.ebook"),
+            Map.entry("bin", "application/octet-stream"),
+            Map.entry("png", "image/png"),
+            Map.entry("gif", "image/gif"),
+            Map.entry("bmp", "image/bmp"),
+            Map.entry("bz", "application/x-bzip"),
+            Map.entry("bz2", "application/x-bzip2"),
+            Map.entry("csh", "application/x-csh"),
+            Map.entry("css", "text/css"),
+            Map.entry("csv", "text/csv"),
+            Map.entry("doc", "application/msword"),
+            Map.entry("docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+            Map.entry("odp", "application/vnd.oasis.opendocument.presentation"),
+            Map.entry("ods", "application/vnd.oasis.opendocument.spreadsheet"),
+            Map.entry("odt", "application/vnd.oasis.opendocument.text"),
+            Map.entry("epub", "application/epub+zip"),
+            Map.entry("gz", "application/gzip"),
+            Map.entry("htm", "text/html"),
+            Map.entry("html", "text/html"),
+            Map.entry("ico", "image/x-icon"),
+            Map.entry("ics", "text/calendar"),
+            Map.entry("jar", "application/java-archive"),
+            Map.entry("jpg", "image/jpeg"),
+            Map.entry("jpeg", "image/jpeg"),
+            Map.entry("js", "text/javascript"),
+            Map.entry("json", "application/json"),
+            Map.entry("mid", "audio/midi"),
+            Map.entry("midi", "audio/midi"),
+            Map.entry("mjs", "text/javascript"),
+            Map.entry("mov", "video/quicktime"),
+            Map.entry("mp3", "audio/mpeg"),
+            Map.entry("mp4", "video/mp4"),
+            Map.entry("mpeg", "video/mpeg"),
+            Map.entry("mpkg", "application/vnd.apple.installer+xml"),
+            Map.entry("otf", "font/otf"),
+            Map.entry("pdf", "application/pdf"),
+            Map.entry("ppt", "application/vnd.ms-powerpoint"),
+            Map.entry("pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"),
+            Map.entry("rar", "application/x-rar-compressed"),
+            Map.entry("rtf", "application/rtf"),
+            Map.entry("svg", "image/svg+xml"),
+            Map.entry("tar", "application/x-tar"),
+            Map.entry("tif", "image/tiff"),
+            Map.entry("tiff", "image/tiff"),
+            Map.entry("ttf", "font/ttf"),
+            Map.entry("vsd", "application/vnd.visio"),
+            Map.entry("wav", "audio/wav"),
+            Map.entry("woff", "font/woff"),
+            Map.entry("woff2", "font/woff2"),
+            Map.entry("xhtml", "application/xhtml+xml"),
+            Map.entry("xls", "application/vnd.ms-excel"),
+            Map.entry("xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+            Map.entry("xml", "application/xml"),
+            Map.entry("zip", "application/zip"),
+            Map.entry("txt", "application/txt"),
+            Map.entry("lst", "application/txt"),
+            Map.entry("webp", "image/webp"));
+
+    private static final Logger logger = LoggerFactory.getLogger(AttachmentValidationHelper.class);
+
+    /**
+     * Validates the file name and resolves its media type. Ensures that the
+     * detected media type is part of the list of acceptable media types.
+     *
+     * @param fileName             the name of the attachment file
+     * @param acceptableMediaTypes list of allowed media types (e.g. "image/*",
+     *                             "application/pdf")
+     * @return the detected media type
+     * @throws ServiceException if the file name is invalid or the media type is not
+     *                          allowed
+     */
+    public static String validateMediaTypeForAttachment(String fileName, List<String> acceptableMediaTypes) {
+        validateFileName(fileName);
+        String detectedMediaType = resolveMimeType(fileName);
+        validateAcceptableMediaType(acceptableMediaTypes, detectedMediaType);
+        return detectedMediaType;
+    }
+
+    private static void validateFileName(String fileName) {
+        String clean = fileName.trim();
+        int lastDotIndex = clean.lastIndexOf('.');
+        if (lastDotIndex <= 0 || lastDotIndex == clean.length() - 1) {
+            throw new ServiceException(
+                    ErrorStatuses.UNSUPPORTED_MEDIA_TYPE,
+                    "Invalid filename format: " + fileName);
+        }
+    }
+
+    private static void validateAcceptableMediaType(List<String> acceptableMediaTypes, String actualMimeType) {
+        if (!checkMimeTypeMatch(acceptableMediaTypes, actualMimeType)) {
+            throw new ServiceException(
+                    ErrorStatuses.UNSUPPORTED_MEDIA_TYPE,
+                    "The attachment file type '{}' is not allowed. Allowed types are: {}", actualMimeType,
+                    String.join(", ", acceptableMediaTypes));
+        }
+    }
+
+    private static String resolveMimeType(String fileName) {
+        String actualMimeType = URLConnection.guessContentTypeFromName(fileName);
+
+        if (actualMimeType == null) {
+            String fileExtension = fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase();
+            actualMimeType = EXT_TO_MEDIA_TYPE.get(fileExtension);
+
+            if (actualMimeType == null) {
+                logger.warn("Could not determine mime type for file: {}. Setting mime type to default: {}",
+                        fileName, DEFAULT_MEDIA_TYPE);
+                actualMimeType = DEFAULT_MEDIA_TYPE;
+            }
+        }
+        return actualMimeType;
+    }
+
+    private static boolean checkMimeTypeMatch(Collection<String> acceptableMediaTypes, String mimeType) {
+        if (acceptableMediaTypes == null || acceptableMediaTypes.isEmpty() || acceptableMediaTypes.contains("*/*"))
+            return true;
+
+        String baseMimeType = mimeType.trim().toLowerCase();
+
+        return acceptableMediaTypes.stream().anyMatch(type -> {
+            String normalizedType = type.trim().toLowerCase();
+            return normalizedType.endsWith("/*")
+                    ? baseMimeType.startsWith(normalizedType.substring(0, normalizedType.length() - 2) + "/")
+                    : baseMimeType.equals(normalizedType);
+        });
+    }
+
+}

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
@@ -27,23 +27,26 @@ public final class ModifyApplicationHandlerHelper {
   /** Default max size when malware scanner binding is present (400 MB). */
   public static final String DEFAULT_SIZE_WITH_SCANNER = "400MB";
 
-  /** Effectively unlimited max size when no malware scanner binding is present. */
+  /**
+   * Effectively unlimited max size when no malware scanner binding is present.
+   */
   public static final String UNLIMITED_SIZE = String.valueOf(Long.MAX_VALUE);
 
-  private static final Filter VALMAX_FILTER =
-      (path, element, type) ->
-          element.getName().contentEquals("content")
-              && element.findAnnotation("Validation.Maximum").isPresent();
+  private static final Filter VALMAX_FILTER = (path, element, type) -> element.getName().contentEquals("content")
+      && element.findAnnotation("Validation.Maximum").isPresent();
 
   /**
    * Handles attachments for entities.
    *
-   * @param entity the {@link CdsEntity entity} to handle attachments for
-   * @param data the given list of {@link CdsData data}
+   * @param entity              the {@link CdsEntity entity} to handle attachments
+   *                            for
+   * @param data                the given list of {@link CdsData data}
    * @param existingAttachments the given list of existing {@link CdsData data}
-   * @param eventFactory the {@link ModifyAttachmentEventFactory} to create the corresponding event
-   * @param eventContext the current {@link EventContext}
-   * @param defaultMaxSize the default max size to use when no annotation is present
+   * @param eventFactory        the {@link ModifyAttachmentEventFactory} to create
+   *                            the corresponding event
+   * @param eventContext        the current {@link EventContext}
+   * @param defaultMaxSize      the default max size to use when no annotation is
+   *                            present
    */
   public static void handleAttachmentForEntities(
       CdsEntity entity,
@@ -53,18 +56,16 @@ public final class ModifyApplicationHandlerHelper {
       EventContext eventContext,
       String defaultMaxSize) {
     // Condense existing attachments to get a flat list for matching
-    List<Attachments> condensedExistingAttachments =
-        ApplicationHandlerHelper.condenseAttachments(existingAttachments, entity);
+    List<Attachments> condensedExistingAttachments = ApplicationHandlerHelper.condenseAttachments(existingAttachments,
+        entity);
 
-    Converter converter =
-        (path, element, value) ->
-            handleAttachmentForEntity(
-                condensedExistingAttachments,
-                eventFactory,
-                eventContext,
-                path,
-                (InputStream) value,
-                defaultMaxSize);
+    Converter converter = (path, element, value) -> handleAttachmentForEntity(
+        condensedExistingAttachments,
+        eventFactory,
+        eventContext,
+        path,
+        (InputStream) value,
+        defaultMaxSize);
 
     CdsDataProcessor.create()
         .addConverter(ApplicationHandlerHelper.MEDIA_CONTENT_FILTER, converter)
@@ -74,12 +75,15 @@ public final class ModifyApplicationHandlerHelper {
   /**
    * Handles attachments for a single entity.
    *
-   * @param existingAttachments the list of existing {@link Attachments} to check against
-   * @param eventFactory the {@link ModifyAttachmentEventFactory} to create the corresponding event
-   * @param eventContext the current {@link EventContext}
-   * @param path the {@link Path} of the attachment
-   * @param content the content of the attachment
-   * @param defaultMaxSize the default max size to use when no annotation is present
+   * @param existingAttachments the list of existing {@link Attachments} to check
+   *                            against
+   * @param eventFactory        the {@link ModifyAttachmentEventFactory} to create
+   *                            the corresponding event
+   * @param eventContext        the current {@link EventContext}
+   * @param path                the {@link Path} of the attachment
+   * @param content             the content of the attachment
+   * @param defaultMaxSize      the default max size to use when no annotation is
+   *                            present
    * @return the processed content as an {@link InputStream}
    */
   public static InputStream handleAttachmentForEntity(
@@ -98,9 +102,8 @@ public final class ModifyApplicationHandlerHelper {
     eventContext.put(
         "attachment.MaxSize",
         maxSizeStr); // make max size available in context for error handling later
-    ServiceException TOO_LARGE_EXCEPTION =
-        new ServiceException(
-            ExtendedErrorStatuses.CONTENT_TOO_LARGE, "AttachmentSizeExceeded", maxSizeStr);
+    ServiceException TOO_LARGE_EXCEPTION = new ServiceException(
+        ExtendedErrorStatuses.CONTENT_TOO_LARGE, "AttachmentSizeExceeded", maxSizeStr);
 
     if (contentLength != null) {
       try {
@@ -111,10 +114,9 @@ public final class ModifyApplicationHandlerHelper {
         throw new ServiceException(ErrorStatuses.BAD_REQUEST, "Invalid Content-Length header");
       }
     }
-    CountingInputStream wrappedContent =
-        content != null ? new CountingInputStream(content, maxSizeStr) : null;
-    ModifyAttachmentEvent eventToProcess =
-        eventFactory.getEvent(wrappedContent, contentId, attachment);
+    CountingInputStream wrappedContent = content != null ? new CountingInputStream(content, maxSizeStr) : null;
+
+    ModifyAttachmentEvent eventToProcess = eventFactory.getEvent(wrappedContent, contentId, attachment);
     try {
       return eventToProcess.processEvent(path, wrappedContent, attachment, eventContext);
     } catch (Exception e) {

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/ApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/ApplicationHandlerHelper.java
@@ -5,43 +5,60 @@ package com.sap.cds.feature.attachments.handler.common;
 
 import static java.util.Objects.nonNull;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.cds.CdsData;
 import com.sap.cds.CdsDataProcessor;
 import com.sap.cds.CdsDataProcessor.Filter;
 import com.sap.cds.CdsDataProcessor.Validator;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.applicationservice.helper.AttachmentValidationHelper;
+import com.sap.cds.reflect.CdsAnnotation;
+import com.sap.cds.reflect.CdsElement;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.reflect.CdsStructuredType;
+import com.sap.cds.services.ErrorStatuses;
+import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.draft.Drafts;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * The class {@link ApplicationHandlerHelper} provides helper methods for the attachment application
+ * The class {@link ApplicationHandlerHelper} provides helper methods for the
+ * attachment application
  * handlers.
  */
 public final class ApplicationHandlerHelper {
   private static final String ANNOTATION_IS_MEDIA_DATA = "_is_media_data";
   private static final String ANNOTATION_CORE_MEDIA_TYPE = "Core.MediaType";
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   /**
-   * A filter for media content fields. The filter checks if the entity is a media entity and if the
+   * Filter to support extraction of file name for attachment validation
+   */
+  public static final Filter FILE_NAME_FILTER = (path, element, type) -> element.getName().contentEquals("fileName");
+
+  /**
+   * A filter for media content fields. The filter checks if the entity is a media
+   * entity and if the
    * element has the annotation "Core.MediaType".
    */
-  public static final Filter MEDIA_CONTENT_FILTER =
-      (path, element, type) ->
-          isMediaEntity(path.target().type())
-              && element.findAnnotation(ANNOTATION_CORE_MEDIA_TYPE).isPresent();
+  public static final Filter MEDIA_CONTENT_FILTER = (path, element, type) -> isMediaEntity(path.target().type())
+      && element.findAnnotation(ANNOTATION_CORE_MEDIA_TYPE).isPresent();
 
   /**
    * Checks if the data contains a content field.
    *
-   * @param entity The {@link CdsEntity entity} type of the given the data to check
-   * @param data The data to check
-   * @return <code>true</code> if the data contains a content field, <code>false</code> otherwise
+   * @param entity The {@link CdsEntity entity} type of the given the data to
+   *               check
+   * @param data   The data to check
+   * @return <code>true</code> if the data contains a content field,
+   *         <code>false</code> otherwise
    */
   public static boolean containsContentField(CdsEntity entity, List<? extends CdsData> data) {
     AtomicBoolean isIncluded = new AtomicBoolean();
@@ -52,11 +69,13 @@ public final class ApplicationHandlerHelper {
   }
 
   /**
-   * Checks if the entity is a media entity. A media entity is an entity that is annotated with the
+   * Checks if the entity is a media entity. A media entity is an entity that is
+   * annotated with the
    * annotation "_is_media_data".
    *
    * @param baseEntity The entity to check
-   * @return <code>true</code> if the entity is a media entity, <code>false</code> otherwise
+   * @return <code>true</code> if the entity is a media entity, <code>false</code>
+   *         otherwise
    */
   public static boolean isMediaEntity(CdsStructuredType baseEntity) {
     return baseEntity.getAnnotationValue(ANNOTATION_IS_MEDIA_DATA, false);
@@ -65,7 +84,7 @@ public final class ApplicationHandlerHelper {
   /**
    * Extracts key fields from CdsData based on the entity definition.
    *
-   * @param data The CdsData to extract keys from
+   * @param data   The CdsData to extract keys from
    * @param entity The entity definition
    * @return A map of key fields and their values
    */
@@ -85,9 +104,10 @@ public final class ApplicationHandlerHelper {
   }
 
   /**
-   * Condenses the attachments from the given data into a list of {@link Attachments attachments}.
+   * Condenses the attachments from the given data into a list of
+   * {@link Attachments attachments}.
    *
-   * @param data the list of {@link CdsData} to process
+   * @param data   the list of {@link CdsData} to process
    * @param entity the {@link CdsEntity entity} type of the given data
    * @return a list of {@link Attachments attachments} condensed from the data
    */
@@ -95,8 +115,7 @@ public final class ApplicationHandlerHelper {
       List<? extends CdsData> data, CdsEntity entity) {
     List<Attachments> resultList = new ArrayList<>();
 
-    Validator validator =
-        (path, element, value) -> resultList.add(Attachments.of(path.target().values()));
+    Validator validator = (path, element, value) -> resultList.add(Attachments.of(path.target().values()));
 
     CdsDataProcessor.create().addValidator(MEDIA_CONTENT_FILTER, validator).process(data, entity);
     return resultList;
@@ -121,6 +140,41 @@ public final class ApplicationHandlerHelper {
     Map<String, Object> keyMap = new HashMap<>(keys);
     keyMap.entrySet().removeIf(entry -> entry.getKey().equals(Drafts.IS_ACTIVE_ENTITY));
     return keyMap;
+  }
+
+  public static void validateAcceptableMediaTypes(CdsEntity entity, List<CdsData> data) {
+    List<String> allowedTypes = getEntityAcceptableMediaTypes(entity);
+    String fileName = extractFileName(entity, data);
+    AttachmentValidationHelper.validateMediaTypeForAttachment(fileName, allowedTypes);
+  }
+
+  private static List<String> getEntityAcceptableMediaTypes(CdsEntity entity) {
+    Optional<CdsAnnotation<Object>> acceptableMediaTypeFromContent = entity.getElement("content")
+        .findAnnotation("Core.AcceptableMediaTypes");
+
+    return acceptableMediaTypeFromContent
+        .map(a -> objectMapper.convertValue(
+            a.getValue(),
+            new TypeReference<List<String>>() {
+            }))
+        .orElse(List.of("*/*"));
+  }
+
+  private static String extractFileName(CdsEntity entity, List<? extends CdsData> data) {
+    CdsDataProcessor processor = CdsDataProcessor.create();
+    AtomicReference<String> fileNameRef = new AtomicReference<>();
+    Validator validator = (path, element, value) -> {
+      if (element.getName().contentEquals("fileName") && value instanceof String) {
+        fileNameRef.set((String) value);
+      }
+    };
+
+    processor.addValidator(FILE_NAME_FILTER, validator).process(data, entity);
+
+    if (fileNameRef.get() == null) {
+      throw new ServiceException(ErrorStatuses.BAD_REQUEST, "Sam's custom test text: Filename is missing");
+    }
+    return fileNameRef.get();
   }
 
   private ApplicationHandlerHelper() {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
@@ -120,6 +120,7 @@ class CreateAttachmentsHandlerTest {
     try (var testStream = new ByteArrayInputStream("testString".getBytes(StandardCharsets.UTF_8))) {
       var attachment = Attachments.create();
       attachment.setContent(testStream);
+      attachment.setFileName("test.pdf");
       when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 
       cut.processBefore(createContext, List.of(attachment));
@@ -234,6 +235,7 @@ class CreateAttachmentsHandlerTest {
     var attachment = Attachments.create();
     var content = mock(InputStream.class);
     attachment.setContent(content);
+    attachment.setFileName("test.pdf");
     items.setAttachments(List.of(attachment));
     events.setItems(List.of(items));
     when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
@@ -260,7 +262,7 @@ class CreateAttachmentsHandlerTest {
     var attachment = Attachments.create();
     attachment.setContent(testStream);
     attachment.put("DRAFT_READONLY_CONTEXT", readonlyFields);
-
+    attachment.setFileName("test.pdf");
     when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 
     cut.processBefore(createContext, List.of(attachment));
@@ -310,8 +312,7 @@ class CreateAttachmentsHandlerTest {
 
   @Test
   void methodHasCorrectAnnotations() throws NoSuchMethodException {
-    var method =
-        cut.getClass().getDeclaredMethod("processBefore", CdsCreateEventContext.class, List.class);
+    var method = cut.getClass().getDeclaredMethod("processBefore", CdsCreateEventContext.class, List.class);
 
     var createBeforeAnnotation = method.getAnnotation(Before.class);
     var createHandlerOrderAnnotation = method.getAnnotation(HandlerOrder.class);

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/AttachmentValidationHelperTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/AttachmentValidationHelperTest.java
@@ -1,0 +1,148 @@
+/*
+* © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+*/
+package com.sap.cds.feature.attachments.handler.applicationservice.helper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.sap.cds.services.ErrorStatuses;
+import com.sap.cds.services.ServiceException;
+
+class AttachmentValidationHelperTest {
+
+    // ---------- constructor ----------
+
+    @Test
+    void constructorShouldBeCallableForCoverage() {
+        new AttachmentValidationHelper();
+    }
+
+    // ---------- validateMimeTypeForAttachment ----------
+    @Test
+    void shouldAcceptMimeTypeFromURLConnection() {
+        String result = AttachmentValidationHelper.validateMediaTypeForAttachment(
+                "document.pdf",
+                List.of("application/pdf"));
+        assertEquals("application/pdf", result);
+    }
+
+    @Test
+    void shouldUseExtensionMapWhenURLConnectionDoesNotDetectMimeType() {
+        String result = AttachmentValidationHelper.validateMediaTypeForAttachment(
+                "image.webp",
+                List.of("image/webp"));
+        assertEquals("image/webp", result);
+    }
+
+    @Test
+    void shouldSupportWildCardTypes() {
+        String result = AttachmentValidationHelper.validateMediaTypeForAttachment(
+                "image.jpeg",
+                List.of("image/*"));
+        assertEquals("image/jpeg", result);
+    }
+
+    @Test
+    void shouldAllowAllMimeTypesWithStarSlashStar() {
+        String result = AttachmentValidationHelper.validateMediaTypeForAttachment(
+                "anyfile.jpeg",
+                List.of("*/*"));
+        assertEquals("image/jpeg", result);
+    }
+
+    @Test
+    void shouldAllowRandomInvalidExtensionWithStarSlashStar() {
+        String result = AttachmentValidationHelper.validateMediaTypeForAttachment(
+                "anyfile.anyext",
+                List.of("*/*"));
+        assertEquals(AttachmentValidationHelper.DEFAULT_MEDIA_TYPE, result);
+    }
+
+    @Test
+    void shouldAllowRandomInvalidExtensionWithNullAcceptableMediaTypes() {
+        String result = AttachmentValidationHelper.validateMediaTypeForAttachment(
+                "anyfile.anyext",
+                null);
+        assertEquals(AttachmentValidationHelper.DEFAULT_MEDIA_TYPE, result);
+    }
+
+    @Test
+    void shouldNotAllowRandomInvalidExtensionWithStarSlashStar() {
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> AttachmentValidationHelper.validateMediaTypeForAttachment(
+                        "anyfile.anyext",
+                        List.of("application/pdf")));
+
+        assertTrue(ex.getErrorStatus().equals(ErrorStatuses.UNSUPPORTED_MEDIA_TYPE));
+    }
+
+    @Test
+    void shouldAllowAllMimeTypesIfNoRestrictionsGiven() {
+        String result = AttachmentValidationHelper.validateMediaTypeForAttachment(
+                "anyfile.anyext",
+                List.of());
+        assertEquals(AttachmentValidationHelper.DEFAULT_MEDIA_TYPE, result);
+    }
+
+    @Test
+    void shouldUseDefaultMimeTypeWhenExtensionIsUnknown() {
+        String result = AttachmentValidationHelper.validateMediaTypeForAttachment(
+                "file.unknownext",
+                List.of(AttachmentValidationHelper.DEFAULT_MEDIA_TYPE));
+        assertEquals(AttachmentValidationHelper.DEFAULT_MEDIA_TYPE, result);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenInvalidFileName() {
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> AttachmentValidationHelper.validateMediaTypeForAttachment(
+                        "invalidfilename",
+                        List.of("application/pdf")));
+
+        assertTrue(ex.getErrorStatus().equals(ErrorStatuses.UNSUPPORTED_MEDIA_TYPE));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenFilenameEndsWithDot() {
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> AttachmentValidationHelper.validateMediaTypeForAttachment(
+                        "file.",
+                        List.of("application/pdf")));
+
+        assertEquals(ErrorStatuses.UNSUPPORTED_MEDIA_TYPE, ex.getErrorStatus());
+    }
+
+    @Test
+    void shouldHandleUppercaseExtension() {
+        String result = AttachmentValidationHelper.validateMediaTypeForAttachment(
+                "photo.JPG",
+                List.of("image/jpeg"));
+
+        assertEquals("image/jpeg", result);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenMimeTypeNotAllowed() {
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> AttachmentValidationHelper.validateMediaTypeForAttachment(
+                        "document.pdf",
+                        List.of("image/png")));
+
+        assertTrue(ex.getMessage().contains("not allowed"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenDefaultMimeTypeNotAllowed() {
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> AttachmentValidationHelper.validateMediaTypeForAttachment(
+                        "file.unknownext",
+                        List.of("application/pdf")));
+
+        assertTrue(ex.getMessage().contains("not allowed"));
+    }
+
+}

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelperTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelperTest.java
@@ -33,185 +33,178 @@ import org.junit.jupiter.api.Test;
 
 class ModifyApplicationHandlerHelperTest {
 
-  private static CdsRuntime runtime;
-  private ModifyAttachmentEventFactory eventFactory;
-  private EventContext eventContext;
-  private ParameterInfo parameterInfo;
-  private Path path;
-  private ResolvedSegment target;
-  private ModifyAttachmentEvent event;
+    private static CdsRuntime runtime;
+    private ModifyAttachmentEventFactory eventFactory;
+    private EventContext eventContext;
+    private ParameterInfo parameterInfo;
+    private Path path;
+    private ResolvedSegment target;
+    private ModifyAttachmentEvent event;
 
-  @BeforeAll
-  static void classSetup() {
-    runtime = RuntimeHelper.runtime;
-  }
+    @BeforeAll
+    static void classSetup() {
+        runtime = RuntimeHelper.runtime;
+    }
 
-  @BeforeEach
-  void setup() {
-    eventFactory = mock(ModifyAttachmentEventFactory.class);
-    eventContext = mock(EventContext.class);
-    parameterInfo = mock(ParameterInfo.class);
-    path = mock(Path.class);
-    target = mock(ResolvedSegment.class);
-    event = mock(ModifyAttachmentEvent.class);
-    when(eventContext.getParameterInfo()).thenReturn(parameterInfo);
-    when(path.target()).thenReturn(target);
-    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
-  }
+    @BeforeEach
+    void setup() {
+        eventFactory = mock(ModifyAttachmentEventFactory.class);
+        eventContext = mock(EventContext.class);
+        parameterInfo = mock(ParameterInfo.class);
+        path = mock(Path.class);
+        target = mock(ResolvedSegment.class);
+        event = mock(ModifyAttachmentEvent.class);
+        when(eventContext.getParameterInfo()).thenReturn(parameterInfo);
+        when(path.target()).thenReturn(target);
+        when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
+    }
 
-  @Test
-  void serviceExceptionDueToContentLength() {
-    // Arrange: Get EventItems entity which has @Validation.Maximum: '10KB' on
-    // sizeLimitedAttachments.content
-    String attachmentEntityName = "unit.test.TestService.EventItems.sizeLimitedAttachments";
-    CdsEntity entity = runtime.getCdsModel().findEntity(attachmentEntityName).orElseThrow();
+    @Test
+    void serviceExceptionDueToContentLength() {
+        // Arrange: Get EventItems entity which has @Validation.Maximum: '10KB' on
+        // sizeLimitedAttachments.content
+        String attachmentEntityName = "unit.test.TestService.EventItems.sizeLimitedAttachments";
+        CdsEntity entity = runtime.getCdsModel().findEntity(attachmentEntityName).orElseThrow();
 
-    // Create attachment data
-    var attachment = Attachments.create();
-    attachment.setId(UUID.randomUUID().toString());
-    attachment.setContent(mock(InputStream.class));
+        // Create attachment data
+        var attachment = Attachments.create();
+        attachment.setId(UUID.randomUUID().toString());
+        attachment.setContent(mock(InputStream.class));
 
-    // Setup path mock to return EventItems entity and attachment values
-    when(target.entity()).thenReturn(entity);
-    when(target.values()).thenReturn(attachment);
-    when(target.keys()).thenReturn(Map.of(Attachments.ID, attachment.getId()));
+        // Setup path mock to return EventItems entity and attachment values
+        when(target.entity()).thenReturn(entity);
+        when(target.values()).thenReturn(attachment);
+        when(target.keys()).thenReturn(Map.of(Attachments.ID, attachment.getId()));
 
-    // Set Content-Length header to exceed 10KB (10240 bytes)
-    when(parameterInfo.getHeader("Content-Length")).thenReturn("20000");
+        // Set Content-Length header to exceed 10KB (10240 bytes)
+        when(parameterInfo.getHeader("Content-Length")).thenReturn("20000");
 
-    var existingAttachments = List.of(attachment);
+        var existingAttachments = List.of(attachment);
 
-    // Act & Assert
-    var exception =
-        assertThrows(
-            ServiceException.class,
-            () ->
-                ModifyApplicationHandlerHelper.handleAttachmentForEntity(
-                    existingAttachments,
-                    eventFactory,
-                    eventContext,
-                    path,
-                    attachment.getContent(),
-                    ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER));
+        // Act & Assert
+        var exception = assertThrows(
+                ServiceException.class,
+                () -> ModifyApplicationHandlerHelper.handleAttachmentForEntity(
+                        existingAttachments,
+                        eventFactory,
+                        eventContext,
+                        path,
+                        attachment.getContent(),
+                        ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER));
 
-    assertThat(exception.getErrorStatus()).isEqualTo(ExtendedErrorStatuses.CONTENT_TOO_LARGE);
-  }
+        assertThat(exception.getErrorStatus()).isEqualTo(ExtendedErrorStatuses.CONTENT_TOO_LARGE);
+    }
 
-  @Test
-  void serviceExceptionDueToLimitExceeded() {
-    // Arrange: Use the attachment entity with @Validation.Maximum: '10KB'
-    String attachmentEntityName = "unit.test.TestService.EventItems.sizeLimitedAttachments";
-    CdsEntity entity = runtime.getCdsModel().findEntity(attachmentEntityName).orElseThrow();
+    @Test
+    void serviceExceptionDueToLimitExceeded() {
+        // Arrange: Use the attachment entity with @Validation.Maximum: '10KB'
+        String attachmentEntityName = "unit.test.TestService.EventItems.sizeLimitedAttachments";
+        CdsEntity entity = runtime.getCdsModel().findEntity(attachmentEntityName).orElseThrow();
 
-    var attachment = Attachments.create();
-    attachment.setId(UUID.randomUUID().toString());
+        var attachment = Attachments.create();
+        attachment.setId(UUID.randomUUID().toString());
 
-    // Content that exceeds 10KB (10240 bytes) when read
-    byte[] largeContent = new byte[15000]; // 15KB
-    var content = new ByteArrayInputStream(largeContent);
-    attachment.setContent(content);
+        // Content that exceeds 10KB (10240 bytes) when read
+        byte[] largeContent = new byte[15000]; // 15KB
+        var content = new ByteArrayInputStream(largeContent);
+        attachment.setContent(content);
 
-    when(target.entity()).thenReturn(entity);
-    when(target.values()).thenReturn(attachment);
-    when(target.keys()).thenReturn(Map.of(Attachments.ID, attachment.getId()));
+        when(target.entity()).thenReturn(entity);
+        when(target.values()).thenReturn(attachment);
+        when(target.keys()).thenReturn(Map.of(Attachments.ID, attachment.getId()));
 
-    // NO Content-Length header - limit will be checked during streaming
-    when(parameterInfo.getHeader("Content-Length")).thenReturn(null);
+        // NO Content-Length header - limit will be checked during streaming
+        when(parameterInfo.getHeader("Content-Length")).thenReturn(null);
 
-    // Make event.processEvent() read from the stream, triggering the limit check
-    when(event.processEvent(any(), any(), any(), any()))
-        .thenAnswer(
-            invocation -> {
-              InputStream wrappedContent = invocation.getArgument(1);
-              if (wrappedContent != null) {
-                // Read all bytes - this will trigger CountingInputStream to throw
-                byte[] buffer = new byte[1024];
-                while (wrappedContent.read(buffer) != -1) {
-                  // Keep reading until exception or EOF
-                }
-              }
-              return null;
-            });
+        // Make event.processEvent() read from the stream, triggering the limit check
+        when(event.processEvent(any(), any(), any(), any()))
+                .thenAnswer(
+                        invocation -> {
+                            InputStream wrappedContent = invocation.getArgument(1);
+                            if (wrappedContent != null) {
+                                // Read all bytes - this will trigger CountingInputStream to throw
+                                byte[] buffer = new byte[1024];
+                                while (wrappedContent.read(buffer) != -1) {
+                                    // Keep reading until exception or EOF
+                                }
+                            }
+                            return null;
+                        });
 
-    var existingAttachments = List.of(attachment);
+        var existingAttachments = List.of(attachment);
 
-    // Act & Assert
-    var exception =
-        assertThrows(
-            ServiceException.class,
-            () ->
-                ModifyApplicationHandlerHelper.handleAttachmentForEntity(
-                    existingAttachments,
-                    eventFactory,
-                    eventContext,
-                    path,
-                    content,
-                    ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER));
+        // Act & Assert
+        var exception = assertThrows(
+                ServiceException.class,
+                () -> ModifyApplicationHandlerHelper.handleAttachmentForEntity(
+                        existingAttachments,
+                        eventFactory,
+                        eventContext,
+                        path,
+                        content,
+                        ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER));
 
-    assertThat(exception.getErrorStatus()).isEqualTo(ExtendedErrorStatuses.CONTENT_TOO_LARGE);
-  }
+        assertThat(exception.getErrorStatus()).isEqualTo(ExtendedErrorStatuses.CONTENT_TOO_LARGE);
+    }
 
-  @Test
-  void defaultValMaxValueUsed() {
-    String attachmentEntityName = "unit.test.TestService.EventItems.defaultSizeLimitedAttachments";
-    CdsEntity entity = runtime.getCdsModel().findEntity(attachmentEntityName).orElseThrow();
+    @Test
+    void defaultValMaxValueUsed() {
+        String attachmentEntityName = "unit.test.TestService.EventItems.defaultSizeLimitedAttachments";
+        CdsEntity entity = runtime.getCdsModel().findEntity(attachmentEntityName).orElseThrow();
 
-    var attachment = Attachments.create();
-    attachment.setId(UUID.randomUUID().toString());
-    var content = mock(InputStream.class);
-    attachment.setContent(content);
+        var attachment = Attachments.create();
+        attachment.setId(UUID.randomUUID().toString());
+        var content = mock(InputStream.class);
+        attachment.setContent(content);
 
-    when(target.entity()).thenReturn(entity);
-    when(target.values()).thenReturn(attachment);
-    when(target.keys()).thenReturn(Map.of(Attachments.ID, attachment.getId()));
+        when(target.entity()).thenReturn(entity);
+        when(target.values()).thenReturn(attachment);
+        when(target.keys()).thenReturn(Map.of(Attachments.ID, attachment.getId()));
 
-    when(parameterInfo.getHeader("Content-Length")).thenReturn("399000000"); // 399MB
+        when(parameterInfo.getHeader("Content-Length")).thenReturn("399000000"); // 399MB
 
-    var existingAttachments = List.<Attachments>of();
+        var existingAttachments = List.<Attachments>of();
 
-    // Act & Assert: No exception should be thrown as default is 400MB
-    assertDoesNotThrow(
-        () ->
-            ModifyApplicationHandlerHelper.handleAttachmentForEntity(
-                existingAttachments,
-                eventFactory,
-                eventContext,
-                path,
-                content,
-                ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER));
-  }
+        // Act & Assert: No exception should be thrown as default is 400MB
+        assertDoesNotThrow(
+                () -> ModifyApplicationHandlerHelper.handleAttachmentForEntity(
+                        existingAttachments,
+                        eventFactory,
+                        eventContext,
+                        path,
+                        content,
+                        ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER));
+    }
 
-  @Test
-  void malformedContentLengthHeader() {
-    String attachmentEntityName = "unit.test.TestService.EventItems.sizeLimitedAttachments";
-    CdsEntity entity = runtime.getCdsModel().findEntity(attachmentEntityName).orElseThrow();
+    @Test
+    void malformedContentLengthHeader() {
+        String attachmentEntityName = "unit.test.TestService.EventItems.sizeLimitedAttachments";
+        CdsEntity entity = runtime.getCdsModel().findEntity(attachmentEntityName).orElseThrow();
 
-    var attachment = Attachments.create();
-    attachment.setId(UUID.randomUUID().toString());
-    var content = mock(InputStream.class);
-    attachment.setContent(content);
+        var attachment = Attachments.create();
+        attachment.setId(UUID.randomUUID().toString());
+        var content = mock(InputStream.class);
+        attachment.setContent(content);
 
-    when(target.entity()).thenReturn(entity);
-    when(target.values()).thenReturn(attachment);
-    when(target.keys()).thenReturn(Map.of(Attachments.ID, attachment.getId()));
+        when(target.entity()).thenReturn(entity);
+        when(target.values()).thenReturn(attachment);
+        when(target.keys()).thenReturn(Map.of(Attachments.ID, attachment.getId()));
 
-    when(parameterInfo.getHeader("Content-Length")).thenReturn("invalid-number");
+        when(parameterInfo.getHeader("Content-Length")).thenReturn("invalid-number");
 
-    var existingAttachments = List.<Attachments>of();
+        var existingAttachments = List.<Attachments>of();
 
-    // Act & Assert
-    var exception =
-        assertThrows(
-            ServiceException.class,
-            () ->
-                ModifyApplicationHandlerHelper.handleAttachmentForEntity(
-                    existingAttachments,
-                    eventFactory,
-                    eventContext,
-                    path,
-                    content,
-                    ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER));
+        // Act & Assert
+        var exception = assertThrows(
+                ServiceException.class,
+                () -> ModifyApplicationHandlerHelper.handleAttachmentForEntity(
+                        existingAttachments,
+                        eventFactory,
+                        eventContext,
+                        path,
+                        content,
+                        ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER));
 
-    assertThat(exception.getErrorStatus()).isEqualTo(ErrorStatuses.BAD_REQUEST);
-  }
+        assertThat(exception.getErrorStatus()).isEqualTo(ErrorStatuses.BAD_REQUEST);
+    }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandlerTest.java
@@ -75,7 +75,9 @@ class DraftPatchAttachmentsHandlerTest {
   @Test
   void draftEntityReadAndUsed() {
     getEntityAndMockContext(RootTable_.CDS_NAME);
-    var root = buildRooWithAttachment(Attachments.create());
+    Attachments attachment = Attachments.create();
+    var root = buildRooWithAttachment(attachment);
+    attachment.setFileName("test.pdf");
     when(persistence.run(any(CqnSelect.class))).thenReturn(mock(Result.class));
 
     cut.processBeforeDraftPatch(eventContext, List.of(Attachments.of(root)));
@@ -93,6 +95,7 @@ class DraftPatchAttachmentsHandlerTest {
     getEntityAndMockContext(draftAttachmentName);
     var attachment = Attachments.create();
     attachment.setContent(mock(InputStream.class));
+    attachment.setFileName("test.pdf");
     when(persistence.run(any(CqnSelect.class))).thenReturn(mock(Result.class));
 
     cut.processBeforeDraftPatch(eventContext, List.of(attachment));
@@ -109,6 +112,7 @@ class DraftPatchAttachmentsHandlerTest {
     var root = buildRooWithAttachment(attachment);
     var content = attachment.getContent();
     var result = mock(Result.class);
+    attachment.setFileName("test.pdf");
     when(persistence.run(any(CqnSelect.class))).thenReturn(result);
     when(result.listOf(Attachments.class)).thenReturn(List.of(attachment));
 
@@ -128,6 +132,7 @@ class DraftPatchAttachmentsHandlerTest {
     var attachment = Attachments.create();
     var root = buildRooWithAttachment(attachment);
     attachment.setContentId(UUID.randomUUID().toString());
+    attachment.setFileName("test.pdf");
     var content = attachment.getContent();
     var result = mock(Result.class);
     when(persistence.run(any(CqnSelect.class))).thenReturn(result);
@@ -165,9 +170,8 @@ class DraftPatchAttachmentsHandlerTest {
 
   @Test
   void methodHasCorrectAnnotations() throws NoSuchMethodException {
-    var method =
-        cut.getClass()
-            .getDeclaredMethod("processBeforeDraftPatch", DraftPatchEventContext.class, List.class);
+    var method = cut.getClass()
+        .getDeclaredMethod("processBeforeDraftPatch", DraftPatchEventContext.class, List.class);
     var beforeAnnotation = method.getAnnotation(Before.class);
     var handlerOrderAnnotation = method.getAnnotation(HandlerOrder.class);
 

--- a/integration-tests/db/data-model.cds
+++ b/integration-tests/db/data-model.cds
@@ -1,19 +1,20 @@
 namespace test.data.model;
 
 using {cuid} from '@sap/cds/common';
-using {sap.attachments.Attachments} from `com.sap.cds/cds-feature-attachments`;
+using {sap.attachments.Attachments} from`com.sap.cds/cds-feature-attachments`;
 
 entity AttachmentEntity : Attachments {
     parentKey : UUID;
 }
 
 entity Roots : cuid {
-    title       : String;
-    attachments : Composition of many AttachmentEntity
-                      on attachments.parentKey = $self.ID;
-    items       : Composition of many Items
-                      on items.parentID = $self.ID;
-    sizeLimitedAttachments : Composition of many Attachments;
+    title                     : String;
+    attachments               : Composition of many AttachmentEntity
+                                    on attachments.parentKey = $self.ID;
+    items                     : Composition of many Items
+                                    on items.parentID = $self.ID;
+    sizeLimitedAttachments    : Composition of many Attachments;
+    mediaValidatedAttachments : Composition of many Attachments; // for media type validation test
 }
 
 entity Items : cuid {

--- a/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/AcceptedMediaTypesAttachmentsValidationDraftTest.java
+++ b/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/AcceptedMediaTypesAttachmentsValidationDraftTest.java
@@ -1,0 +1,176 @@
+/*
+* © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+*/
+package com.sap.cds.feature.attachments.integrationtests.draftservice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sap.cds.CdsData;
+import com.sap.cds.Struct;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.testdraftservice.DraftRoots;
+import com.sap.cds.feature.attachments.integrationtests.common.MockHttpRequestHelper;
+import com.sap.cds.feature.attachments.integrationtests.constants.Profiles;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles(Profiles.TEST_HANDLER_DISABLED)
+class AcceptedMediaTypesAttachmentsValidationDraftTest extends DraftOdataRequestValidationBase {
+
+    private static final String BASE_URL = MockHttpRequestHelper.ODATA_BASE_URL + "TestDraftService/";
+    private static final String BASE_ROOT_URL = BASE_URL + "DraftRoots";
+
+    @Test
+    void uploadingAllowedMediaTypeShouldSucceed() throws Exception {
+        DraftRoots draftRoot = createNewDraftWithMediaValidatedAttachment(
+                "Root with mediaValidatedAttachments",
+                "test.jpeg",
+                MediaType.IMAGE_JPEG.toString());
+        Attachments attachment = draftRoot.getMediaValidatedAttachments().get(0);
+
+        String url = buildDraftMediaValidatedAttachmentContentUrl(
+                draftRoot.getId(),
+                attachment.getId());
+
+        requestHelper.setContentType(MediaType.IMAGE_JPEG);
+
+        requestHelper.executePutWithMatcher(
+                url,
+                "fake-jpeg-content".getBytes(StandardCharsets.UTF_8),
+                status().isNoContent());
+    }
+
+    @Test
+    void uploadingNotAllowedMediaTypeShouldFail() throws Exception {
+        DraftRoots draftRoot = createNewDraftWithMediaValidatedAttachment(
+                "Root with pdf attachment",
+                "test.pdf",
+                MediaType.APPLICATION_PDF.toString());
+        Attachments attachment = draftRoot.getMediaValidatedAttachments().get(0);
+
+        String url = buildDraftMediaValidatedAttachmentContentUrl(
+                draftRoot.getId(),
+                attachment.getId());
+
+        requestHelper.setContentType(MediaType.APPLICATION_PDF);
+
+        requestHelper.executePutWithMatcher(
+                url,
+                "fake-pdf-content".getBytes(StandardCharsets.UTF_8),
+                status().isUnsupportedMediaType());
+    }
+
+    // helper methods
+    private DraftRoots createNewDraftWithMediaValidatedAttachment(String title, String fileName, String mimeType)
+            throws Exception {
+
+        // Create new draft root
+        CdsData responseRootCdsData = requestHelper.executePostWithODataResponseAndAssertStatusCreated(BASE_ROOT_URL,
+                "{}");
+        DraftRoots draftRoot = Struct.access(responseRootCdsData).as(DraftRoots.class);
+        draftRoot.setTitle(title);
+        String rootUrl = getRootUrl(draftRoot.getId(), false);
+        requestHelper.executePatchWithODataResponseAndAssertStatusOk(rootUrl, draftRoot.toJson());
+
+        // Create attachment
+        Attachments attachment = Attachments.create();
+        attachment.setFileName(fileName);
+        attachment.setMimeType(mimeType);
+
+        String attachmentUrl = rootUrl + "/mediaValidatedAttachments";
+        CdsData responseAttachmentCdsData = requestHelper.executePostWithODataResponseAndAssertStatusCreated(
+                attachmentUrl, attachment.toJson());
+
+        Attachments createdAttachment = Struct.access(responseAttachmentCdsData).as(Attachments.class);
+
+        // Attach to draft root
+        draftRoot.setMediaValidatedAttachments(java.util.List.of(createdAttachment));
+        return draftRoot;
+    }
+
+    private String getRootUrl(String rootId, boolean isActiveEntity) {
+        return BASE_ROOT_URL + "(ID=" + rootId + ",IsActiveEntity=" + isActiveEntity + ")";
+    }
+
+    private String buildDraftMediaValidatedAttachmentContentUrl(String rootId, String attachmentId) {
+        return BASE_ROOT_URL
+                + "(ID="
+                + rootId
+                + ",IsActiveEntity=false)"
+                + "/mediaValidatedAttachments(ID="
+                + attachmentId
+                + ",up__ID="
+                + rootId
+                + ",IsActiveEntity=false)"
+                + "/content";
+    }
+
+    // methods we do not need, but should override
+
+    @Override
+    public void verifyTwoCreateAndRevertedDeleteEvents() {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifyTwoCreateAndDeleteEvents(String param1, String param2) {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifyEventContextEmptyForEvent(String... params) {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void clearServiceHandlerContext() {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifyOnlyTwoCreateEvents(String param1, String param2) {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    protected void verifyContentId(String contentId, String attachmentId) {
+        assertThat(contentId).isEqualTo(attachmentId);
+    }
+
+    @Override
+    protected void verifyContent(InputStream attachment, String testContent) throws IOException {
+        if (Objects.nonNull(testContent)) {
+            assertThat(attachment.readAllBytes())
+                    .isEqualTo(testContent.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        } else {
+            assertThat(attachment).isNull();
+        }
+    }
+
+    @Override
+    public void verifyTwoReadEvents() {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifyOnlyTwoDeleteEvents(String param1, String param2) {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifyNoAttachmentEventsCalled() {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifyTwoUpdateEvents(String param1, String param2, String param3, String param4) {
+        // No service handler is present, so no actions are required.
+    }
+}

--- a/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/DraftOdataRequestValidationBase.java
+++ b/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/DraftOdataRequestValidationBase.java
@@ -42,18 +42,21 @@ import org.springframework.test.web.servlet.ResultMatcher;
 @AutoConfigureMockMvc
 abstract class DraftOdataRequestValidationBase {
 
-  protected static final Logger logger =
-      LoggerFactory.getLogger(DraftOdataRequestValidationBase.class);
+  protected static final Logger logger = LoggerFactory.getLogger(DraftOdataRequestValidationBase.class);
   private static final String BASE_URL = MockHttpRequestHelper.ODATA_BASE_URL + "TestDraftService/";
   private static final String BASE_ROOT_URL = BASE_URL + "DraftRoots";
 
   @Autowired(required = false)
   protected TestPluginAttachmentsServiceHandler serviceHandler;
 
-  @Autowired protected MockHttpRequestHelper requestHelper;
-  @Autowired protected PersistenceService persistenceService;
-  @Autowired private TableDataDeleter dataDeleter;
-  @Autowired private TestPersistenceHandler testPersistenceHandler;
+  @Autowired
+  protected MockHttpRequestHelper requestHelper;
+  @Autowired
+  protected PersistenceService persistenceService;
+  @Autowired
+  private TableDataDeleter dataDeleter;
+  @Autowired
+  private TestPersistenceHandler testPersistenceHandler;
 
   @AfterEach
   void teardown() {
@@ -107,16 +110,14 @@ abstract class DraftOdataRequestValidationBase {
     clearServiceHandlerContext();
     createNewDraftForExistingRoot(selectedRoot.getId());
 
-    var attachmentUrl =
-        getAttachmentBaseUrl(
-                selectedRoot.getItems().get(0).getId(),
-                selectedRoot.getItems().get(0).getAttachments().get(0).getId(),
-                false)
-            + "/content";
-    var attachmentEntityUrl =
-        getAttachmentEntityBaseUrl(
-                selectedRoot.getItems().get(0).getAttachmentEntities().get(0).getId(), false)
-            + "/content";
+    var attachmentUrl = getAttachmentBaseUrl(
+        selectedRoot.getItems().get(0).getId(),
+        selectedRoot.getItems().get(0).getAttachments().get(0).getId(),
+        false)
+        + "/content";
+    var attachmentEntityUrl = getAttachmentEntityBaseUrl(
+        selectedRoot.getItems().get(0).getAttachmentEntities().get(0).getId(), false)
+        + "/content";
 
     Awaitility.await()
         .atMost(60, TimeUnit.SECONDS)
@@ -128,9 +129,8 @@ abstract class DraftOdataRequestValidationBase {
               var attachmentEntityResponse = requestHelper.executeGet(attachmentEntityUrl);
               var attachmentResponseContent = getResponseContent(attachmentResponse);
               var attachmentEntityResponseContent = getResponseContent(attachmentEntityResponse);
-              var result =
-                  attachmentResponseContent.equals(testContentAttachment)
-                      && attachmentEntityResponseContent.equals(testContentAttachmentEntity);
+              var result = attachmentResponseContent.equals(testContentAttachment)
+                  && attachmentEntityResponseContent.equals(testContentAttachmentEntity);
               if (!result) {
                 logger.info(
                     "Attachment response content: {}, Attachment Test Content: {}, Attachment Entity response content: {}, Attachment Entity Test Content: {}",
@@ -154,16 +154,15 @@ abstract class DraftOdataRequestValidationBase {
 
   @Test
   void deleteAttachmentAndActivateDraft() throws Exception {
-    var selectedRoot =
-        deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
+    var selectedRoot = deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
     clearServiceHandlerContext();
     createNewDraftForExistingRoot(selectedRoot.getId());
 
     var itemAttachment = selectedRoot.getItems().get(0).getAttachments().get(0);
     var itemAttachmentEntity = selectedRoot.getItems().get(0).getAttachmentEntities().get(0);
 
-    var attachmentDeleteUrl =
-        getAttachmentBaseUrl(selectedRoot.getItems().get(0).getId(), itemAttachment.getId(), false);
+    var attachmentDeleteUrl = getAttachmentBaseUrl(selectedRoot.getItems().get(0).getId(), itemAttachment.getId(),
+        false);
     var attachmentEntityDeleteUrl = getAttachmentEntityBaseUrl(itemAttachmentEntity.getId(), false);
 
     requestHelper.executeDeleteWithMatcher(attachmentDeleteUrl, status().isNoContent());
@@ -180,8 +179,7 @@ abstract class DraftOdataRequestValidationBase {
 
   @Test
   void updateAttachmentAndActivateDraft() throws Exception {
-    var selectedRoot =
-        deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
+    var selectedRoot = deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
     clearServiceHandlerContext();
     createNewDraftForExistingRoot(selectedRoot.getId());
 
@@ -203,15 +201,14 @@ abstract class DraftOdataRequestValidationBase {
     assertThat(selectedRootAfterUpdate.getItems().get(0).getAttachments().get(0).getFileName())
         .isEqualTo(changedAttachmentFileName);
     assertThat(
-            selectedRootAfterUpdate.getItems().get(0).getAttachmentEntities().get(0).getFileName())
+        selectedRootAfterUpdate.getItems().get(0).getAttachmentEntities().get(0).getFileName())
         .isEqualTo(changedAttachmentEntityFileName);
     verifyNoAttachmentEventsCalled();
   }
 
   @Test
   void updateAttachmentAndCancelDraft() throws Exception {
-    var selectedRoot =
-        deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
+    var selectedRoot = deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
     clearServiceHandlerContext();
     createNewDraftForExistingRoot(selectedRoot.getId());
 
@@ -233,15 +230,14 @@ abstract class DraftOdataRequestValidationBase {
     assertThat(selectedRootAfterUpdate.getItems().get(0).getAttachments().get(0).getFileName())
         .isEqualTo(originAttachmentFileName);
     assertThat(
-            selectedRootAfterUpdate.getItems().get(0).getAttachmentEntities().get(0).getFileName())
+        selectedRootAfterUpdate.getItems().get(0).getAttachmentEntities().get(0).getFileName())
         .isEqualTo(originAttachmentEntityFileName);
     verifyNoAttachmentEventsCalled();
   }
 
   @Test
   void createAttachmentAndActivateDraft() throws Exception {
-    var selectedRoot =
-        deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
+    var selectedRoot = deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
     clearServiceHandlerContext();
     createNewDraftForExistingRoot(selectedRoot.getId());
 
@@ -261,8 +257,7 @@ abstract class DraftOdataRequestValidationBase {
 
   @Test
   void createAttachmentAndCancelDraft() throws Exception {
-    var selectedRoot =
-        deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
+    var selectedRoot = deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
     clearServiceHandlerContext();
     createNewDraftForExistingRoot(selectedRoot.getId());
 
@@ -282,9 +277,8 @@ abstract class DraftOdataRequestValidationBase {
 
   @Test
   void deleteContentInDraft() throws Exception {
-    var selectedRoot =
-        deepCreateAndActivate(
-            "testContent attachment for delete", "testContent attachmentEntity for delete");
+    var selectedRoot = deepCreateAndActivate(
+        "testContent attachment for delete", "testContent attachmentEntity for delete");
     clearServiceHandlerContext();
     createNewDraftForExistingRoot(selectedRoot.getId());
     var itemAttachment = selectedRoot.getItems().get(0).getAttachments().get(0);
@@ -305,8 +299,7 @@ abstract class DraftOdataRequestValidationBase {
 
   @Test
   void doNotDeleteContentInCancelledDraft() throws Exception {
-    var selectedRoot =
-        deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
+    var selectedRoot = deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
     clearServiceHandlerContext();
     createNewDraftForExistingRoot(selectedRoot.getId());
 
@@ -328,8 +321,7 @@ abstract class DraftOdataRequestValidationBase {
 
   @Test
   void updateContentInDraft() throws Exception {
-    var selectedRoot =
-        deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
+    var selectedRoot = deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
     clearServiceHandlerContext();
     createNewDraftForExistingRoot(selectedRoot.getId());
 
@@ -363,12 +355,12 @@ abstract class DraftOdataRequestValidationBase {
     assertThat(selectedRootAfterDeletion.getItems().get(0).getAttachments().get(0).getContentId())
         .isNotEmpty();
     assertThat(
-            selectedRootAfterDeletion
-                .getItems()
-                .get(0)
-                .getAttachmentEntities()
-                .get(0)
-                .getContentId())
+        selectedRootAfterDeletion
+            .getItems()
+            .get(0)
+            .getAttachmentEntities()
+            .get(0)
+            .getContentId())
         .isNotEmpty();
   }
 
@@ -439,7 +431,7 @@ abstract class DraftOdataRequestValidationBase {
         .isNotEmpty();
     assertThat(selectedRootAfterDelete.getItems().get(0).getAttachmentEntities()).isNotEmpty();
     assertThat(
-            selectedRootAfterDelete.getItems().get(0).getAttachmentEntities().get(0).getContentId())
+        selectedRootAfterDelete.getItems().get(0).getAttachmentEntities().get(0).getContentId())
         .isNotEmpty();
     verifyNoAttachmentEventsCalled();
   }
@@ -462,16 +454,14 @@ abstract class DraftOdataRequestValidationBase {
     assertThat(result).isEmpty();
 
     var attachmentContentId = selectedRoot.getItems().get(0).getAttachments().get(0).getContentId();
-    var attachmentEntityContentId =
-        selectedRoot.getItems().get(0).getAttachmentEntities().get(0).getContentId();
+    var attachmentEntityContentId = selectedRoot.getItems().get(0).getAttachmentEntities().get(0).getContentId();
 
     verifyOnlyTwoDeleteEvents(attachmentContentId, attachmentEntityContentId);
   }
 
   @Test
   void errorInTransactionAfterCreateCallsDelete() throws Exception {
-    var selectedRoot =
-        deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
+    var selectedRoot = deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
     clearServiceHandlerContext();
     createNewDraftForExistingRoot(selectedRoot.getId());
 
@@ -486,8 +476,7 @@ abstract class DraftOdataRequestValidationBase {
 
   @Test
   void errorInTransactionAfterCreateCallsDeleteAndNothingForCancel() throws Exception {
-    var selectedRoot =
-        deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
+    var selectedRoot = deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
     clearServiceHandlerContext();
     createNewDraftForExistingRoot(selectedRoot.getId());
 
@@ -538,8 +527,7 @@ abstract class DraftOdataRequestValidationBase {
 
   @Test
   void createAndDeleteAttachmentWorks() throws Exception {
-    var selectedRoot =
-        deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
+    var selectedRoot = deepCreateAndActivate("testContent attachment", "testContent attachmentEntity");
     clearServiceHandlerContext();
     createNewDraftForExistingRoot(selectedRoot.getId());
 
@@ -555,21 +543,18 @@ abstract class DraftOdataRequestValidationBase {
     var existingAttachment = selectedRoot.getItems().get(0).getAttachments().get(0);
     var existingAttachmentEntity = selectedRoot.getItems().get(0).getAttachmentEntities().get(0);
 
-    var newAttachment =
-        draftRoot.getItems().get(0).getAttachments().stream()
-            .filter(attachment -> !attachment.getId().equals(existingAttachment.getId()))
-            .findAny()
-            .orElseThrow();
-    var newAttachmentEntity =
-        draftRoot.getItems().get(0).getAttachmentEntities().stream()
-            .filter(
-                attachmentEntity ->
-                    !attachmentEntity.getId().equals(existingAttachmentEntity.getId()))
-            .findAny()
-            .orElseThrow();
+    var newAttachment = draftRoot.getItems().get(0).getAttachments().stream()
+        .filter(attachment -> !attachment.getId().equals(existingAttachment.getId()))
+        .findAny()
+        .orElseThrow();
+    var newAttachmentEntity = draftRoot.getItems().get(0).getAttachmentEntities().stream()
+        .filter(
+            attachmentEntity -> !attachmentEntity.getId().equals(existingAttachmentEntity.getId()))
+        .findAny()
+        .orElseThrow();
 
-    var attachmentDeleteUrl =
-        getAttachmentBaseUrl(selectedRoot.getItems().get(0).getId(), newAttachment.getId(), false);
+    var attachmentDeleteUrl = getAttachmentBaseUrl(selectedRoot.getItems().get(0).getId(), newAttachment.getId(),
+        false);
     var attachmentEntityDeleteUrl = getAttachmentEntityBaseUrl(newAttachmentEntity.getId(), false);
 
     requestHelper.executeDeleteWithMatcher(attachmentDeleteUrl, status().isNoContent());
@@ -595,8 +580,7 @@ abstract class DraftOdataRequestValidationBase {
   }
 
   private DraftRoots createNewDraft() throws Exception {
-    var responseRootCdsData =
-        requestHelper.executePostWithODataResponseAndAssertStatusCreated(BASE_ROOT_URL, "{}");
+    var responseRootCdsData = requestHelper.executePostWithODataResponseAndAssertStatusCreated(BASE_ROOT_URL, "{}");
     return Struct.access(responseRootCdsData).as(DraftRoots.class);
   }
 
@@ -621,8 +605,7 @@ abstract class DraftOdataRequestValidationBase {
     var item = Items.create();
     item.setTitle("some item");
     var itemUrl = rootUrl + "/items";
-    var responseItemCdsData =
-        requestHelper.executePostWithODataResponseAndAssertStatusCreated(itemUrl, item.toJson());
+    var responseItemCdsData = requestHelper.executePostWithODataResponseAndAssertStatusCreated(itemUrl, item.toJson());
     return Struct.access(responseItemCdsData).as(Items.class);
   }
 
@@ -661,9 +644,8 @@ abstract class DraftOdataRequestValidationBase {
     itemAttachment.setFileName("itemAttachment.txt");
 
     var attachmentPostUrl = BASE_URL + "Items(ID=" + itemId + ",IsActiveEntity=false)/attachments";
-    var responseAttachmentCdsData =
-        requestHelper.executePostWithODataResponseAndAssertStatusCreated(
-            attachmentPostUrl, itemAttachment.toJson());
+    var responseAttachmentCdsData = requestHelper.executePostWithODataResponseAndAssertStatusCreated(
+        attachmentPostUrl, itemAttachment.toJson());
     return Struct.access(responseAttachmentCdsData).as(Attachments.class);
   }
 
@@ -696,8 +678,7 @@ abstract class DraftOdataRequestValidationBase {
   private void putNewContentForAttachmentEntity(
       String testContentAttachmentEntity, String attachmentId, ResultMatcher matcher)
       throws Exception {
-    var attachmentEntityPutUrl =
-        BASE_URL + "/AttachmentEntity(ID=" + attachmentId + ",IsActiveEntity=false)/content";
+    var attachmentEntityPutUrl = BASE_URL + "/AttachmentEntity(ID=" + attachmentId + ",IsActiveEntity=false)/content";
     requestHelper.setContentType("image/jpeg");
     requestHelper.executePutWithMatcher(
         attachmentEntityPutUrl,
@@ -711,9 +692,8 @@ abstract class DraftOdataRequestValidationBase {
     itemAttachmentEntity.setFileName("itemAttachmentEntity.txt");
 
     var attachmentEntityPostUrl = getItemUrl(responseItem, false) + "/attachmentEntities";
-    var responseAttachmentEntityCdsData =
-        requestHelper.executePostWithODataResponseAndAssertStatusCreated(
-            attachmentEntityPostUrl, itemAttachmentEntity.toJson());
+    var responseAttachmentEntityCdsData = requestHelper.executePostWithODataResponseAndAssertStatusCreated(
+        attachmentEntityPostUrl, itemAttachmentEntity.toJson());
     return Struct.access(responseAttachmentEntityCdsData).as(AttachmentEntity.class);
   }
 
@@ -764,33 +744,29 @@ abstract class DraftOdataRequestValidationBase {
   }
 
   private DraftRoots selectStoredRootData(String entityName, DraftRoots responseRoot) {
-    var select =
-        Select.from(entityName)
-            .where(root -> root.get(DraftRoots.ID).eq(responseRoot.getId()))
-            .columns(
-                StructuredType::_all,
-                root ->
-                    root.to(DraftRoots.ITEMS)
-                        .expand(
-                            StructuredType::_all,
-                            item -> item.to(Items.ATTACHMENTS).expand(),
-                            item -> item.to(Items.ATTACHMENT_ENTITIES).expand()));
+    var select = Select.from(entityName)
+        .where(root -> root.get(DraftRoots.ID).eq(responseRoot.getId()))
+        .columns(
+            StructuredType::_all,
+            root -> root.to(DraftRoots.ITEMS)
+                .expand(
+                    StructuredType::_all,
+                    item -> item.to(Items.ATTACHMENTS).expand(),
+                    item -> item.to(Items.ATTACHMENT_ENTITIES).expand()));
     return persistenceService.run(select).single(DraftRoots.class);
   }
 
   protected void readAndValidateActiveContent(
       DraftRoots selectedRoot, String attachmentContent, String attachmentEntityContent)
       throws Exception {
-    var attachmentUrl =
-        getAttachmentBaseUrl(
-                selectedRoot.getItems().get(0).getId(),
-                selectedRoot.getItems().get(0).getAttachments().get(0).getId(),
-                true)
-            + "/content";
-    var attachmentEntityUrl =
-        getAttachmentEntityBaseUrl(
-                selectedRoot.getItems().get(0).getAttachmentEntities().get(0).getId(), true)
-            + "/content";
+    var attachmentUrl = getAttachmentBaseUrl(
+        selectedRoot.getItems().get(0).getId(),
+        selectedRoot.getItems().get(0).getAttachments().get(0).getId(),
+        true)
+        + "/content";
+    var attachmentEntityUrl = getAttachmentEntityBaseUrl(
+        selectedRoot.getItems().get(0).getAttachmentEntities().get(0).getId(), true)
+        + "/content";
 
     Awaitility.await()
         .atMost(60, TimeUnit.SECONDS)
@@ -801,12 +777,10 @@ abstract class DraftOdataRequestValidationBase {
               var attachmentResponse = requestHelper.executeGet(attachmentUrl);
               var attachmentEntityResponse = requestHelper.executeGet(attachmentEntityUrl);
               var attachmentContentAsString = attachmentResponse.getResponse().getContentAsString();
-              var attachmentEntityContentAsString =
-                  attachmentEntityResponse.getResponse().getContentAsString();
+              var attachmentEntityContentAsString = attachmentEntityResponse.getResponse().getContentAsString();
 
-              var booleanResult =
-                  attachmentContentAsString.equals(attachmentContent)
-                      && attachmentEntityContentAsString.equals(attachmentEntityContent);
+              var booleanResult = attachmentContentAsString.equals(attachmentContent)
+                  && attachmentEntityContentAsString.equals(attachmentEntityContent);
 
               if (!booleanResult) {
                 logger.info(
@@ -832,11 +806,9 @@ abstract class DraftOdataRequestValidationBase {
   private void deleteContent(
       DraftRoots selectedRoot, Attachments itemAttachment, AttachmentEntity itemAttachmentEntity)
       throws Exception {
-    var attachmentUrl =
-        getAttachmentBaseUrl(selectedRoot.getItems().get(0).getId(), itemAttachment.getId(), false)
-            + "/content";
-    var attachmentEntityUrl =
-        getAttachmentEntityBaseUrl(itemAttachmentEntity.getId(), false) + "/content";
+    var attachmentUrl = getAttachmentBaseUrl(selectedRoot.getItems().get(0).getId(), itemAttachment.getId(), false)
+        + "/content";
+    var attachmentEntityUrl = getAttachmentEntityBaseUrl(itemAttachmentEntity.getId(), false) + "/content";
 
     requestHelper.executeDeleteWithMatcher(attachmentUrl, status().isNoContent());
     requestHelper.executeDeleteWithMatcher(attachmentEntityUrl, status().isNoContent());
@@ -866,8 +838,7 @@ abstract class DraftOdataRequestValidationBase {
       String changedAttachmentEntityFileName,
       HttpStatus httpStatus)
       throws Exception {
-    var attachmentUrl =
-        getAttachmentBaseUrl(selectedRoot.getItems().get(0).getId(), itemAttachment.getId(), false);
+    var attachmentUrl = getAttachmentBaseUrl(selectedRoot.getItems().get(0).getId(), itemAttachment.getId(), false);
     var attachmentEntityUrl = getAttachmentEntityBaseUrl(itemAttachmentEntity.getId(), false);
 
     requestHelper.executePatchWithODataResponseAndAssertStatus(
@@ -911,12 +882,12 @@ abstract class DraftOdataRequestValidationBase {
     assertThat(selectedRootAfterDeletion.getItems().get(0).getAttachments().get(0).getContentId())
         .isNotEmpty();
     assertThat(
-            selectedRootAfterDeletion
-                .getItems()
-                .get(0)
-                .getAttachmentEntities()
-                .get(0)
-                .getContentId())
+        selectedRootAfterDeletion
+            .getItems()
+            .get(0)
+            .getAttachmentEntities()
+            .get(0)
+            .getContentId())
         .isNotEmpty();
   }
 

--- a/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/AcceptedMediaTypesAttachmentsValidationNonDraftTest.java
+++ b/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/AcceptedMediaTypesAttachmentsValidationNonDraftTest.java
@@ -1,0 +1,188 @@
+/*
+* © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+*/
+package com.sap.cds.feature.attachments.integrationtests.nondraftservice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sap.cds.Result;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.testservice.AttachmentEntity;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.testservice.Roots;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.testservice.Roots_;
+import com.sap.cds.feature.attachments.integrationtests.constants.Profiles;
+import com.sap.cds.feature.attachments.integrationtests.nondraftservice.helper.AttachmentsBuilder;
+import com.sap.cds.feature.attachments.integrationtests.nondraftservice.helper.RootEntityBuilder;
+import com.sap.cds.ql.Select;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MvcResult;
+
+@ActiveProfiles(Profiles.TEST_HANDLER_DISABLED)
+class AcceptedMediaTypesAttachmentsValidationNonDraftTest extends OdataRequestValidationBase {
+
+    @Test
+    void uploadingAllowedMediaTypeShouldSucceed() throws Exception {
+        // Arrange: Create root with mediaValidatedAttachments
+        Roots serviceRoot = buildServiceRootWithMediaValidatedAttachments("test.jpeg", MediaType.IMAGE_JPEG.toString());
+        postServiceRoot(serviceRoot);
+
+        Roots selectedRoot = selectStoredRootWithMediaValidatedAttachments();
+        Attachments attachment = selectedRoot.getMediaValidatedAttachments().get(0);
+
+        // Act & Assert: Upload content with allowed media type
+        String url = buildNavigationMediaValidationAttachmentUrl(selectedRoot.getId(), attachment.getId()) + "/content";
+        requestHelper.setContentType(MediaType.IMAGE_JPEG);
+
+        requestHelper.executePutWithMatcher(
+                url,
+                "fake-jpeg-content".getBytes(StandardCharsets.UTF_8),
+                status().isNoContent());
+    }
+
+    @Test
+    void uploadingNotAllowedMediaTypeShouldFail() throws Exception {
+        Roots serviceRoot = buildServiceRootWithMediaValidatedAttachments("test.pdf",
+                MediaType.APPLICATION_PDF.toString());
+        postServiceRoot(serviceRoot);
+
+        Roots selectedRoot = selectStoredRootWithMediaValidatedAttachments();
+        Attachments attachment = selectedRoot.getMediaValidatedAttachments().get(0);
+
+        // Act & Assert: Upload with disallowed media type fails
+        String url = buildNavigationMediaValidationAttachmentUrl(selectedRoot.getId(), attachment.getId()) + "/content";
+        requestHelper.setContentType(MediaType.APPLICATION_PDF);
+
+        requestHelper.executePutWithMatcher(
+                url,
+                "fake-jpeg-content".getBytes(StandardCharsets.UTF_8),
+                status().isUnsupportedMediaType());
+    }
+
+    // Helper methods
+    private String buildNavigationMediaValidationAttachmentUrl(String rootId, String attachmentId) {
+        return "/odata/v4/TestService/Roots("
+                + rootId
+                + ")/mediaValidatedAttachments(ID="
+                + attachmentId
+                + ",up__ID="
+                + rootId
+                + ")";
+    }
+
+    private Roots buildServiceRootWithMediaValidatedAttachments(String fileName, String mimeType) {
+        return RootEntityBuilder.create()
+                .setTitle("Root with mediaValidatedAttachments")
+                .addMediaValidatedAttachments(
+                        AttachmentsBuilder.create().setFileName(fileName).setMimeType(mimeType))
+                .build();
+    }
+
+    private Roots selectStoredRootWithMediaValidatedAttachments() {
+        Select<Roots_> select = Select.from(
+                Roots_.class)
+                .columns(r -> r._all(), r -> r.mediaValidatedAttachments().expand());
+
+        Result result = persistenceService.run(select);
+        return result.single(Roots.class);
+    }
+
+    // Required abstract method implementations
+    @Override
+    protected void executeContentRequestAndValidateContent(String url, String content)
+            throws Exception {
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .until(
+                        () -> {
+                            MvcResult response = requestHelper.executeGet(url);
+                            return response.getResponse().getContentAsString().equals(content);
+                        });
+
+        MvcResult response = requestHelper.executeGet(url);
+        assertThat(response.getResponse().getContentAsString()).isEqualTo(content);
+    }
+
+    // Required abstract method implementations
+
+    @Override
+    protected void verifyContentId(
+            Attachments attachmentWithExpectedContent, String attachmentId, String contentId) {
+        assertThat(attachmentWithExpectedContent.getContentId()).isEqualTo(attachmentId);
+    }
+
+    @Override
+    protected void verifyContentAndContentId(
+            Attachments attachment, String testContent, Attachments itemAttachment) throws IOException {
+        assertThat(attachment.getContent().readAllBytes())
+                .isEqualTo(testContent.getBytes(StandardCharsets.UTF_8));
+        assertThat(attachment.getContentId()).isEqualTo(itemAttachment.getId());
+    }
+
+    @Override
+    protected void verifyContentAndContentIdForAttachmentEntity(
+            AttachmentEntity attachment, String testContent, AttachmentEntity itemAttachment)
+            throws IOException {
+        assertThat(attachment.getContent().readAllBytes())
+                .isEqualTo(testContent.getBytes(StandardCharsets.UTF_8));
+        assertThat(attachment.getContentId()).isEqualTo(itemAttachment.getId());
+    }
+
+    @Override
+    public void verifySingleCreateAndUpdateEvent(String arg1, String arg2, String arg3) {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void clearServiceHandlerContext() {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifySingleReadEvent(String arg) {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifyTwoDeleteEvents(AttachmentEntity entity, Attachments attachments) {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void clearServiceHandlerDocuments() {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifyEventContextEmptyForEvent(String... args) {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifyNoAttachmentEventsCalled() {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifyNumberOfEvents(String arg, int count) {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifySingleCreateEvent(String arg1, String arg2) {
+        // No service handler is present, so no actions are required.
+    }
+
+    @Override
+    public void verifySingleDeletionEvent(String arg) {
+        // No service handler is present, so no actions are required.
+    }
+
+}

--- a/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/OdataRequestValidationBase.java
+++ b/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/OdataRequestValidationBase.java
@@ -53,10 +53,14 @@ abstract class OdataRequestValidationBase {
   @Autowired(required = false)
   protected TestPluginAttachmentsServiceHandler serviceHandler;
 
-  @Autowired protected MockHttpRequestHelper requestHelper;
-  @Autowired protected PersistenceService persistenceService;
-  @Autowired private TableDataDeleter dataDeleter;
-  @Autowired private TestPersistenceHandler testPersistenceHandler;
+  @Autowired
+  protected MockHttpRequestHelper requestHelper;
+  @Autowired
+  protected PersistenceService persistenceService;
+  @Autowired
+  private TableDataDeleter dataDeleter;
+  @Autowired
+  private TestPersistenceHandler testPersistenceHandler;
 
   @AfterEach
   void teardown() {
@@ -117,9 +121,8 @@ abstract class OdataRequestValidationBase {
     var item = getItemWithAttachment(selectedRoot);
 
     var url = buildExpandAttachmentUrl(selectedRoot.getId(), item.getId());
-    var responseItem =
-        requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
-            url, Items.class, HttpStatus.OK);
+    var responseItem = requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
+        url, Items.class, HttpStatus.OK);
 
     assertThat(responseItem.getAttachments()).hasSameSizeAs(item.getAttachments());
     assertThat(responseItem.getAttachments())
@@ -143,17 +146,15 @@ abstract class OdataRequestValidationBase {
     var content = putContentForAttachmentWithNavigation(selectedRoot, itemAttachment);
 
     var url = buildExpandAttachmentUrl(selectedRoot.getId(), item.getId());
-    var responseItem =
-        requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
-            url, Items.class, HttpStatus.OK);
+    var responseItem = requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
+        url, Items.class, HttpStatus.OK);
 
     assertThat(responseItem.getAttachments()).hasSameSizeAs(item.getAttachments());
 
-    var attachmentWithExpectedContent =
-        responseItem.getAttachments().stream()
-            .filter(attach -> attach.getId().equals(itemAttachment.getId()))
-            .findAny()
-            .orElseThrow();
+    var attachmentWithExpectedContent = responseItem.getAttachments().stream()
+        .filter(attach -> attach.getId().equals(itemAttachment.getId()))
+        .findAny()
+        .orElseThrow();
     assertThat(attachmentWithExpectedContent)
         .containsEntry("content@mediaContentType", "application/octet-stream;charset=UTF-8")
         .containsEntry(Attachments.FILE_NAME, itemAttachment.getFileName());
@@ -176,9 +177,8 @@ abstract class OdataRequestValidationBase {
     var selectedItemAfterChange = selectItem(item);
     var itemAttachmentAfterChange = getRandomItemAttachment(selectedItemAfterChange);
 
-    var url =
-        buildNavigationAttachmentUrl(selectedRoot.getId(), item.getId(), itemAttachment.getId())
-            + "/content";
+    var url = buildNavigationAttachmentUrl(selectedRoot.getId(), item.getId(), itemAttachment.getId())
+        + "/content";
     executeContentRequestAndValidateContent(url, content);
     verifySingleReadEvent(itemAttachmentAfterChange.getContentId());
   }
@@ -201,9 +201,8 @@ abstract class OdataRequestValidationBase {
         itemAttachmentAfterChange.getContentId());
 
     var expandUrl = buildExpandAttachmentUrl(selectedRoot.getId(), item.getId());
-    var responseItem =
-        requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
-            expandUrl, Items.class, HttpStatus.OK);
+    var responseItem = requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
+        expandUrl, Items.class, HttpStatus.OK);
 
     assertThat(responseItem.getAttachments()).hasSameSizeAs(item.getAttachments());
     assertThat(responseItem.getAttachments())
@@ -229,13 +228,11 @@ abstract class OdataRequestValidationBase {
     var selectedItemAfterChange = selectItem(item);
     var itemAttachmentAfterChange = getRandomItemAttachment(selectedItemAfterChange);
 
-    var url =
-        buildNavigationAttachmentUrl(selectedRoot.getId(), item.getId(), itemAttachment.getId());
+    var url = buildNavigationAttachmentUrl(selectedRoot.getId(), item.getId(), itemAttachment.getId());
     requestHelper.executeDelete(url);
     var expandUrl = buildExpandAttachmentUrl(selectedRoot.getId(), item.getId());
-    var responseItem =
-        requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
-            expandUrl, Items.class, HttpStatus.OK);
+    var responseItem = requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
+        expandUrl, Items.class, HttpStatus.OK);
 
     assertThat(responseItem.getAttachments()).hasSize(1);
     assertThat(responseItem.getAttachments())
@@ -262,8 +259,7 @@ abstract class OdataRequestValidationBase {
     var selectedItemAfterChange = selectItem(item);
     var itemAttachmentAfterChange = getRandomItemAttachment(selectedItemAfterChange);
 
-    var url =
-        buildNavigationAttachmentUrl(selectedRoot.getId(), item.getId(), itemAttachment.getId());
+    var url = buildNavigationAttachmentUrl(selectedRoot.getId(), item.getId(), itemAttachment.getId());
     requestHelper.executeDelete(url);
     var result = requestHelper.executeDelete(url);
 
@@ -281,9 +277,8 @@ abstract class OdataRequestValidationBase {
     var itemAttachment = getRandomItemAttachmentEntity(item);
 
     var url = buildDirectAttachmentEntityUrl(itemAttachment.getId());
-    var responseAttachment =
-        requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
-            url, Attachments.class, HttpStatus.OK);
+    var responseAttachment = requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
+        url, Attachments.class, HttpStatus.OK);
 
     assertThat(responseAttachment.get("content@mediaContentType")).isNull();
     assertThat(responseAttachment.getContentId()).isNull();
@@ -303,9 +298,8 @@ abstract class OdataRequestValidationBase {
     clearServiceHandlerContext();
 
     var url = buildDirectAttachmentEntityUrl(itemAttachment.getId());
-    var responseAttachment =
-        requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
-            url, Attachments.class, HttpStatus.OK);
+    var responseAttachment = requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
+        url, Attachments.class, HttpStatus.OK);
 
     assertThat(responseAttachment)
         .containsEntry("content@mediaContentType", "application/octet-stream;charset=UTF-8")
@@ -350,9 +344,8 @@ abstract class OdataRequestValidationBase {
         itemAttachmentAfterChange.getContentId());
 
     var expandUrl = buildExpandAttachmentUrl(selectedRoot.getId(), item.getId());
-    var responseItem =
-        requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
-            expandUrl, Items.class, HttpStatus.OK);
+    var responseItem = requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
+        expandUrl, Items.class, HttpStatus.OK);
 
     assertThat(responseItem.getAttachmentEntities()).hasSameSizeAs(item.getAttachmentEntities());
     assertThat(responseItem.getAttachmentEntities())
@@ -381,9 +374,8 @@ abstract class OdataRequestValidationBase {
     var url = buildDirectAttachmentEntityUrl(itemAttachment.getId());
     requestHelper.executeDelete(url);
     var expandUrl = buildExpandAttachmentUrl(selectedRoot.getId(), item.getId());
-    var responseItem =
-        requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
-            expandUrl, Items.class, HttpStatus.OK);
+    var responseItem = requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
+        expandUrl, Items.class, HttpStatus.OK);
 
     assertThat(responseItem.getAttachmentEntities()).isEmpty();
     verifySingleDeletionEvent(itemAttachmentAfterChange.getContentId());
@@ -431,8 +423,7 @@ abstract class OdataRequestValidationBase {
     var itemAttachmentEntityAfterChange = getRandomItemAttachmentEntity(selectedItemAfterChange);
     var itemAttachmentAfterChange = getRandomItemAttachment(selectedItemAfterChange);
 
-    var url =
-        MockHttpRequestHelper.ODATA_BASE_URL + "TestService/Roots(" + selectedRoot.getId() + ")";
+    var url = MockHttpRequestHelper.ODATA_BASE_URL + "TestService/Roots(" + selectedRoot.getId() + ")";
     requestHelper.executeDeleteWithMatcher(url, status().isNoContent());
 
     verifyTwoDeleteEvents(itemAttachmentEntityAfterChange, itemAttachmentAfterChange);
@@ -541,7 +532,7 @@ abstract class OdataRequestValidationBase {
   }
 
   @ParameterizedTest
-  @CsvSource({"status,INFECTED", "contentId,TEST"})
+  @CsvSource({ "status,INFECTED", "contentId,TEST" })
   void statusCannotBeUpdated(String field, String value) throws Exception {
     var serviceRoot = buildServiceRootWithDeepData();
     postServiceRoot(serviceRoot);
@@ -648,17 +639,15 @@ abstract class OdataRequestValidationBase {
   }
 
   protected Roots selectStoredRootWithDeepData() {
-    CqnSelect select =
-        Select.from(Roots_.class)
-            .columns(
-                StructuredType::_all,
-                root -> root.attachments().expand(),
-                root ->
-                    root.items()
-                        .expand(
-                            StructuredType::_all,
-                            item -> item.attachments().expand(),
-                            item -> item.attachmentEntities().expand()));
+    CqnSelect select = Select.from(Roots_.class)
+        .columns(
+            StructuredType::_all,
+            root -> root.attachments().expand(),
+            root -> root.items()
+                .expand(
+                    StructuredType::_all,
+                    item -> item.attachments().expand(),
+                    item -> item.attachmentEntities().expand()));
     var result = persistenceService.run(select);
     return result.single(Roots.class);
   }
@@ -726,18 +715,15 @@ abstract class OdataRequestValidationBase {
 
   private String putContentForAttachmentWithNavigation(
       Roots selectedRoot, Attachments itemAttachment, ResultMatcher matcher) throws Exception {
-    var selectedItem =
-        selectedRoot.getItems().stream()
-            .filter(
-                item ->
-                    item.getAttachments().stream()
-                        .anyMatch(attach -> attach.getId().equals(itemAttachment.getId())))
-            .findAny()
-            .orElseThrow();
-    var url =
-        buildNavigationAttachmentUrl(
-                selectedRoot.getId(), selectedItem.getId(), itemAttachment.getId())
-            + "/content";
+    var selectedItem = selectedRoot.getItems().stream()
+        .filter(
+            item -> item.getAttachments().stream()
+                .anyMatch(attach -> attach.getId().equals(itemAttachment.getId())))
+        .findAny()
+        .orElseThrow();
+    var url = buildNavigationAttachmentUrl(
+        selectedRoot.getId(), selectedItem.getId(), itemAttachment.getId())
+        + "/content";
 
     var testContent = "testContent" + itemAttachment.getNote();
     requestHelper.setContentType(MediaType.APPLICATION_OCTET_STREAM);
@@ -775,9 +761,8 @@ abstract class OdataRequestValidationBase {
 
   protected String putContentForSizeLimitedAttachment(
       Roots selectedRoot, Attachments attachment, ResultMatcher matcher) throws Exception {
-    var url =
-        buildNavigationSizeLimitedAttachmentUrl(selectedRoot.getId(), attachment.getId())
-            + "/content";
+    var url = buildNavigationSizeLimitedAttachmentUrl(selectedRoot.getId(), attachment.getId())
+        + "/content";
     var testContent = "testContent" + attachment.getNote();
     requestHelper.setContentType(MediaType.APPLICATION_OCTET_STREAM);
     requestHelper.executePutWithMatcher(url, testContent.getBytes(StandardCharsets.UTF_8), matcher);
@@ -816,10 +801,9 @@ abstract class OdataRequestValidationBase {
 
   private Attachments selectUpdatedAttachmentWithExpand(
       Roots selectedRoot, Attachments itemAttachment) {
-    CqnSelect attachmentSelect =
-        Select.from(Items_.class)
-            .where(a -> a.ID().eq(selectedRoot.getItems().get(0).getId()))
-            .columns(item -> item.attachments().expand());
+    CqnSelect attachmentSelect = Select.from(Items_.class)
+        .where(a -> a.ID().eq(selectedRoot.getItems().get(0).getId()))
+        .columns(item -> item.attachments().expand());
     var result = persistenceService.run(attachmentSelect);
     var items = result.single(Items.class);
     return items.getAttachments().stream()
@@ -829,8 +813,7 @@ abstract class OdataRequestValidationBase {
   }
 
   private AttachmentEntity selectUpdatedAttachment(AttachmentEntity itemAttachment) {
-    CqnSelect attachmentSelect =
-        Select.from(AttachmentEntity_.class).where(a -> a.ID().eq(itemAttachment.getId()));
+    CqnSelect attachmentSelect = Select.from(AttachmentEntity_.class).where(a -> a.ID().eq(itemAttachment.getId()));
     var result = persistenceService.run(attachmentSelect);
     return result.single(AttachmentEntity.class);
   }

--- a/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/helper/RootEntityBuilder.java
+++ b/integration-tests/srv/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/helper/RootEntityBuilder.java
@@ -38,6 +38,16 @@ public class RootEntityBuilder {
     }
     Arrays.stream(attachments)
         .forEach(attachment -> rootEntity.getSizeLimitedAttachments().add(attachment.build()));
+
+    return this;
+  }
+
+  public RootEntityBuilder addMediaValidatedAttachments(AttachmentsBuilder... attachments) {
+    if (rootEntity.getMediaValidatedAttachments() == null) {
+      rootEntity.setMediaValidatedAttachments(new ArrayList<>());
+    }
+    Arrays.stream(attachments)
+        .forEach(attachment -> rootEntity.getMediaValidatedAttachments().add(attachment.build()));
     return this;
   }
 

--- a/integration-tests/srv/test-service.cds
+++ b/integration-tests/srv/test-service.cds
@@ -2,7 +2,15 @@ using test.data.model as db from '../db/data-model';
 
 annotate db.Roots.sizeLimitedAttachments with {
     content @Validation.Maximum: '5MB';
-};
+}
+
+// Media type validation for attachments - for testing purposes.
+annotate db.Roots.mediaValidatedAttachments with {
+    content @(Core.AcceptableMediaTypes: [
+        'image/jpeg',
+        'image/png'
+    ]);
+}
 
 service TestService {
     entity Roots            as projection on db.Roots;

--- a/samples/bookshop/srv/attachments.cds
+++ b/samples/bookshop/srv/attachments.cds
@@ -4,13 +4,23 @@ using {sap.attachments.Attachments} from 'com.sap.cds/cds-feature-attachments';
 // Extend Books entity to support file attachments (images, PDFs, documents)
 // Each book can have multiple attachments via composition relationship
 extend my.Books with {
-  attachments : Composition of many Attachments;
+  attachments               : Composition of many Attachments;
   @UI.Hidden
-  sizeLimitedAttachments : Composition of many Attachments;
+  sizeLimitedAttachments    : Composition of many Attachments;
+  @UI.Hidden
+  mediaValidatedAttachments : Composition of many Attachments;
 }
 
 annotate my.Books.sizeLimitedAttachments with {
   content @Validation.Maximum: '5MB';
+}
+
+// Media type validation for attachments
+annotate my.Books.mediaValidatedAttachments with {
+  content @Core.AcceptableMediaTypes: [
+    'image/jpeg',
+    'image/png'
+  ];
 }
 
 // Add UI component for attachments table to the Browse Books App


### PR DESCRIPTION
# Add Support to Restrict @Core.AcceptableMediaTypes

### New Features

✨ Introduced validation for acceptable media types in attachment uploads using the `@Core.AcceptableMediaTypes` annotation, enabling applications to restrict file types for enhanced security and consistency.

### Changes

* **`AttachmentValidationHelper.java`**: New validation helper class that determines file MIME types and validates them against allowed media types. Includes fallback to default MIME type `application/octet-stream` when type cannot be detected. Maps common file extensions to their respective MIME types and supports wildcard patterns for flexible type matching.

* **`ModifyApplicationHandlerHelper.java`**: Enhanced attachment processing to validate media types before upload. Added methods to extract acceptable media types from entity annotations (`getEntityAcceptableMediaTypes`) and retrieve filenames from attachments or path values (`getFileName`). Integrated validation into the attachment handling workflow to ensure MIME type compliance.

* **`AttachmentValidationHelperTest.java`**: Comprehensive test suite for media type validation including edge cases for unknown extensions, uppercase extensions, and wildcard type support. Tests cover scenarios with various MIME types, default fallback behavior, and error handling for invalid or restricted file types.

* **`ModifyApplicationHandlerHelperTest.java`**: Tests for filename retrieval and acceptable media types extraction from entity annotations. Validates behavior when filenames are missing or retrieved from different sources, and ensures proper handling of annotation-based media type restrictions.

* **Test Files**: Updated test infrastructure across multiple files to support new validation scenarios:
  - `CreateAttachmentsHandlerTest.java` & `UpdateAttachmentsHandlerTest.java`: Added filename validation to ensure all attachment entities specify a filename
  - `DraftPatchAttachmentsHandlerTest.java`: Updated to include filename in test attachments
  - `AcceptedMediaTypesAttachmentsValidationDraftTest.java` & `AcceptedMediaTypesAttachmentsValidationNonDraftTest.java`: New integration tests verifying media type validation in both draft and non-draft scenarios

* **CDS Models**: 
  - `data-model.cds`: Added `mediaValidatedAttachments` composition to the `Roots` entity for testing media type validation
  - `test-service.cds` & `attachments.cds`: Configured `@Core.AcceptableMediaTypes` annotation to restrict uploads to `image/jpeg` and `image/png` only

* **Documentation**: 
  - `README.md`: Added new section "Restrict allowed MIME types" with examples showing how to use `@Core.AcceptableMediaTypes` annotation, including wildcard patterns and default behavior

* **Helper Classes**:
  - `RootEntityBuilder.java`: Added helper method to build entities with media-validated attachments
  - `OdataRequestValidationBase.java` & `DraftOdataRequestValidationBase.java`: Code formatting improvements

- [ ] 🔄 Regenerate and Update Summary

