### PR TITLE
Fix central publishing exclude list for renamed modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,8 @@
               <excludeArtifacts>
                 <excludeArtifact>cds-feature-attachments-integration-tests-parent</excludeArtifact>
                 <excludeArtifact>cds-feature-attachments-integration-tests-db</excludeArtifact>
-                <excludeArtifact>cds-feature-attachments-integration-tests-srv</excludeArtifact>
+                <excludeArtifact>cds-feature-attachments-integration-tests-generic</excludeArtifact>
+                <excludeArtifact>cds-feature-attachments-integration-tests-mtx-local</excludeArtifact>
               </excludeArtifacts>
             </configuration>
           </plugin>


### PR DESCRIPTION
# Fix Central Publishing Exclude List for Renamed Modules

### Bug Fix

🐛 Updated the central publishing exclude list in the Maven `pom.xml` to reflect renamed integration test modules. The old module `cds-feature-attachments-integration-tests-srv` was replaced by two new modules: `cds-feature-attachments-integration-tests-generic` and `cds-feature-attachments-integration-tests-mtx-local`.

### Changes

* `pom.xml`: Replaced the outdated `cds-feature-attachments-integration-tests-srv` artifact exclusion with the two new module names (`cds-feature-attachments-integration-tests-generic` and `cds-feature-attachments-integration-tests-mtx-local`) in the `central-publishing-maven-plugin` configuration to ensure these integration test modules are correctly excluded from central publishing.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.11` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- File Content Strategy: Full file content
- Correlation ID: `23f48c70-371b-11f1-8482-b2f6f4ebda78`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
