### PR TITLE
Single attachment

### DIFF
--- a/samples/bookshop/pom.xml
+++ b/samples/bookshop/pom.xml
@@ -48,7 +48,7 @@
 			<dependency>
 				<groupId>com.sap.cds</groupId>
 				<artifactId>cds-feature-attachments</artifactId>
-				<version>1.3.3</version>
+				<version>1.4.0-SNAPSHOT</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/samples/bookshop/srv/attachments.cds
+++ b/samples/bookshop/srv/attachments.cds
@@ -8,7 +8,7 @@ extend my.Books with {
   @UI.Hidden
   sizeLimitedAttachments           : Composition of many Attachments;
   @UI.Hidden
-  mediaValidatedAttachments        : Composition of many Attachments;
+  mediaValidatedAttachments        : Composition of one Attachments;
   @UI.Hidden
   anotherMediaValidatedAttachments : Composition of many Attachments;
 }
@@ -42,10 +42,20 @@ annotate adminService.Books with @(UI.Facets: [{
   $Type : 'UI.ReferenceFacet',
   ID    : 'AttachmentsFacet',
   Label : '{i18n>attachments}',
-  Target: 'mediaValidatedAttachments/@UI.LineItem'
+  Target: 'mediaValidatedAttachments/@UI.FieldGroup'
 }]);
 
 annotate adminService.Books with @odata.draft.enabled;
+
+
+annotate adminService.Books.mediaValidatedAttachments with @UI.FieldGroup: {
+    Data: [
+        {Value: content},
+        {Value: fileName},
+        {Value: mimeType},
+        {Value: status}
+    ]
+};
 
 service nonDraft {
   entity Books as projection on my.Books;

--- a/samples/bookshop/srv/attachments.cds
+++ b/samples/bookshop/srv/attachments.cds
@@ -45,6 +45,7 @@ annotate adminService.Books with @(UI.Facets: [{
   Target: 'mediaValidatedAttachments/@UI.LineItem'
 }]);
 
+annotate adminService.Books with @odata.draft.enabled;
 
 service nonDraft {
   entity Books as projection on my.Books;


### PR DESCRIPTION
Work in progress for supporting single attachments (e.g. for profile pictures).
The actual handling for uploading is missing.
What works now is:
- Open the management site: http://localhost:8080/index.html#Books-manage
- Edit the book
- Click the delete button
- Then upload the attachment.

Further work needs to be done here, this is only a starting point.