### PR TITLE
fix: skip rescan-on-download when no malware scanner is bound

### DIFF
--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -160,7 +160,10 @@ public class Registration implements CdsRuntimeConfiguration {
           new EndTransactionMalwareScanRunner(null, null, malwareScanner, runtime);
       configurer.eventHandler(
           new ReadAttachmentsHandler(
-              attachmentService, new AttachmentStatusValidator(), scanRunner, persistenceService,
+              attachmentService,
+              new AttachmentStatusValidator(),
+              scanRunner,
+              persistenceService,
               scanClient != null));
     } else {
       logger.debug(

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -160,7 +160,8 @@ public class Registration implements CdsRuntimeConfiguration {
           new EndTransactionMalwareScanRunner(null, null, malwareScanner, runtime);
       configurer.eventHandler(
           new ReadAttachmentsHandler(
-              attachmentService, new AttachmentStatusValidator(), scanRunner, persistenceService));
+              attachmentService, new AttachmentStatusValidator(), scanRunner, persistenceService,
+              scanClient != null));
     } else {
       logger.debug(
           "No application service is available. Application service event handlers will not be registered.");

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
@@ -77,18 +77,21 @@ public class ReadAttachmentsHandler implements EventHandler {
   private final AttachmentStatusValidator statusValidator;
   private final AsyncMalwareScanExecutor scanExecutor;
   private final PersistenceService persistenceService;
+  private final boolean scannerAvailable;
 
   public ReadAttachmentsHandler(
       AttachmentService attachmentService,
       AttachmentStatusValidator statusValidator,
       AsyncMalwareScanExecutor scanExecutor,
-      PersistenceService persistenceService) {
+      PersistenceService persistenceService,
+      boolean scannerAvailable) {
     this.attachmentService =
         requireNonNull(attachmentService, "attachmentService must not be null");
     this.statusValidator = requireNonNull(statusValidator, "statusValidator must not be null");
     this.scanExecutor = requireNonNull(scanExecutor, "scanExecutor must not be null");
     this.persistenceService =
         requireNonNull(persistenceService, "persistenceService must not be null");
+    this.scannerAvailable = scannerAvailable;
   }
 
   @Before
@@ -174,7 +177,7 @@ public class ReadAttachmentsHandler implements EventHandler {
           "In verify status for content id {} and status {}",
           attachment.getContentId(),
           currentStatus);
-      if (needsScan(currentStatus, attachment.getScannedAt())) {
+      if (scannerAvailable && needsScan(currentStatus, attachment.getScannedAt())) {
         if (StatusCode.CLEAN.equals(currentStatus)) {
           transitionToScanning(path.target().entity(), attachment);
         }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
@@ -82,7 +82,8 @@ class ReadAttachmentsHandlerTest {
             attachmentService,
             attachmentStatusValidator,
             asyncMalwareScanExecutor,
-            persistenceService);
+            persistenceService,
+            true);
 
     readEventContext = mock(CdsReadEventContext.class);
   }
@@ -421,6 +422,79 @@ class ReadAttachmentsHandlerTest {
 
     verifyNoInteractions(attachmentStatusValidator);
     assertThat(attachment.getContent()).isNull();
+  }
+
+  @Test
+  void scannerNotAvailable_staleCleanAttachmentIsNotRescanned() {
+    var handlerWithoutScanner =
+        new ReadAttachmentsHandler(
+            attachmentService,
+            attachmentStatusValidator,
+            asyncMalwareScanExecutor,
+            persistenceService,
+            false);
+    mockEventContext(Attachment_.CDS_NAME, mock(CqnSelect.class));
+    var attachment = Attachments.create();
+    attachment.setContentId("some ID");
+    attachment.setContent(mock(InputStream.class));
+    attachment.setStatus(StatusCode.CLEAN);
+    attachment.setScannedAt(Instant.now().minus(4, ChronoUnit.DAYS));
+
+    handlerWithoutScanner.processAfter(readEventContext, List.of(attachment));
+
+    verifyNoInteractions(asyncMalwareScanExecutor);
+    verifyNoInteractions(persistenceService);
+    assertThat(attachment.getStatus()).isEqualTo(StatusCode.CLEAN);
+  }
+
+  @Test
+  void scannerNotAvailable_cleanAttachmentWithNullScannedAtIsNotRescanned() {
+    var handlerWithoutScanner =
+        new ReadAttachmentsHandler(
+            attachmentService,
+            attachmentStatusValidator,
+            asyncMalwareScanExecutor,
+            persistenceService,
+            false);
+    mockEventContext(Attachment_.CDS_NAME, mock(CqnSelect.class));
+    var attachment = Attachments.create();
+    attachment.setContentId("some ID");
+    attachment.setContent(mock(InputStream.class));
+    attachment.setStatus(StatusCode.CLEAN);
+    attachment.setScannedAt(null);
+
+    handlerWithoutScanner.processAfter(readEventContext, List.of(attachment));
+
+    verifyNoInteractions(asyncMalwareScanExecutor);
+    verifyNoInteractions(persistenceService);
+    assertThat(attachment.getStatus()).isEqualTo(StatusCode.CLEAN);
+  }
+
+  @Test
+  void scannerNotAvailable_unscannedAttachmentStillFailsValidation() {
+    var handlerWithoutScanner =
+        new ReadAttachmentsHandler(
+            attachmentService,
+            attachmentStatusValidator,
+            asyncMalwareScanExecutor,
+            persistenceService,
+            false);
+    mockEventContext(Attachment_.CDS_NAME, mock(CqnSelect.class));
+    var attachment = Attachments.create();
+    attachment.setContentId("some ID");
+    attachment.setContent(mock(InputStream.class));
+    attachment.setStatus(StatusCode.UNSCANNED);
+    doThrow(AttachmentStatusException.class)
+        .when(attachmentStatusValidator)
+        .verifyStatus(StatusCode.UNSCANNED);
+
+    List<CdsData> attachments = List.of(attachment);
+    assertThrows(
+        AttachmentStatusException.class,
+        () -> handlerWithoutScanner.processAfter(readEventContext, attachments));
+
+    verifyNoInteractions(asyncMalwareScanExecutor);
+    verifyNoInteractions(persistenceService);
   }
 
   private void mockEventContext(String entityName, CqnSelect select) {


### PR DESCRIPTION
# Fix: Skip Rescan-on-Download When No Malware Scanner Is Bound

### Bug Fix

🐛 Fixed an issue where the `ReadAttachmentsHandler` would attempt to trigger rescan-on-download logic even when no malware scanner service is bound. When `scanClient` is `null` (i.e., no malware scanning service is available), stale or unscanned attachments should not be queued for rescanning on download.

### Changes

* `Registration.java`: Passes `scanClient != null` as the `scannerAvailable` flag when constructing `ReadAttachmentsHandler`, ensuring the handler is aware of whether a malware scanner is actually bound.

* `ReadAttachmentsHandler.java`: Added a `scannerAvailable` boolean field and updated the constructor to accept it. The `verifyStatus` method now short-circuits the rescan check when `scannerAvailable` is `false`, preventing unnecessary scan attempts when no scanner is configured.

* `ReadAttachmentsHandlerTest.java`: Updated the existing handler instantiation to pass `true` for `scannerAvailable`. Added three new test cases covering the `scannerAvailable = false` scenario:
  - Stale clean attachments are **not** re-triggered for scanning.
  - Clean attachments with a `null` `scannedAt` timestamp are **not** re-triggered.
  - Attachments with `UNSCANNED` status still fail validation as expected (status validation is unaffected by scanner availability).

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.4` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `9c915e60-33f6-11f1-8c2d-1502b3e0d84c`
</details>
