### PR TITLE
Add dedicated unit tests for ReadonlyDataContextEnhancer

### DIFF
--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancerTest.java
@@ -1,4 +1,6 @@
-/* © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors. */
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
 package com.sap.cds.feature.attachments.handler.applicationservice.helper;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancerTest.java
@@ -46,7 +46,8 @@ class ReadonlyDataContextEnhancerTest {
     assertThat(backup)
         .containsEntry(Attachments.CONTENT_ID, "doc-123")
         .containsEntry(Attachments.STATUS, "Clean")
-        .containsEntry(Attachments.SCANNED_AT, scannedAt);
+        .containsEntry(Attachments.SCANNED_AT, scannedAt)
+        .doesNotContainKey(Attachments.CONTENT);
   }
 
   @Test
@@ -109,5 +110,33 @@ class ReadonlyDataContextEnhancerTest {
     assertThat(data).doesNotContainKey(Attachments.CONTENT_ID);
     assertThat(data).doesNotContainKey(Attachments.STATUS);
     assertThat(data).doesNotContainKey(Attachments.SCANNED_AT);
+  }
+
+  @Test
+  void restoreReadonlyFields_withPartialBackup_nullsOverwriteExistingValues() {
+    var data = CdsData.create();
+    data.put(Attachments.STATUS, "Clean");
+    var backup = CdsData.create();
+    backup.put(Attachments.CONTENT_ID, "restored-id");
+    // STATUS and SCANNED_AT intentionally absent from backup
+    data.put(DRAFT_READONLY_CONTEXT, backup);
+
+    ReadonlyDataContextEnhancer.restoreReadonlyFields(data);
+
+    assertThat(data.get(Attachments.CONTENT_ID)).isEqualTo("restored-id");
+    assertThat(data.get(Attachments.STATUS)).isNull();
+    assertThat(data.get(Attachments.SCANNED_AT)).isNull();
+    assertThat(data.get(DRAFT_READONLY_CONTEXT)).isNull();
+  }
+
+  @Test
+  void preserveReadonlyFields_isNotDraft_noExistingBackup_nothingHappens() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+    var attachment = Attachments.create();
+    attachment.setContent(null);
+
+    ReadonlyDataContextEnhancer.preserveReadonlyFields(entity, List.of(attachment), false);
+
+    assertThat(attachment.get(DRAFT_READONLY_CONTEXT)).isNull();
   }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancerTest.java
@@ -1,0 +1,111 @@
+/* © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors. */
+package com.sap.cds.feature.attachments.handler.applicationservice.helper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sap.cds.CdsData;
+import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Events_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
+import com.sap.cds.reflect.CdsEntity;
+import com.sap.cds.services.runtime.CdsRuntime;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ReadonlyDataContextEnhancerTest {
+
+  private static final String DRAFT_READONLY_CONTEXT = "DRAFT_READONLY_CONTEXT";
+
+  private static CdsRuntime runtime;
+
+  @BeforeAll
+  static void classSetup() {
+    runtime = RuntimeHelper.runtime;
+  }
+
+  @Test
+  void preserveReadonlyFields_isDraft_backupCreated() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+
+    var attachment = Attachments.create();
+    attachment.setContentId("doc-123");
+    attachment.setStatus("Clean");
+    Instant scannedAt = Instant.parse("2024-06-01T12:00:00Z");
+    attachment.setScannedAt(scannedAt);
+    attachment.setContent(null);
+
+    ReadonlyDataContextEnhancer.preserveReadonlyFields(entity, List.of(attachment), true);
+
+    assertThat(attachment.get(DRAFT_READONLY_CONTEXT)).isNotNull();
+    var backup = (CdsData) attachment.get(DRAFT_READONLY_CONTEXT);
+    assertThat(backup)
+        .containsEntry(Attachments.CONTENT_ID, "doc-123")
+        .containsEntry(Attachments.STATUS, "Clean")
+        .containsEntry(Attachments.SCANNED_AT, scannedAt);
+  }
+
+  @Test
+  void preserveReadonlyFields_isNotDraft_backupRemoved() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+
+    var attachment = Attachments.create();
+    attachment.setContentId("doc-456");
+    attachment.setContent(null);
+    var existingBackup = CdsData.create();
+    existingBackup.put(Attachments.CONTENT_ID, "old-id");
+    existingBackup.put(Attachments.STATUS, "old-status");
+    existingBackup.put(Attachments.SCANNED_AT, Instant.EPOCH);
+    attachment.put(DRAFT_READONLY_CONTEXT, existingBackup);
+
+    ReadonlyDataContextEnhancer.preserveReadonlyFields(entity, List.of(attachment), false);
+
+    assertThat(attachment.get(DRAFT_READONLY_CONTEXT)).isNull();
+  }
+
+  @Test
+  void preserveReadonlyFields_isDraft_noAttachmentEntity_nothingHappens() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Events_.CDS_NAME).orElseThrow();
+
+    var data = CdsData.create();
+    data.put("content", "some text");
+
+    ReadonlyDataContextEnhancer.preserveReadonlyFields(entity, List.of(data), true);
+
+    assertThat(data.get(DRAFT_READONLY_CONTEXT)).isNull();
+  }
+
+  @Test
+  void restoreReadonlyFields_withBackup_fieldsRestoredAndBackupRemoved() {
+    var data = CdsData.create();
+    var backup = CdsData.create();
+    backup.put(Attachments.CONTENT_ID, "restored-id");
+    backup.put(Attachments.STATUS, "Infected");
+    Instant scannedAt = Instant.parse("2025-01-15T08:30:00Z");
+    backup.put(Attachments.SCANNED_AT, scannedAt);
+    data.put(DRAFT_READONLY_CONTEXT, backup);
+
+    ReadonlyDataContextEnhancer.restoreReadonlyFields(data);
+
+    assertThat(data.get(Attachments.CONTENT_ID)).isEqualTo("restored-id");
+    assertThat(data.get(Attachments.STATUS)).isEqualTo("Infected");
+    assertThat(data.get(Attachments.SCANNED_AT)).isEqualTo(scannedAt);
+    assertThat(data.get(DRAFT_READONLY_CONTEXT)).isNull();
+  }
+
+  @Test
+  void restoreReadonlyFields_withoutBackup_noOp() {
+    var data = CdsData.create();
+    data.put("someKey", "someValue");
+
+    ReadonlyDataContextEnhancer.restoreReadonlyFields(data);
+
+    assertThat(data).containsEntry("someKey", "someValue");
+    assertThat(data).doesNotContainKey(DRAFT_READONLY_CONTEXT);
+    assertThat(data).doesNotContainKey(Attachments.CONTENT_ID);
+    assertThat(data).doesNotContainKey(Attachments.STATUS);
+    assertThat(data).doesNotContainKey(Attachments.SCANNED_AT);
+  }
+}


### PR DESCRIPTION
# Add Dedicated Unit Tests for `ReadonlyDataContextEnhancer`

### Test

🧪 Adds a new test class `ReadonlyDataContextEnhancerTest` covering the `preserveReadonlyFields` and `restoreReadonlyFields` methods with 5 targeted unit tests. Tests use real CDS entities from `RuntimeHelper` with zero Mockito usage.

### Changes

* `ReadonlyDataContextEnhancerTest.java`: New test class with 5 tests covering:
  - `preserveReadonlyFields_isDraft_backupCreated` — verifies that a readonly backup (`DRAFT_READONLY_CONTEXT`) is created with the correct field values (`contentId`, `status`, `scannedAt`) when the draft flag is `true`.
  - `preserveReadonlyFields_isNotDraft_backupRemoved` — verifies that any existing readonly backup is removed when the draft flag is `false`.
  - `preserveReadonlyFields_isDraft_noAttachmentEntity_nothingHappens` — confirms no backup is created for non-attachment entities.
  - `restoreReadonlyFields_withBackup_fieldsRestoredAndBackupRemoved` — verifies that readonly fields are restored from the backup and the backup entry is subsequently removed.
  - `restoreReadonlyFields_withoutBackup_noOp` — confirms no modifications occur when no backup exists.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.11` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Event Trigger: `issue_comment.edited`
- Correlation ID: `295ad2d0-3777-11f1-9c0b-e94530c31a11`
</details>
