### PR TITLE
Fix SCM URL inheritance for child modules on Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <module>integration-tests</module>
   </modules>
 
-  <scm>
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
     <connection>scm:git:https://github.com/cap-java/cds-feature-attachments.git</connection>
     <developerConnection>scm:git:git@github.com:cap-java/cds-feature-attachments.git</developerConnection>
     <url>https://github.com/cap-java/cds-feature-attachments</url>


### PR DESCRIPTION
# Fix SCM URL Inheritance for Child Modules on Maven Central

### Bug Fix

🐛 Fixed an issue where child modules were incorrectly inheriting and appending their paths to the parent SCM URL when published to Maven Central.

### Changes

* `pom.xml`: Added `child.scm.connection.inherit.append.path="false"`, `child.scm.developerConnection.inherit.append.path="false"`, and `child.scm.url.inherit.append.path="false"` attributes to the `<scm>` element. This prevents Maven from automatically appending child module paths to the inherited SCM URLs, ensuring all modules point to the correct root repository URL on Maven Central.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.11` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `e9f85300-37e5-11f1-8ab9-481a42d333a4`
- File Content Strategy: Full file content
</details>
