### PR TITLE
Fix central publishing exclude list for renamed modules

### DIFF
--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -24,7 +24,9 @@ import com.sap.cds.feature.attachments.handler.draftservice.DraftCancelAttachmen
 import com.sap.cds.feature.attachments.handler.draftservice.DraftPatchAttachmentsHandler;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.AttachmentsServiceImpl;
+import com.sap.cds.feature.attachments.service.MalwareScannerServiceImpl;
 import com.sap.cds.feature.attachments.service.handler.DefaultAttachmentsServiceHandler;
+import com.sap.cds.feature.attachments.service.handler.DefaultMalwareScannerServiceHandler;
 import com.sap.cds.feature.attachments.service.handler.transaction.EndTransactionMalwareScanProvider;
 import com.sap.cds.feature.attachments.service.handler.transaction.EndTransactionMalwareScanRunner;
 import com.sap.cds.feature.attachments.service.malware.AttachmentMalwareScanner;
@@ -88,6 +90,7 @@ public class Registration implements CdsRuntimeConfiguration {
   @Override
   public void services(CdsRuntimeConfigurer configurer) {
     configurer.service(new AttachmentsServiceImpl());
+    configurer.service(new MalwareScannerServiceImpl());
   }
 
   @Override
@@ -136,6 +139,9 @@ public class Registration implements CdsRuntimeConfiguration {
     // register event handlers for attachment service
     configurer.eventHandler(
         new DefaultAttachmentsServiceHandler(malwareScanEndTransactionListener));
+
+    // register event handler for malware scanner service
+    configurer.eventHandler(new DefaultMalwareScannerServiceHandler(scanClient));
 
     MarkAsDeletedAttachmentEvent deleteEvent =
         new MarkAsDeletedAttachmentEvent(outboxedAttachmentService);

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/MalwareScannerService.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/MalwareScannerService.java
@@ -1,0 +1,31 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.service;
+
+import com.sap.cds.feature.attachments.service.malware.client.MalwareScanResultStatus;
+import com.sap.cds.services.Service;
+import java.io.InputStream;
+
+/**
+ * The {@link MalwareScannerService} provides malware scanning capabilities independent of the
+ * {@link AttachmentService}. It can be injected from the CAP service catalog and used to scan
+ * arbitrary content for malware.
+ */
+public interface MalwareScannerService extends Service {
+
+  /** The {@link MalwareScannerService} uses this name in the service catalog */
+  String DEFAULT_NAME = "MalwareScannerService$Default";
+
+  /** This event is emitted when content shall be scanned for malware */
+  String EVENT_SCAN_CONTENT = "SCAN_CONTENT";
+
+  /**
+   * Scans the given content for malware.
+   *
+   * @param content the {@link InputStream} of the content to scan
+   * @return the result of the malware scan
+   * @see MalwareScanResultStatus
+   */
+  MalwareScanResultStatus scanContent(InputStream content);
+}

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/MalwareScannerService.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/MalwareScannerService.java
@@ -1,5 +1,5 @@
 /*
- * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
  */
 package com.sap.cds.feature.attachments.service;
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/MalwareScannerServiceImpl.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/MalwareScannerServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
  */
 package com.sap.cds.feature.attachments.service;
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/MalwareScannerServiceImpl.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/MalwareScannerServiceImpl.java
@@ -1,0 +1,31 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.service;
+
+import com.sap.cds.feature.attachments.service.malware.client.MalwareScanResultStatus;
+import com.sap.cds.feature.attachments.service.model.servicehandler.MalwareScanEventContext;
+import com.sap.cds.services.ServiceDelegator;
+import java.io.InputStream;
+
+/**
+ * Implementation of the {@link MalwareScannerService} interface. The main purpose of this class is
+ * to set data in the corresponding context and to call the emit method for the
+ * MalwareScannerService.
+ */
+public class MalwareScannerServiceImpl extends ServiceDelegator implements MalwareScannerService {
+
+  public MalwareScannerServiceImpl() {
+    super(DEFAULT_NAME);
+  }
+
+  @Override
+  public MalwareScanResultStatus scanContent(InputStream content) {
+    var scanContext = MalwareScanEventContext.create();
+    scanContext.setContent(content);
+
+    emit(scanContext);
+
+    return scanContext.getScanResult();
+  }
+}

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/DefaultMalwareScannerServiceHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/DefaultMalwareScannerServiceHandler.java
@@ -1,5 +1,5 @@
 /*
- * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
  */
 package com.sap.cds.feature.attachments.service.handler;
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/DefaultMalwareScannerServiceHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/DefaultMalwareScannerServiceHandler.java
@@ -1,0 +1,63 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.service.handler;
+
+import com.sap.cds.feature.attachments.service.MalwareScannerService;
+import com.sap.cds.feature.attachments.service.malware.client.MalwareScanClient;
+import com.sap.cds.feature.attachments.service.malware.client.MalwareScanResultStatus;
+import com.sap.cds.feature.attachments.service.model.servicehandler.MalwareScanEventContext;
+import com.sap.cds.services.handler.EventHandler;
+import com.sap.cds.services.handler.annotations.HandlerOrder;
+import com.sap.cds.services.handler.annotations.On;
+import com.sap.cds.services.handler.annotations.ServiceName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The class {@link DefaultMalwareScannerServiceHandler} is the default event handler for the {@link
+ * MalwareScannerService}. It delegates to the {@link MalwareScanClient} to perform the actual
+ * malware scan.
+ */
+@ServiceName(value = "*", type = MalwareScannerService.class)
+public class DefaultMalwareScannerServiceHandler implements EventHandler {
+
+  private static final int DEFAULT_ON = 10 * HandlerOrder.AFTER + HandlerOrder.LATE;
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(DefaultMalwareScannerServiceHandler.class);
+
+  private final MalwareScanClient malwareScanClient;
+
+  /**
+   * Constructs a new instance of {@link DefaultMalwareScannerServiceHandler}.
+   *
+   * @param malwareScanClient an optional {@link MalwareScanClient} instance, may be {@code null} if
+   *     no malware scanner service binding is available
+   */
+  public DefaultMalwareScannerServiceHandler(MalwareScanClient malwareScanClient) {
+    this.malwareScanClient = malwareScanClient;
+  }
+
+  @On
+  @HandlerOrder(DEFAULT_ON)
+  void scanContent(MalwareScanEventContext context) {
+    if (malwareScanClient == null) {
+      logger.info("No malware scanner service binding available. Returning NO_SCANNER status.");
+      context.setScanResult(MalwareScanResultStatus.NO_SCANNER);
+      context.setCompleted();
+      return;
+    }
+
+    try {
+      logger.debug("Starting malware scan of content.");
+      MalwareScanResultStatus result = malwareScanClient.scanContent(context.getContent());
+      context.setScanResult(result);
+      logger.debug("Malware scan completed with status '{}'.", result);
+    } catch (RuntimeException e) {
+      logger.error("Error during malware scan.", e);
+      context.setScanResult(MalwareScanResultStatus.FAILED);
+    }
+    context.setCompleted();
+  }
+}

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/model/servicehandler/MalwareScanEventContext.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/model/servicehandler/MalwareScanEventContext.java
@@ -1,5 +1,5 @@
 /*
- * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
  */
 package com.sap.cds.feature.attachments.service.model.servicehandler;
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/model/servicehandler/MalwareScanEventContext.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/model/servicehandler/MalwareScanEventContext.java
@@ -1,0 +1,51 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.service.model.servicehandler;
+
+import com.sap.cds.feature.attachments.service.MalwareScannerService;
+import com.sap.cds.feature.attachments.service.malware.client.MalwareScanResultStatus;
+import com.sap.cds.services.EventContext;
+import com.sap.cds.services.EventName;
+import java.io.InputStream;
+
+/**
+ * The {@link MalwareScanEventContext} is used to store the context of a malware scan event.
+ */
+@EventName(MalwareScannerService.EVENT_SCAN_CONTENT)
+public interface MalwareScanEventContext extends EventContext {
+
+  /**
+   * Creates an {@link EventContext} already overlaid with this interface. The event is set to be
+   * {@link MalwareScannerService#EVENT_SCAN_CONTENT}
+   *
+   * @return the {@link MalwareScanEventContext}
+   */
+  static MalwareScanEventContext create() {
+    return EventContext.create(MalwareScanEventContext.class, null);
+  }
+
+  /**
+   * @return the content {@link InputStream} to scan for malware
+   */
+  InputStream getContent();
+
+  /**
+   * Sets the content to scan for malware
+   *
+   * @param content the content {@link InputStream} to scan
+   */
+  void setContent(InputStream content);
+
+  /**
+   * @return the result of the malware scan or {@code null} if not yet scanned
+   */
+  MalwareScanResultStatus getScanResult();
+
+  /**
+   * Sets the result of the malware scan
+   *
+   * @param scanResult the result of the malware scan
+   */
+  void setScanResult(MalwareScanResultStatus scanResult);
+}

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/model/servicehandler/MalwareScanEventContext.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/model/servicehandler/MalwareScanEventContext.java
@@ -9,9 +9,7 @@ import com.sap.cds.services.EventContext;
 import com.sap.cds.services.EventName;
 import java.io.InputStream;
 
-/**
- * The {@link MalwareScanEventContext} is used to store the context of a malware scan event.
- */
+/** The {@link MalwareScanEventContext} is used to store the context of a malware scan event. */
 @EventName(MalwareScannerService.EVENT_SCAN_CONTENT)
 public interface MalwareScanEventContext extends EventContext {
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/configuration/RegistrationTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/configuration/RegistrationTest.java
@@ -19,7 +19,9 @@ import com.sap.cds.feature.attachments.handler.draftservice.DraftActiveAttachmen
 import com.sap.cds.feature.attachments.handler.draftservice.DraftCancelAttachmentsHandler;
 import com.sap.cds.feature.attachments.handler.draftservice.DraftPatchAttachmentsHandler;
 import com.sap.cds.feature.attachments.service.AttachmentService;
+import com.sap.cds.feature.attachments.service.MalwareScannerService;
 import com.sap.cds.feature.attachments.service.handler.DefaultAttachmentsServiceHandler;
+import com.sap.cds.feature.attachments.service.handler.DefaultMalwareScannerServiceHandler;
 import com.sap.cds.feature.attachments.service.malware.DefaultAttachmentMalwareScanner;
 import com.sap.cds.services.Service;
 import com.sap.cds.services.ServiceCatalog;
@@ -96,13 +98,16 @@ class RegistrationTest {
   void serviceIsRegistered() {
     cut.services(configurer);
 
-    verify(configurer).service(serviceArgumentCaptor.capture());
+    verify(configurer, times(2)).service(serviceArgumentCaptor.capture());
     var services = serviceArgumentCaptor.getAllValues();
-    assertThat(services).hasSize(1);
+    assertThat(services).hasSize(2);
 
     var attachmentServiceFound = services.stream().anyMatch(AttachmentService.class::isInstance);
+    var malwareScannerServiceFound =
+        services.stream().anyMatch(MalwareScannerService.class::isInstance);
 
     assertThat(attachmentServiceFound).isTrue();
+    assertThat(malwareScannerServiceFound).isTrue();
   }
 
   @Test
@@ -119,7 +124,7 @@ class RegistrationTest {
 
     cut.eventHandlers(configurer);
 
-    var handlerSize = 8;
+    var handlerSize = 9;
     verify(configurer, times(handlerSize)).eventHandler(handlerArgumentCaptor.capture());
     checkHandlers(handlerArgumentCaptor.getAllValues(), handlerSize);
   }
@@ -139,7 +144,7 @@ class RegistrationTest {
 
     cut.eventHandlers(configurer);
 
-    var handlerSize = 8;
+    var handlerSize = 9;
     verify(configurer, times(handlerSize)).eventHandler(handlerArgumentCaptor.capture());
     checkHandlers(handlerArgumentCaptor.getAllValues(), handlerSize);
   }
@@ -147,6 +152,7 @@ class RegistrationTest {
   private void checkHandlers(List<EventHandler> handlers, int handlerSize) {
     assertThat(handlers).hasSize(handlerSize);
     isHandlerForClassIncluded(handlers, DefaultAttachmentsServiceHandler.class);
+    isHandlerForClassIncluded(handlers, DefaultMalwareScannerServiceHandler.class);
     isHandlerForClassIncluded(handlers, CreateAttachmentsHandler.class);
     isHandlerForClassIncluded(handlers, UpdateAttachmentsHandler.class);
     isHandlerForClassIncluded(handlers, DeleteAttachmentsHandler.class);
@@ -167,11 +173,12 @@ class RegistrationTest {
 
     cut.eventHandlers(configurer);
 
-    var handlerSize = 1;
+    var handlerSize = 2;
     verify(configurer, times(handlerSize)).eventHandler(handlerArgumentCaptor.capture());
     var handlers = handlerArgumentCaptor.getAllValues();
     assertThat(handlers).hasSize(handlerSize);
     isHandlerForClassIncluded(handlers, DefaultAttachmentsServiceHandler.class);
+    isHandlerForClassIncluded(handlers, DefaultMalwareScannerServiceHandler.class);
     // event handlers for application services are not registered
     isHandlerForClassMissing(handlers, CreateAttachmentsHandler.class);
     isHandlerForClassMissing(handlers, UpdateAttachmentsHandler.class);

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/MalwareScannerServiceImplTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/MalwareScannerServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
  */
 package com.sap.cds.feature.attachments.service;
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/MalwareScannerServiceImplTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/MalwareScannerServiceImplTest.java
@@ -19,7 +19,6 @@ import com.sap.cds.services.runtime.CdsRuntime;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/MalwareScannerServiceImplTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/MalwareScannerServiceImplTest.java
@@ -1,0 +1,68 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.sap.cds.feature.attachments.service.malware.client.MalwareScanResultStatus;
+import com.sap.cds.feature.attachments.service.model.servicehandler.MalwareScanEventContext;
+import com.sap.cds.services.environment.CdsEnvironment;
+import com.sap.cds.services.environment.CdsProperties;
+import com.sap.cds.services.handler.Handler;
+import com.sap.cds.services.impl.ServiceSPI;
+import com.sap.cds.services.runtime.CdsRuntime;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class MalwareScannerServiceImplTest {
+
+  private MalwareScannerServiceImpl cut;
+  private Handler handler;
+  private ServiceSPI serviceSpi;
+
+  @BeforeEach
+  void setup() {
+    cut = new MalwareScannerServiceImpl();
+
+    CdsEnvironment env = mock(CdsEnvironment.class);
+    CdsProperties props = new CdsProperties();
+    when(env.getCdsProperties()).thenReturn(props);
+    CdsRuntime runtime = mock(CdsRuntime.class);
+    when(runtime.getEnvironment()).thenReturn(env);
+    handler = mock(Handler.class);
+    serviceSpi = (ServiceSPI) cut.getDelegatedService();
+    serviceSpi.setCdsRuntime(runtime);
+  }
+
+  @ParameterizedTest
+  @EnumSource(MalwareScanResultStatus.class)
+  void scanContentReturnsCorrectStatus(MalwareScanResultStatus expectedStatus) {
+    var contextReference = new AtomicReference<MalwareScanEventContext>();
+    var stream = mock(InputStream.class);
+    doAnswer(
+            input -> {
+              var context = (MalwareScanEventContext) input.getArgument(0);
+              contextReference.set(context);
+              context.setCompleted();
+              context.setScanResult(expectedStatus);
+              return null;
+            })
+        .when(handler)
+        .process(any());
+    serviceSpi.on(MalwareScannerService.EVENT_SCAN_CONTENT, "", handler);
+
+    var result = cut.scanContent(stream);
+
+    assertThat(result).isEqualTo(expectedStatus);
+    assertThat(contextReference.get().getContent()).isEqualTo(stream);
+  }
+}

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/DefaultMalwareScannerServiceHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/DefaultMalwareScannerServiceHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
  */
 package com.sap.cds.feature.attachments.service.handler;
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/DefaultMalwareScannerServiceHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/DefaultMalwareScannerServiceHandlerTest.java
@@ -1,0 +1,101 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.service.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.sap.cds.feature.attachments.service.MalwareScannerService;
+import com.sap.cds.feature.attachments.service.malware.client.MalwareScanClient;
+import com.sap.cds.feature.attachments.service.malware.client.MalwareScanResultStatus;
+import com.sap.cds.feature.attachments.service.model.servicehandler.MalwareScanEventContext;
+import com.sap.cds.services.handler.annotations.HandlerOrder;
+import com.sap.cds.services.handler.annotations.On;
+import com.sap.cds.services.handler.annotations.ServiceName;
+import java.io.InputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DefaultMalwareScannerServiceHandlerTest {
+
+  private static final int EXPECTED_HANDLER_ORDER = 11000;
+
+  private DefaultMalwareScannerServiceHandler cut;
+  private MalwareScanClient malwareScanClient;
+
+  @BeforeEach
+  void setup() {
+    malwareScanClient = mock(MalwareScanClient.class);
+    cut = new DefaultMalwareScannerServiceHandler(malwareScanClient);
+  }
+
+  @Test
+  void scanContentWithClientReturnsClean() {
+    when(malwareScanClient.scanContent(any())).thenReturn(MalwareScanResultStatus.CLEAN);
+    var context = MalwareScanEventContext.create();
+    context.setContent(mock(InputStream.class));
+
+    cut.scanContent(context);
+
+    assertThat(context.isCompleted()).isTrue();
+    assertThat(context.getScanResult()).isEqualTo(MalwareScanResultStatus.CLEAN);
+  }
+
+  @Test
+  void scanContentWithClientReturnsInfected() {
+    when(malwareScanClient.scanContent(any())).thenReturn(MalwareScanResultStatus.INFECTED);
+    var context = MalwareScanEventContext.create();
+    context.setContent(mock(InputStream.class));
+
+    cut.scanContent(context);
+
+    assertThat(context.isCompleted()).isTrue();
+    assertThat(context.getScanResult()).isEqualTo(MalwareScanResultStatus.INFECTED);
+  }
+
+  @Test
+  void scanContentWithoutClientReturnsNoScanner() {
+    cut = new DefaultMalwareScannerServiceHandler(null);
+    var context = MalwareScanEventContext.create();
+    context.setContent(mock(InputStream.class));
+
+    cut.scanContent(context);
+
+    assertThat(context.isCompleted()).isTrue();
+    assertThat(context.getScanResult()).isEqualTo(MalwareScanResultStatus.NO_SCANNER);
+  }
+
+  @Test
+  void scanContentWithClientThrowingExceptionReturnsFailed() {
+    when(malwareScanClient.scanContent(any())).thenThrow(new RuntimeException("scan error"));
+    var context = MalwareScanEventContext.create();
+    context.setContent(mock(InputStream.class));
+
+    cut.scanContent(context);
+
+    assertThat(context.isCompleted()).isTrue();
+    assertThat(context.getScanResult()).isEqualTo(MalwareScanResultStatus.FAILED);
+  }
+
+  @Test
+  void classHasCorrectAnnotation() {
+    var annotation = cut.getClass().getAnnotation(ServiceName.class);
+
+    assertThat(annotation.value()).containsOnly("*");
+    assertThat(annotation.type()).containsOnly(MalwareScannerService.class);
+  }
+
+  @Test
+  void scanMethodHasCorrectAnnotation() throws NoSuchMethodException {
+    var scanMethod =
+        cut.getClass().getDeclaredMethod("scanContent", MalwareScanEventContext.class);
+    var onAnnotation = scanMethod.getAnnotation(On.class);
+    var handlerOrderAnnotation = scanMethod.getAnnotation(HandlerOrder.class);
+
+    assertThat(onAnnotation.event()).isEmpty();
+    assertThat(handlerOrderAnnotation.value()).isEqualTo(EXPECTED_HANDLER_ORDER);
+  }
+}

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/DefaultMalwareScannerServiceHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/DefaultMalwareScannerServiceHandlerTest.java
@@ -57,6 +57,18 @@ class DefaultMalwareScannerServiceHandlerTest {
   }
 
   @Test
+  void scanContentWithClientReturnsEncrypted() {
+    when(malwareScanClient.scanContent(any())).thenReturn(MalwareScanResultStatus.ENCRYPTED);
+    var context = MalwareScanEventContext.create();
+    context.setContent(mock(InputStream.class));
+
+    cut.scanContent(context);
+
+    assertThat(context.isCompleted()).isTrue();
+    assertThat(context.getScanResult()).isEqualTo(MalwareScanResultStatus.ENCRYPTED);
+  }
+
+  @Test
   void scanContentWithoutClientReturnsNoScanner() {
     cut = new DefaultMalwareScannerServiceHandler(null);
     var context = MalwareScanEventContext.create();

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/DefaultMalwareScannerServiceHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/DefaultMalwareScannerServiceHandlerTest.java
@@ -90,8 +90,7 @@ class DefaultMalwareScannerServiceHandlerTest {
 
   @Test
   void scanMethodHasCorrectAnnotation() throws NoSuchMethodException {
-    var scanMethod =
-        cut.getClass().getDeclaredMethod("scanContent", MalwareScanEventContext.class);
+    var scanMethod = cut.getClass().getDeclaredMethod("scanContent", MalwareScanEventContext.class);
     var onAnnotation = scanMethod.getAnnotation(On.class);
     var handlerOrderAnnotation = scanMethod.getAnnotation(HandlerOrder.class);
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/model/servicehandler/MalwareScanEventContextTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/model/servicehandler/MalwareScanEventContextTest.java
@@ -1,5 +1,5 @@
 /*
- * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
  */
 package com.sap.cds.feature.attachments.service.model.servicehandler;
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/model/servicehandler/MalwareScanEventContextTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/model/servicehandler/MalwareScanEventContextTest.java
@@ -1,0 +1,33 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.service.model.servicehandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sap.cds.feature.attachments.service.malware.client.MalwareScanResultStatus;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MalwareScanEventContextTest {
+  private MalwareScanEventContext cut;
+
+  @BeforeEach
+  void setup() {
+    cut = MalwareScanEventContext.create();
+  }
+
+  @Test
+  void fieldsCanBeSetAndRead() throws IOException {
+    try (var testStream = new ByteArrayInputStream("testString".getBytes(StandardCharsets.UTF_8))) {
+      cut.setContent(testStream);
+      cut.setScanResult(MalwareScanResultStatus.CLEAN);
+
+      assertThat(cut.getContent()).isEqualTo(testStream);
+      assertThat(cut.getScanResult()).isEqualTo(MalwareScanResultStatus.CLEAN);
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,8 @@
               <excludeArtifacts>
                 <excludeArtifact>cds-feature-attachments-integration-tests-parent</excludeArtifact>
                 <excludeArtifact>cds-feature-attachments-integration-tests-db</excludeArtifact>
-                <excludeArtifact>cds-feature-attachments-integration-tests-srv</excludeArtifact>
+                <excludeArtifact>cds-feature-attachments-integration-tests-generic</excludeArtifact>
+                <excludeArtifact>cds-feature-attachments-integration-tests-mtx-local</excludeArtifact>
               </excludeArtifacts>
             </configuration>
           </plugin>


### PR DESCRIPTION
# Add `MalwareScannerService` and Fix Central Publishing Exclude List

### New Features

✨ Introduces a standalone `MalwareScannerService` that can be injected from the CAP service catalog to scan arbitrary content for malware, independent of the `AttachmentService`. Also fixes the central publishing exclude list to reflect renamed integration test modules.

### Changes

* `pom.xml`: Replaces the outdated `cds-feature-attachments-integration-tests-srv` exclude entry with the renamed modules `cds-feature-attachments-integration-tests-generic` and `cds-feature-attachments-integration-tests-mtx-local` in the central publishing plugin configuration.

* `MalwareScannerService.java` *(new)*: Defines the `MalwareScannerService` interface with a `scanContent(InputStream)` method and associated constants for the service name and event.

* `MalwareScannerServiceImpl.java` *(new)*: Implements `MalwareScannerService` using `ServiceDelegator`, populates a `MalwareScanEventContext`, emits the event, and returns the scan result.

* `MalwareScanEventContext.java` *(new)*: Defines the `EventContext` interface for the `SCAN_CONTENT` event, carrying the content `InputStream` and the resulting `MalwareScanResultStatus`.

* `DefaultMalwareScannerServiceHandler.java` *(new)*: Default `@On` event handler for `MalwareScannerService` that delegates to `MalwareScanClient`. Returns `NO_SCANNER` if no client binding is available, or `FAILED` on exception.

* `Registration.java`: Registers `MalwareScannerServiceImpl` as a service and `DefaultMalwareScannerServiceHandler` as an event handler during runtime configuration.

* `RegistrationTest.java`: Updates tests to expect two registered services (`AttachmentService` + `MalwareScannerService`) and nine event handlers (previously eight), including verification of `DefaultMalwareScannerServiceHandler`.

* `MalwareScannerServiceImplTest.java` *(new)*: Parameterized tests verifying that `scanContent` correctly propagates all `MalwareScanResultStatus` values and passes the content stream through the event context.

* `DefaultMalwareScannerServiceHandlerTest.java` *(new)*: Unit tests covering clean/infected/encrypted results, missing client (`NO_SCANNER`), exception handling (`FAILED`), and correct handler annotations.

* `MalwareScanEventContextTest.java` *(new)*: Verifies that fields on `MalwareScanEventContext` can be set and read correctly.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.11` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `ca1b9a40-371a-11f1-95dd-800252494c9c`
- Event Trigger: `pull_request.opened`
</details>
