### PR TITLE
Centralize inline field resolution with AttachmentFieldResolver

### DIFF
--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -18,6 +18,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.Att
 import com.sap.cds.feature.attachments.handler.applicationservice.transaction.CreationChangeSetListener;
 import com.sap.cds.feature.attachments.handler.applicationservice.transaction.ListenerProvider;
 import com.sap.cds.feature.attachments.handler.common.AssociationCascader;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.feature.attachments.handler.draftservice.DraftActiveAttachmentsHandler;
 import com.sap.cds.feature.attachments.handler.draftservice.DraftCancelAttachmentsHandler;
@@ -129,9 +130,9 @@ public class Registration implements CdsRuntimeConfiguration {
         new DefaultAttachmentMalwareScanner(persistenceService, attachmentService, scanClient);
 
     EndTransactionMalwareScanProvider malwareScanEndTransactionListener =
-        (attachmentEntity, contentId, inlinePrefix) ->
+        (attachmentEntity, contentId, resolver) ->
             new EndTransactionMalwareScanRunner(
-                attachmentEntity, contentId, inlinePrefix, malwareScanner, runtime);
+                attachmentEntity, contentId, resolver, malwareScanner, runtime);
 
     // register event handlers for attachment service
     configurer.eventHandler(
@@ -158,7 +159,7 @@ public class Registration implements CdsRuntimeConfiguration {
       configurer.eventHandler(new DeleteAttachmentsHandler(attachmentsReader, deleteEvent));
       EndTransactionMalwareScanRunner scanRunner =
           new EndTransactionMalwareScanRunner(
-              null, null, Optional.empty(), malwareScanner, runtime);
+              null, null, AttachmentFieldResolver.DIRECT, malwareScanner, runtime);
       configurer.eventHandler(
           new ReadAttachmentsHandler(
               attachmentService,

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandler.java
@@ -10,6 +10,7 @@ import com.sap.cds.CdsDataProcessor.Converter;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.services.cds.ApplicationService;
 import com.sap.cds.services.cds.CdsDeleteEventContext;
@@ -19,7 +20,6 @@ import com.sap.cds.services.handler.annotations.HandlerOrder;
 import com.sap.cds.services.handler.annotations.ServiceName;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,15 +54,12 @@ public class DeleteAttachmentsHandler implements EventHandler {
 
     Converter converter =
         (path, element, value) -> {
-          Optional<String> inlinePrefix =
-              ApplicationHandlerHelper.getInlineAttachmentPrefix(
-                  path.target().entity(), element.getName());
+          AttachmentFieldResolver resolver =
+              AttachmentFieldResolver.of(
+                  ApplicationHandlerHelper.getInlineAttachmentPrefix(
+                      path.target().entity(), element.getName()));
           return deleteEvent.processEvent(
-              path,
-              (InputStream) value,
-              Attachments.of(path.target().values()),
-              context,
-              inlinePrefix);
+              path, (InputStream) value, Attachments.of(path.target().values()), context, resolver);
         };
 
     CdsDataProcessor.create()

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
@@ -15,6 +15,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.Att
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.BeforeReadItemsModifier;
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.LazyProxyInputStream;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.AsyncMalwareScanExecutor;
 import com.sap.cds.ql.CQL;
@@ -43,7 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -123,19 +123,20 @@ public class ReadAttachmentsHandler implements EventHandler {
           (path, element, value) -> {
             Attachments attachment;
             // Check if this is an inline attachment field
-            Optional<String> inlinePrefix =
-                ApplicationHandlerHelper.getInlineAttachmentPrefix(
-                    path.target().type(), element.getName());
-            if (inlinePrefix.isPresent()) {
+            AttachmentFieldResolver resolver =
+                AttachmentFieldResolver.of(
+                    ApplicationHandlerHelper.getInlineAttachmentPrefix(
+                        path.target().type(), element.getName()));
+            if (resolver.isInline()) {
               attachment =
                   ApplicationHandlerHelper.extractInlineAttachment(
-                      path.target().values(), inlinePrefix.get());
+                      path.target().values(), resolver.inlinePrefix().get());
             } else {
               attachment = Attachments.of(path.target().values());
             }
             InputStream content = attachment.getContent();
             if (nonNull(attachment.getContentId())) {
-              verifyStatus(path, attachment, inlinePrefix);
+              verifyStatus(path, attachment, resolver);
               Supplier<InputStream> supplier =
                   nonNull(content)
                       ? () -> content
@@ -185,7 +186,7 @@ public class ReadAttachmentsHandler implements EventHandler {
     return associationNames;
   }
 
-  private void verifyStatus(Path path, Attachments attachment, Optional<String> inlinePrefix) {
+  private void verifyStatus(Path path, Attachments attachment, AttachmentFieldResolver resolver) {
     if (areKeysEmpty(path.target().keys())) {
       String currentStatus = attachment.getStatus();
       logger.debug(
@@ -194,13 +195,14 @@ public class ReadAttachmentsHandler implements EventHandler {
           currentStatus);
       if (scannerAvailable && needsScan(currentStatus, attachment.getScannedAt())) {
         if (StatusCode.CLEAN.equals(currentStatus)) {
-          transitionToScanning(path.target().entity(), attachment, inlinePrefix);
+          transitionToScanning(path.target().entity(), attachment, resolver);
         }
         logger.debug(
             "Scanning content with ID {} for malware, has current status {}",
             attachment.getContentId(),
             currentStatus);
-        scanExecutor.scanAsync(path.target().entity(), attachment.getContentId(), inlinePrefix);
+        scanExecutor.scanAsync(
+            path.target().entity(), attachment.getContentId(), resolver.inlinePrefix());
       }
       statusValidator.verifyStatus(attachment.getStatus());
     }
@@ -220,31 +222,24 @@ public class ReadAttachmentsHandler implements EventHandler {
   }
 
   private void transitionToScanning(
-      CdsEntity entity, Attachments attachment, Optional<String> inlinePrefix) {
+      CdsEntity entity, Attachments attachment, AttachmentFieldResolver resolver) {
     logger.debug(
         "Attachment {} has stale scan (scannedAt={}), transitioning to SCANNING for rescan.",
         attachment.getContentId(),
         attachment.getScannedAt());
 
-    String contentIdCol = resolveColumn(Attachments.CONTENT_ID, inlinePrefix);
-    String statusCol = resolveColumn(Attachments.STATUS, inlinePrefix);
-
     Attachments updateData = Attachments.create();
-    updateData.put(statusCol, StatusCode.SCANNING);
+    updateData.put(resolver.status(), StatusCode.SCANNING);
 
     // Filter by contentId because primary keys are unavailable during content-only reads
     // (areKeysEmpty returns true). This is consistent with DefaultAttachmentMalwareScanner.
     CqnUpdate update =
         Update.entity(entity)
             .data(updateData)
-            .where(entry -> entry.get(contentIdCol).eq(attachment.getContentId()));
+            .where(entry -> entry.get(resolver.contentId()).eq(attachment.getContentId()));
     persistenceService.run(update);
 
     attachment.setStatus(StatusCode.SCANNING);
-  }
-
-  private static String resolveColumn(String fieldName, Optional<String> inlinePrefix) {
-    return inlinePrefix.map(p -> p + "_" + fieldName).orElse(fieldName);
   }
 
   private boolean areKeysEmpty(Map<String, Object> keys) {

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
@@ -11,6 +11,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.M
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEventFactory;
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.CountingInputStream;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.reflect.CdsAnnotation;
 import com.sap.cds.reflect.CdsEntity;
@@ -53,9 +54,10 @@ public final class ModifyApplicationHandlerHelper {
 
     Converter converter =
         (path, element, value) -> {
-          Optional<String> inlinePrefix =
-              ApplicationHandlerHelper.getInlineAttachmentPrefix(
-                  path.target().entity(), element.getName());
+          AttachmentFieldResolver resolver =
+              AttachmentFieldResolver.of(
+                  ApplicationHandlerHelper.getInlineAttachmentPrefix(
+                      path.target().entity(), element.getName()));
           return handleAttachmentForEntity(
               condensedExistingAttachments,
               eventFactory,
@@ -63,7 +65,7 @@ public final class ModifyApplicationHandlerHelper {
               path,
               (InputStream) value,
               defaultMaxSize,
-              inlinePrefix);
+              resolver);
         };
 
     CdsDataProcessor.create()
@@ -80,7 +82,7 @@ public final class ModifyApplicationHandlerHelper {
    * @param path the {@link Path} of the attachment
    * @param content the content of the attachment
    * @param defaultMaxSize the default max size to use when no annotation is present
-   * @param inlinePrefix the inline attachment field prefix, or empty for composition-based
+   * @param resolver resolves field names for composition-based or inline attachments
    * @return the processed content as an {@link InputStream}
    */
   public static InputStream handleAttachmentForEntity(
@@ -90,19 +92,12 @@ public final class ModifyApplicationHandlerHelper {
       Path path,
       InputStream content,
       String defaultMaxSize,
-      Optional<String> inlinePrefix) {
+      AttachmentFieldResolver resolver) {
     Map<String, Object> keys = ApplicationHandlerHelper.removeDraftKey(path.target().keys());
     ReadonlyDataContextEnhancer.restoreReadonlyFields((CdsData) path.target().values());
     Attachments attachment = getExistingAttachment(keys, existingAttachments);
 
-    // For inline attachment fields, extract contentId using the known prefix
-    String contentId;
-    if (inlinePrefix.isPresent()) {
-      contentId =
-          (String) path.target().values().get(inlinePrefix.get() + "_" + Attachments.CONTENT_ID);
-    } else {
-      contentId = (String) path.target().values().get(Attachments.CONTENT_ID);
-    }
+    String contentId = (String) path.target().values().get(resolver.contentId());
     String contentLength = eventContext.getParameterInfo().getHeader("Content-Length");
     String maxSizeStr = getValMaxValue(path.target().entity(), defaultMaxSize);
     eventContext.put(
@@ -128,8 +123,7 @@ public final class ModifyApplicationHandlerHelper {
     ModifyAttachmentEvent eventToProcess =
         eventFactory.getEvent(wrappedContent, contentId, attachment);
     try {
-      return eventToProcess.processEvent(
-          path, wrappedContent, attachment, eventContext, inlinePrefix);
+      return eventToProcess.processEvent(path, wrappedContent, attachment, eventContext, resolver);
     } catch (Exception e) {
       if (wrappedContent != null && wrappedContent.isLimitExceeded()) {
         throw tooLargeException;

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancer.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancer.java
@@ -8,6 +8,7 @@ import com.sap.cds.CdsDataProcessor;
 import com.sap.cds.CdsDataProcessor.Validator;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.reflect.CdsEntity;
 import java.util.List;
 import java.util.Objects;
@@ -37,20 +38,18 @@ public final class ReadonlyDataContextEnhancer {
         (path, element, value) -> {
           if (isDraft) {
             // Determine if this is an inline attachment field
-            Optional<String> inlinePrefix =
-                ApplicationHandlerHelper.getInlineAttachmentPrefix(
-                    path.target().type(), element.getName());
-            if (inlinePrefix.isPresent()) {
+            AttachmentFieldResolver resolver =
+                AttachmentFieldResolver.of(
+                    ApplicationHandlerHelper.getInlineAttachmentPrefix(
+                        path.target().type(), element.getName()));
+            if (resolver.isInline()) {
               // Inline attachment: use prefixed field names
-              String prefix = inlinePrefix.get() + "_";
               Attachments attachment = Attachments.create();
-              attachment.setContentId(
-                  (String) path.target().values().get(prefix + Attachments.CONTENT_ID));
-              attachment.setStatus(
-                  (String) path.target().values().get(prefix + Attachments.STATUS));
+              attachment.setContentId((String) path.target().values().get(resolver.contentId()));
+              attachment.setStatus((String) path.target().values().get(resolver.status()));
               attachment.setScannedAt(
-                  (java.time.Instant) path.target().values().get(prefix + Attachments.SCANNED_AT));
-              path.target().values().put(prefix + DRAFT_READONLY_CONTEXT, attachment);
+                  (java.time.Instant) path.target().values().get(resolver.scannedAt()));
+              path.target().values().put(resolver.resolve(DRAFT_READONLY_CONTEXT), attachment);
             } else {
               // Composition-based attachment: use direct field names
               Attachments values = Attachments.of(path.target().values());
@@ -98,13 +97,10 @@ public final class ReadonlyDataContextEnhancer {
         String prefix = key.substring(0, key.length() - DRAFT_READONLY_CONTEXT.length() - 1);
         CdsData inlineReadOnlyData = (CdsData) data.get(key);
         if (Objects.nonNull(inlineReadOnlyData)) {
-          data.put(
-              prefix + "_" + Attachments.CONTENT_ID,
-              inlineReadOnlyData.get(Attachments.CONTENT_ID));
-          data.put(prefix + "_" + Attachments.STATUS, inlineReadOnlyData.get(Attachments.STATUS));
-          data.put(
-              prefix + "_" + Attachments.SCANNED_AT,
-              inlineReadOnlyData.get(Attachments.SCANNED_AT));
+          AttachmentFieldResolver resolver = AttachmentFieldResolver.of(Optional.of(prefix));
+          data.put(resolver.contentId(), inlineReadOnlyData.get(Attachments.CONTENT_ID));
+          data.put(resolver.status(), inlineReadOnlyData.get(Attachments.STATUS));
+          data.put(resolver.scannedAt(), inlineReadOnlyData.get(Attachments.SCANNED_AT));
           data.remove(key);
         }
       }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEvent.java
@@ -10,6 +10,7 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachmen
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
 import com.sap.cds.feature.attachments.handler.applicationservice.transaction.ListenerProvider;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.model.service.AttachmentModificationResult;
 import com.sap.cds.feature.attachments.service.model.service.CreateAttachmentInput;
@@ -47,7 +48,7 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
       InputStream content,
       Attachments attachment,
       EventContext eventContext,
-      Optional<String> inlinePrefix) {
+      AttachmentFieldResolver resolver) {
     logger.debug(
         "Calling attachment service with create event for entity {}",
         path.target().entity().getQualifiedName());
@@ -55,9 +56,9 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
     Map<String, Object> keys = ApplicationHandlerHelper.removeDraftKey(path.target().keys());
 
     Optional<String> mimeTypeOptional =
-        getFieldValue(MediaData.MIME_TYPE, values, attachment, inlinePrefix);
+        getFieldValue(MediaData.MIME_TYPE, values, attachment, resolver);
     Optional<String> fileNameOptional =
-        getFieldValue(MediaData.FILE_NAME, values, attachment, inlinePrefix);
+        getFieldValue(MediaData.FILE_NAME, values, attachment, resolver);
 
     CreateAttachmentInput createEventInput =
         new CreateAttachmentInput(
@@ -66,23 +67,16 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
             fileNameOptional.orElse(null),
             mimeTypeOptional.orElse(null),
             content,
-            inlinePrefix);
+            resolver);
     AttachmentModificationResult result = attachmentService.createAttachment(createEventInput);
     ChangeSetListener createListener =
         listenerProvider.provideListener(result.contentId(), eventContext.getCdsRuntime());
 
     eventContext.getChangeSetContext().register(createListener);
-    // Set contentId and status using correct field names (prefixed for inline)
-    String contentIdField =
-        inlinePrefix.map(p -> p + "_" + Attachments.CONTENT_ID).orElse(Attachments.CONTENT_ID);
-    String statusField =
-        inlinePrefix.map(p -> p + "_" + Attachments.STATUS).orElse(Attachments.STATUS);
-    path.target().values().put(contentIdField, result.contentId());
-    path.target().values().put(statusField, result.status());
+    path.target().values().put(resolver.contentId(), result.contentId());
+    path.target().values().put(resolver.status(), result.status());
     if (nonNull(result.scannedAt())) {
-      String scannedAtField =
-          inlinePrefix.map(p -> p + "_" + Attachments.SCANNED_AT).orElse(Attachments.SCANNED_AT);
-      path.target().values().put(scannedAtField, result.scannedAt());
+      path.target().values().put(resolver.scannedAt(), result.scannedAt());
     }
     return result.isInternalStored() ? content : null;
   }
@@ -91,10 +85,10 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
       String fieldName,
       Map<String, Object> values,
       Attachments attachment,
-      Optional<String> inlinePrefix) {
+      AttachmentFieldResolver resolver) {
     // Try prefixed field name first (for inline types)
-    if (inlinePrefix.isPresent()) {
-      Object prefixedValue = values.get(inlinePrefix.get() + "_" + fieldName);
+    if (resolver.isInline()) {
+      Object prefixedValue = values.get(resolver.resolve(fieldName));
       if (nonNull(prefixedValue)) return Optional.of((String) prefixedValue);
     }
     // Fall back to direct field name

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/DoNothingAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/DoNothingAttachmentEvent.java
@@ -4,10 +4,10 @@
 package com.sap.cds.feature.attachments.handler.applicationservice.modifyevents;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.services.EventContext;
 import java.io.InputStream;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +25,7 @@ public class DoNothingAttachmentEvent implements ModifyAttachmentEvent {
       InputStream content,
       Attachments attachment,
       EventContext eventContext,
-      Optional<String> inlinePrefix) {
+      AttachmentFieldResolver resolver) {
     logger.debug("Do nothing event for entity {}", path.target().entity().getQualifiedName());
 
     return content;

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/MarkAsDeletedAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/MarkAsDeletedAttachmentEvent.java
@@ -7,14 +7,13 @@ import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
-import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.services.EventContext;
 import com.sap.cds.services.draft.DraftService;
 import java.io.InputStream;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +38,7 @@ public class MarkAsDeletedAttachmentEvent implements ModifyAttachmentEvent {
       InputStream content,
       Attachments attachment,
       EventContext eventContext,
-      Optional<String> inlinePrefix) {
+      AttachmentFieldResolver resolver) {
     String qualifiedName = eventContext.getTarget().getQualifiedName();
     logger.debug(
         "Processing the event for calling attachment service with mark as delete event for entity {}",
@@ -57,33 +56,23 @@ public class MarkAsDeletedAttachmentEvent implements ModifyAttachmentEvent {
           qualifiedName);
     }
     if (nonNull(path)) {
-      String contentIdField = resolveField(Attachments.CONTENT_ID, inlinePrefix);
-      String statusField = resolveField(Attachments.STATUS, inlinePrefix);
-      String scannedAtField = resolveField(Attachments.SCANNED_AT, inlinePrefix);
-      String mimeTypeField = resolveField(MediaData.MIME_TYPE, inlinePrefix);
-      String fileNameField = resolveField(MediaData.FILE_NAME, inlinePrefix);
-
-      String newContentId = (String) path.target().values().get(contentIdField);
+      String newContentId = (String) path.target().values().get(resolver.contentId());
       if (nonNull(newContentId) && newContentId.equals(attachment.getContentId())
-          || !path.target().values().containsKey(contentIdField)) {
-        path.target().values().put(contentIdField, null);
-        path.target().values().put(statusField, null);
-        path.target().values().put(scannedAtField, null);
+          || !path.target().values().containsKey(resolver.contentId())) {
+        path.target().values().put(resolver.contentId(), null);
+        path.target().values().put(resolver.status(), null);
+        path.target().values().put(resolver.scannedAt(), null);
         // For inline attachments, also clear mimeType/fileName on the parent entity.
         // For composition-based attachments these live on the attachment entity itself and must NOT
         // be cleared here.
         // Otherwise UpdateAttachmentEvent's delete step would destroy them before the subsequent
         // create step can use them.
-        if (inlinePrefix.isPresent()) {
-          path.target().values().put(mimeTypeField, null);
-          path.target().values().put(fileNameField, null);
+        if (resolver.isInline()) {
+          path.target().values().put(resolver.mimeType(), null);
+          path.target().values().put(resolver.fileName(), null);
         }
       }
     }
     return content;
-  }
-
-  private static String resolveField(String fieldName, Optional<String> inlinePrefix) {
-    return inlinePrefix.map(p -> p + "_" + fieldName).orElse(fieldName);
   }
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEvent.java
@@ -4,11 +4,11 @@
 package com.sap.cds.feature.attachments.handler.applicationservice.modifyevents;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.services.EventContext;
 import java.io.InputStream;
-import java.util.Optional;
 
 /**
  * The interface {@link ModifyAttachmentEvent} provides a method to process an event on the {@link
@@ -23,8 +23,7 @@ public interface ModifyAttachmentEvent {
    * @param content the content of the attachment
    * @param attachment existing attachment data
    * @param eventContext the current event context
-   * @param inlinePrefix the inline attachment field prefix (e.g. "coverImage"), or empty for
-   *     composition-based attachments
+   * @param resolver resolves field names for composition-based or inline attachments
    * @return the processed content
    */
   InputStream processEvent(
@@ -32,5 +31,5 @@ public interface ModifyAttachmentEvent {
       InputStream content,
       Attachments attachment,
       EventContext eventContext,
-      Optional<String> inlinePrefix);
+      AttachmentFieldResolver resolver);
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/UpdateAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/UpdateAttachmentEvent.java
@@ -6,11 +6,11 @@ package com.sap.cds.feature.attachments.handler.applicationservice.modifyevents;
 import static java.util.Objects.requireNonNull;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.services.EventContext;
 import java.io.InputStream;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,12 +39,12 @@ public class UpdateAttachmentEvent implements ModifyAttachmentEvent {
       InputStream content,
       Attachments attachment,
       EventContext eventContext,
-      Optional<String> inlinePrefix) {
+      AttachmentFieldResolver resolver) {
     logger.debug(
         "Processing UPDATE event by calling attachment service with create and delete event for entity {}",
         path.target().entity().getQualifiedName());
 
-    deleteEvent.processEvent(path, content, attachment, eventContext, inlinePrefix);
-    return createEvent.processEvent(path, content, attachment, eventContext, inlinePrefix);
+    deleteEvent.processEvent(path, content, attachment, eventContext, resolver);
+    return createEvent.processEvent(path, content, attachment, eventContext, resolver);
   }
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AttachmentFieldResolver.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AttachmentFieldResolver.java
@@ -1,0 +1,56 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.handler.common;
+
+import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
+import java.util.Optional;
+
+/**
+ * Resolves attachment field names for both composition-based and inline attachment types. For
+ * inline attachments, field names are prefixed (e.g., "profilePicture_contentId"). For
+ * composition-based attachments, field names are used directly (e.g., "contentId").
+ */
+public record AttachmentFieldResolver(Optional<String> inlinePrefix) {
+
+  /** Resolver for composition-based (non-inline) attachments. */
+  public static final AttachmentFieldResolver DIRECT =
+      new AttachmentFieldResolver(Optional.empty());
+
+  public static AttachmentFieldResolver of(Optional<String> inlinePrefix) {
+    return inlinePrefix.isEmpty() ? DIRECT : new AttachmentFieldResolver(inlinePrefix);
+  }
+
+  public boolean isInline() {
+    return inlinePrefix.isPresent();
+  }
+
+  public String contentId() {
+    return resolve(Attachments.CONTENT_ID);
+  }
+
+  public String status() {
+    return resolve(Attachments.STATUS);
+  }
+
+  public String scannedAt() {
+    return resolve(Attachments.SCANNED_AT);
+  }
+
+  public String content() {
+    return resolve(MediaData.CONTENT);
+  }
+
+  public String mimeType() {
+    return resolve(MediaData.MIME_TYPE);
+  }
+
+  public String fileName() {
+    return resolve(MediaData.FILE_NAME);
+  }
+
+  public String resolve(String fieldName) {
+    return inlinePrefix.map(p -> p + "_" + fieldName).orElse(fieldName);
+  }
+}

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
@@ -12,6 +12,7 @@ import com.sap.cds.CdsDataProcessor.Validator;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.cqn.CqnDelete;
@@ -100,12 +101,13 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
   private Validator buildDeleteContentValidator(
       DraftCancelEventContext context, List<? extends CdsData> activeCondensedAttachments) {
     return (path, element, value) -> {
-      Optional<String> inlinePrefix =
-          ApplicationHandlerHelper.getInlineAttachmentPrefix(
-              path.target().entity(), element.getName());
+      AttachmentFieldResolver resolver =
+          AttachmentFieldResolver.of(
+              ApplicationHandlerHelper.getInlineAttachmentPrefix(
+                  path.target().entity(), element.getName()));
       Attachments attachment = Attachments.of(path.target().values());
       if (Boolean.FALSE.equals(attachment.get(Drafts.HAS_ACTIVE_ENTITY))) {
-        deleteEvent.processEvent(path, null, attachment, context, inlinePrefix);
+        deleteEvent.processEvent(path, null, attachment, context, resolver);
         return;
       }
       Map<String, Object> keys = ApplicationHandlerHelper.removeDraftKey(path.target().keys());
@@ -116,7 +118,7 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
       existingEntry.ifPresent(
           entry -> {
             if (!entry.get(Attachments.CONTENT_ID).equals(value)) {
-              deleteEvent.processEvent(null, null, attachment, context, inlinePrefix);
+              deleteEvent.processEvent(null, null, attachment, context, resolver);
             }
           });
     };

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandler.java
@@ -13,6 +13,7 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachmen
 import com.sap.cds.feature.attachments.handler.applicationservice.helper.ModifyApplicationHandlerHelper;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEventFactory;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.ql.Select;
 import com.sap.cds.ql.cqn.CqnSelect;
 import com.sap.cds.reflect.CdsEntity;
@@ -26,7 +27,6 @@ import com.sap.cds.services.persistence.PersistenceService;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,10 +67,11 @@ public class DraftPatchAttachmentsHandler implements EventHandler {
           Result result = persistence.run(select);
 
           List<Attachments> existingAttachments;
-          Optional<String> inlinePrefix =
-              ApplicationHandlerHelper.getInlineAttachmentPrefix(
-                  path.target().entity(), element.getName());
-          if (inlinePrefix.isPresent()) {
+          AttachmentFieldResolver resolver =
+              AttachmentFieldResolver.of(
+                  ApplicationHandlerHelper.getInlineAttachmentPrefix(
+                      path.target().entity(), element.getName()));
+          if (resolver.isInline()) {
             // For inline attachments, the DB result has flattened column names (e.g.
             // profileIcon_contentId).
             // Extract to unprefixed Attachments and carry over parent entity keys for matching.
@@ -81,7 +82,7 @@ public class DraftPatchAttachmentsHandler implements EventHandler {
                         raw -> {
                           Attachments extracted =
                               ApplicationHandlerHelper.extractInlineAttachment(
-                                  raw, inlinePrefix.get());
+                                  raw, resolver.inlinePrefix().get());
                           parentKeys.forEach(extracted::putIfAbsent);
                           return extracted;
                         })
@@ -97,7 +98,7 @@ public class DraftPatchAttachmentsHandler implements EventHandler {
               path,
               (InputStream) value,
               defaultMaxSize,
-              inlinePrefix);
+              resolver);
         };
 
     CdsDataProcessor.create()

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/AttachmentsServiceImpl.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/AttachmentsServiceImpl.java
@@ -50,7 +50,10 @@ public class AttachmentsServiceImpl extends ServiceDelegator implements Attachme
     mediaData.setMimeType(input.mimeType());
     mediaData.setContent(input.content());
     createContext.setData(mediaData);
-    input.inlinePrefix().ifPresent(prefix -> createContext.put("attachment.inlinePrefix", prefix));
+    input
+        .resolver()
+        .inlinePrefix()
+        .ifPresent(prefix -> createContext.put("attachment.inlinePrefix", prefix));
 
     emit(createContext);
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/DefaultAttachmentsServiceHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/DefaultAttachmentsServiceHandler.java
@@ -5,6 +5,7 @@ package com.sap.cds.feature.attachments.service.handler;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.StatusCode;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.handler.transaction.EndTransactionMalwareScanProvider;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
@@ -68,10 +69,10 @@ public class DefaultAttachmentsServiceHandler implements EventHandler {
   @After
   void afterCreateAttachment(AttachmentCreateEventContext context) {
     String prefix = (String) context.get("attachment.inlinePrefix");
-    Optional<String> inlinePrefix = Optional.ofNullable(prefix);
+    AttachmentFieldResolver resolver = AttachmentFieldResolver.of(Optional.ofNullable(prefix));
     ChangeSetListener listener =
         malwareScanProvider.getChangeSetListener(
-            context.getAttachmentEntity(), context.getContentId(), inlinePrefix);
+            context.getAttachmentEntity(), context.getContentId(), resolver);
     context.getChangeSetContext().register(listener);
   }
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/transaction/EndTransactionMalwareScanProvider.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/transaction/EndTransactionMalwareScanProvider.java
@@ -3,9 +3,9 @@
  */
 package com.sap.cds.feature.attachments.service.handler.transaction;
 
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.services.changeset.ChangeSetListener;
-import java.util.Optional;
 
 /**
  * This interface provides a {@link ChangeSetListener} for the malware scan after the transaction is
@@ -18,10 +18,9 @@ public interface EndTransactionMalwareScanProvider {
    *
    * @param attachmentEntity The entity containing the attachment to scan
    * @param contentId The ID of the attachment content
-   * @param inlinePrefix For inline attachments, the field name prefix; empty for composition-based
-   *     attachments
+   * @param resolver resolves field names for composition-based or inline attachments
    * @return The {@link ChangeSetListener} for the malware scan after the transaction is completed
    */
   ChangeSetListener getChangeSetListener(
-      CdsEntity attachmentEntity, String contentId, Optional<String> inlinePrefix);
+      CdsEntity attachmentEntity, String contentId, AttachmentFieldResolver resolver);
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/transaction/EndTransactionMalwareScanRunner.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/transaction/EndTransactionMalwareScanRunner.java
@@ -3,6 +3,7 @@
  */
 package com.sap.cds.feature.attachments.service.handler.transaction;
 
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.service.malware.AsyncMalwareScanExecutor;
 import com.sap.cds.feature.attachments.service.malware.AttachmentMalwareScanner;
 import com.sap.cds.reflect.CdsEntity;
@@ -23,14 +24,14 @@ import org.slf4j.LoggerFactory;
  *
  * @param attachmentEntity The attachment entity to be scanned
  * @param contentId The content ID of the attachment
- * @param inlinePrefix For inline attachments, the field name prefix; empty for composition-based
+ * @param resolver resolves field names for composition-based or inline attachments
  * @param attachmentMalwareScanner The attachment malware scanner to be used for scanning
  * @param runtime The runtime instance to be used for creating the request context
  */
 public record EndTransactionMalwareScanRunner(
     CdsEntity attachmentEntity,
     String contentId,
-    Optional<String> inlinePrefix,
+    AttachmentFieldResolver resolver,
     AttachmentMalwareScanner attachmentMalwareScanner,
     CdsRuntime runtime)
     implements ChangeSetListener, AsyncMalwareScanExecutor {
@@ -41,18 +42,18 @@ public record EndTransactionMalwareScanRunner(
   @Override
   public void afterClose(boolean completed) {
     if (completed) {
-      startScanning(attachmentEntity, contentId, inlinePrefix);
+      startScanning(attachmentEntity, contentId, resolver);
     }
   }
 
   @Override
   public void scanAsync(
       CdsEntity attachmentEntity, String contentId, Optional<String> inlinePrefix) {
-    startScanning(attachmentEntity, contentId, inlinePrefix);
+    startScanning(attachmentEntity, contentId, AttachmentFieldResolver.of(inlinePrefix));
   }
 
   private void startScanning(
-      CdsEntity attachmentEntityToScan, String contentId, Optional<String> prefix) {
+      CdsEntity attachmentEntityToScan, String contentId, AttachmentFieldResolver fieldResolver) {
     // get current request context
     RequestContextRunner runner = runtime.requestContext();
 
@@ -76,7 +77,7 @@ public record EndTransactionMalwareScanRunner(
                               contentId,
                               attachmentEntityToScan.getQualifiedName());
                           attachmentMalwareScanner.scanAttachment(
-                              attachmentEntityToScan, contentId, prefix);
+                              attachmentEntityToScan, contentId, fieldResolver);
                         });
               });
           return null;

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/AttachmentMalwareScanner.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/AttachmentMalwareScanner.java
@@ -3,9 +3,9 @@
  */
 package com.sap.cds.feature.attachments.service.malware;
 
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.services.ServiceException;
-import java.util.Optional;
 
 /**
  * The {@link AttachmentMalwareScanner} is the connection to the malware scan service. It reads the
@@ -19,9 +19,9 @@ public interface AttachmentMalwareScanner {
    *
    * @param attachmentEntity The entity containing the attachment to scan
    * @param contentId The content id of the attachment entity
-   * @param inlinePrefix For inline attachments, the field name prefix (e.g. "profileIcon"); empty
-   *     for composition-based attachments
+   * @param resolver resolves field names for composition-based or inline attachments
    * @throws ServiceException Exception to be thrown in case of errors during scanning the content
    */
-  void scanAttachment(CdsEntity attachmentEntity, String contentId, Optional<String> inlinePrefix);
+  void scanAttachment(
+      CdsEntity attachmentEntity, String contentId, AttachmentFieldResolver resolver);
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/DefaultAttachmentMalwareScanner.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/DefaultAttachmentMalwareScanner.java
@@ -9,6 +9,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.sap.cds.Result;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.StatusCode;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.client.MalwareScanClient;
 import com.sap.cds.feature.attachments.service.malware.client.MalwareScanResultStatus;
@@ -25,7 +26,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,16 +69,15 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
 
   @Override
   public void scanAttachment(
-      CdsEntity attachmentEntity, String contentId, Optional<String> inlinePrefix) {
+      CdsEntity attachmentEntity, String contentId, AttachmentFieldResolver resolver) {
     logger.debug(
         "Started scanning attachment {} of entity {}.",
         contentId,
         attachmentEntity.getQualifiedName());
 
-    List<SelectionResult> selectionResults = selectData(attachmentEntity, contentId, inlinePrefix);
+    List<SelectionResult> selectionResults = selectData(attachmentEntity, contentId, resolver);
 
-    MalwareScanResultStatus status =
-        findAndScanAttachments(selectionResults, contentId, inlinePrefix);
+    MalwareScanResultStatus status = findAndScanAttachments(selectionResults, contentId, resolver);
 
     if (status == null) {
       logger.debug("Attachment {} not found in any entity, skipping update.", contentId);
@@ -88,16 +87,16 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
     // Update ALL candidate entities. This ensures the scan result is persisted
     // even if the attachment moved between draft and active tables during the scan.
     for (SelectionResult result : selectionResults) {
-      updateData(result.entity(), contentId, status, inlinePrefix);
+      updateData(result.entity(), contentId, status, resolver);
     }
   }
 
   private MalwareScanResultStatus findAndScanAttachments(
-      List<SelectionResult> selectionResults, String contentId, Optional<String> inlinePrefix) {
+      List<SelectionResult> selectionResults, String contentId, AttachmentFieldResolver resolver) {
     return selectionResults.stream()
         .filter(result -> validateAndFilter(result, contentId))
         .findFirst()
-        .map(result -> scanDocument(extractAttachment(result.result(), inlinePrefix)))
+        .map(result -> scanDocument(extractAttachment(result.result(), resolver)))
         .orElse(null);
   }
 
@@ -123,50 +122,43 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
     return true;
   }
 
-  private Attachments extractAttachment(Result queryResult, Optional<String> inlinePrefix) {
-    if (inlinePrefix.isEmpty()) {
+  private Attachments extractAttachment(Result queryResult, AttachmentFieldResolver resolver) {
+    if (!resolver.isInline()) {
       return queryResult.single(Attachments.class);
     }
-    String prefix = inlinePrefix.get() + "_";
     var row = queryResult.single();
     Attachments attachment = Attachments.create();
-    attachment.setContentId((String) row.get(prefix + Attachments.CONTENT_ID));
-    attachment.setContent((InputStream) row.get(prefix + Attachments.CONTENT));
-    attachment.setStatus((String) row.get(prefix + Attachments.STATUS));
+    attachment.setContentId((String) row.get(resolver.contentId()));
+    attachment.setContent((InputStream) row.get(resolver.content()));
+    attachment.setStatus((String) row.get(resolver.status()));
     return attachment;
   }
 
-  @VisibleForTesting
-  static String resolveColumn(String fieldName, Optional<String> inlinePrefix) {
-    return inlinePrefix.map(p -> p + "_" + fieldName).orElse(fieldName);
-  }
-
   private List<SelectionResult> selectData(
-      CdsEntity attachmentEntity, String contentId, Optional<String> inlinePrefix) {
+      CdsEntity attachmentEntity, String contentId, AttachmentFieldResolver resolver) {
     List<SelectionResult> result = new ArrayList<>();
     try {
       CdsEntity entity = (CdsEntity) attachmentEntity.getTargetOf(Drafts.SIBLING_ENTITY);
-      Result selectionResult = readData(contentId, entity, inlinePrefix);
+      Result selectionResult = readData(contentId, entity, resolver);
       result.add(new SelectionResult(entity, selectionResult));
     } catch (CdsElementNotFoundException ignored) {
       // no sibling found nothing to select
     }
-    Result selectionResult = readData(contentId, attachmentEntity, inlinePrefix);
+    Result selectionResult = readData(contentId, attachmentEntity, resolver);
     result.add(new SelectionResult(attachmentEntity, selectionResult));
 
     return result;
   }
 
-  private Result readData(String contentId, CdsEntity entity, Optional<String> inlinePrefix) {
-    String contentIdCol = resolveColumn(Attachments.CONTENT_ID, inlinePrefix);
-    String contentCol = resolveColumn(Attachments.CONTENT, inlinePrefix);
-    String statusCol = resolveColumn(Attachments.STATUS, inlinePrefix);
-
+  private Result readData(String contentId, CdsEntity entity, AttachmentFieldResolver resolver) {
     CqnSelect select =
         Select.from(entity)
-            .columns(contentIdCol, contentCol, statusCol)
+            .columns(resolver.contentId(), resolver.content(), resolver.status())
             .where(
-                e -> e.get(contentIdCol).eq(contentId).and(e.get(statusCol).ne(StatusCode.CLEAN)));
+                e ->
+                    e.get(resolver.contentId())
+                        .eq(contentId)
+                        .and(e.get(resolver.status()).ne(StatusCode.CLEAN)));
 
     Result result = persistenceService.run(select);
     result.stream()
@@ -174,9 +166,9 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
             row ->
                 logger.debug(
                     "Found attachment {} in entity {} with status {}.",
-                    row.get(contentIdCol),
+                    row.get(resolver.contentId()),
                     entity.getQualifiedName(),
-                    row.get(statusCol)));
+                    row.get(resolver.status())));
     return result;
   }
 
@@ -201,22 +193,18 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
       CdsEntity attachmentEntity,
       String contentId,
       MalwareScanResultStatus status,
-      Optional<String> inlinePrefix) {
-    String contentIdCol = resolveColumn(Attachments.CONTENT_ID, inlinePrefix);
-    String statusCol = resolveColumn(Attachments.STATUS, inlinePrefix);
-    String scannedAtCol = resolveColumn(Attachments.SCANNED_AT, inlinePrefix);
-
+      AttachmentFieldResolver resolver) {
     String mappedStatus = mapStatus(status);
     Instant scannedAt = Instant.now();
 
     Attachments updateData = Attachments.create();
-    updateData.put(statusCol, mappedStatus);
-    updateData.put(scannedAtCol, scannedAt);
+    updateData.put(resolver.status(), mappedStatus);
+    updateData.put(resolver.scannedAt(), scannedAt);
 
     CqnUpdate update =
         Update.entity(attachmentEntity)
             .data(updateData)
-            .where(entry -> entry.get(contentIdCol).eq(contentId));
+            .where(entry -> entry.get(resolver.contentId()).eq(contentId));
     Result result = persistenceService.run(update);
 
     logger.debug(

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/model/service/CreateAttachmentInput.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/model/service/CreateAttachmentInput.java
@@ -3,10 +3,10 @@
  */
 package com.sap.cds.feature.attachments.service.model.service;
 
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.reflect.CdsEntity;
 import java.io.InputStream;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * The class {@link CreateAttachmentInput} is used to store the input for creating an attachment.
@@ -16,7 +16,7 @@ import java.util.Optional;
  * @param fileName The file name of the content
  * @param mimeType The mime type of the content
  * @param content The input stream of the content
- * @param inlinePrefix For inline attachments, the field name prefix; empty for composition-based
+ * @param resolver resolves field names for composition-based or inline attachments
  */
 public record CreateAttachmentInput(
     Map<String, Object> attachmentIds,
@@ -24,4 +24,4 @@ public record CreateAttachmentInput(
     String fileName,
     String mimeType,
     InputStream content,
-    Optional<String> inlinePrefix) {}
+    AttachmentFieldResolver resolver) {}

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelperTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelperTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEventFactory;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.ql.cqn.ResolvedSegment;
@@ -96,7 +97,7 @@ class ModifyApplicationHandlerHelperTest {
                     path,
                     attachment.getContent(),
                     ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER,
-                    Optional.empty()));
+                    AttachmentFieldResolver.DIRECT));
 
     assertThat(exception.getErrorStatus()).isEqualTo(ExtendedErrorStatuses.CONTENT_TOO_LARGE);
   }
@@ -151,7 +152,7 @@ class ModifyApplicationHandlerHelperTest {
                     path,
                     content,
                     ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER,
-                    Optional.empty()));
+                    AttachmentFieldResolver.DIRECT));
 
     assertThat(exception.getErrorStatus()).isEqualTo(ExtendedErrorStatuses.CONTENT_TOO_LARGE);
   }
@@ -184,7 +185,7 @@ class ModifyApplicationHandlerHelperTest {
                 path,
                 content,
                 ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER,
-                Optional.empty()));
+                AttachmentFieldResolver.DIRECT));
   }
 
   @Test
@@ -217,7 +218,7 @@ class ModifyApplicationHandlerHelperTest {
                     path,
                     content,
                     ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER,
-                    Optional.empty()));
+                    AttachmentFieldResolver.DIRECT));
 
     assertThat(exception.getErrorStatus()).isEqualTo(ErrorStatuses.BAD_REQUEST);
   }
@@ -249,7 +250,7 @@ class ModifyApplicationHandlerHelperTest {
         path,
         (InputStream) values.get("profilePicture_content"),
         ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER,
-        Optional.of("profilePicture"));
+        AttachmentFieldResolver.of(Optional.of("profilePicture")));
 
     // Verify eventFactory was called with the resolved contentId
     verify(eventFactory).getEvent(any(), eq("existing-doc-77"), any());

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEventTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEventTest.java
@@ -13,6 +13,7 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachmen
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
 import com.sap.cds.feature.attachments.handler.applicationservice.transaction.ListenerProvider;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.model.service.AttachmentModificationResult;
@@ -101,7 +102,8 @@ class CreateAttachmentEventTest {
     existingData.setFileName("some file name");
     existingData.setMimeType("some mime type");
 
-    cut.processEvent(path, attachment.getContent(), existingData, eventContext, Optional.empty());
+    cut.processEvent(
+        path, attachment.getContent(), existingData, eventContext, AttachmentFieldResolver.DIRECT);
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     var createInput = contextArgumentCaptor.getValue();
@@ -125,7 +127,11 @@ class CreateAttachmentEventTest {
     when(target.values()).thenReturn(attachment);
 
     cut.processEvent(
-        path, attachment.getContent(), Attachments.create(), eventContext, Optional.empty());
+        path,
+        attachment.getContent(),
+        Attachments.create(),
+        eventContext,
+        AttachmentFieldResolver.DIRECT);
 
     assertThat(attachment.getContentId()).isEqualTo(attachmentServiceResult.contentId());
     assertThat(attachment.getStatus()).isEqualTo(attachmentServiceResult.status());
@@ -141,7 +147,8 @@ class CreateAttachmentEventTest {
     when(attachmentService.createAttachment(any()))
         .thenReturn(new AttachmentModificationResult(false, contentId, "test", null));
 
-    cut.processEvent(path, null, Attachments.create(), eventContext, Optional.empty());
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, AttachmentFieldResolver.DIRECT);
 
     verify(changeSetContext).register(listener);
   }
@@ -163,7 +170,11 @@ class CreateAttachmentEventTest {
 
     var result =
         cut.processEvent(
-            path, attachment.getContent(), Attachments.create(), eventContext, Optional.empty());
+            path,
+            attachment.getContent(),
+            Attachments.create(),
+            eventContext,
+            AttachmentFieldResolver.DIRECT);
 
     var expectedContent = isExternalStored ? attachment.getContent() : null;
     assertThat(result).isEqualTo(expectedContent);
@@ -183,7 +194,11 @@ class CreateAttachmentEventTest {
         .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
 
     cut.processEvent(
-        path, attachment.getContent(), Attachments.create(), eventContext, Optional.empty());
+        path,
+        attachment.getContent(),
+        Attachments.create(),
+        eventContext,
+        AttachmentFieldResolver.DIRECT);
     return attachment;
   }
 
@@ -209,7 +224,11 @@ class CreateAttachmentEventTest {
         .thenReturn(new AttachmentModificationResult(false, "doc-123", "Clean", null));
 
     cut.processEvent(
-        path, content, Attachments.create(), eventContext, Optional.of("profilePicture"));
+        path,
+        content,
+        Attachments.create(),
+        eventContext,
+        AttachmentFieldResolver.of(Optional.of("profilePicture")));
 
     assertThat(values).containsEntry("profilePicture_contentId", "doc-123");
     assertThat(values).containsEntry("profilePicture_status", "Clean");
@@ -233,7 +252,11 @@ class CreateAttachmentEventTest {
         .thenReturn(new AttachmentModificationResult(false, "id", "ok", null));
 
     cut.processEvent(
-        path, content, Attachments.create(), eventContext, Optional.of("profilePicture"));
+        path,
+        content,
+        Attachments.create(),
+        eventContext,
+        AttachmentFieldResolver.of(Optional.of("profilePicture")));
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     var input = contextArgumentCaptor.getValue();
@@ -262,7 +285,12 @@ class CreateAttachmentEventTest {
     existingData.setFileName("fallback.txt");
     existingData.setMimeType("text/plain");
 
-    cut.processEvent(path, content, existingData, eventContext, Optional.of("profilePicture"));
+    cut.processEvent(
+        path,
+        content,
+        existingData,
+        eventContext,
+        AttachmentFieldResolver.of(Optional.of("profilePicture")));
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     var input = contextArgumentCaptor.getValue();
@@ -287,7 +315,8 @@ class CreateAttachmentEventTest {
     when(attachmentService.createAttachment(any()))
         .thenReturn(new AttachmentModificationResult(false, "doc-999", "ok", null));
 
-    cut.processEvent(path, content, Attachments.create(), eventContext, Optional.empty());
+    cut.processEvent(
+        path, content, Attachments.create(), eventContext, AttachmentFieldResolver.DIRECT);
 
     // Fields written with unprefixed names
     assertThat(values).containsEntry(Attachments.CONTENT_ID, "doc-999");
@@ -313,7 +342,11 @@ class CreateAttachmentEventTest {
         .thenReturn(new AttachmentModificationResult(false, "doc-scan", "Clean", scannedAt));
 
     cut.processEvent(
-        path, content, Attachments.create(), eventContext, Optional.of("profilePicture"));
+        path,
+        content,
+        Attachments.create(),
+        eventContext,
+        AttachmentFieldResolver.of(Optional.of("profilePicture")));
 
     assertThat(values).containsEntry("profilePicture_contentId", "doc-scan");
     assertThat(values).containsEntry("profilePicture_status", "Clean");

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/DoNothingAttachmentEventTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/DoNothingAttachmentEventTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.ql.cqn.ResolvedSegment;
 import com.sap.cds.reflect.CdsElement;
@@ -17,7 +18,6 @@ import com.sap.cds.services.EventContext;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
@@ -51,7 +51,8 @@ class DoNothingAttachmentEventTest {
     when(entity.getQualifiedName()).thenReturn("some.qualified.name");
 
     var result =
-        cut.processEvent(path, streamInput, data, mock(EventContext.class), Optional.empty());
+        cut.processEvent(
+            path, streamInput, data, mock(EventContext.class), AttachmentFieldResolver.DIRECT);
 
     assertThat(result).isEqualTo(streamInput);
     verifyNoInteractions(element, data);

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/MarkAsDeletedAttachmentEventTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/MarkAsDeletedAttachmentEventTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
@@ -69,7 +70,8 @@ class MarkAsDeletedAttachmentEventTest {
     var data = Attachments.create();
     data.setContentId(contentId);
 
-    var expectedValue = cut.processEvent(path, value, data, context, Optional.empty());
+    var expectedValue =
+        cut.processEvent(path, value, data, context, AttachmentFieldResolver.DIRECT);
 
     assertThat(expectedValue).isEqualTo(value);
     assertThat(data.getContentId()).isEqualTo(contentId);
@@ -90,7 +92,8 @@ class MarkAsDeletedAttachmentEventTest {
     var value = new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8));
     var data = Attachments.create();
 
-    var expectedValue = cut.processEvent(path, value, data, context, Optional.empty());
+    var expectedValue =
+        cut.processEvent(path, value, data, context, AttachmentFieldResolver.DIRECT);
 
     assertThat(expectedValue).isEqualTo(value);
     assertThat(data.getContentId()).isNull();
@@ -109,7 +112,8 @@ class MarkAsDeletedAttachmentEventTest {
     data.setContentId(contentId);
     when(context.getEvent()).thenReturn(DraftService.EVENT_DRAFT_PATCH);
 
-    var expectedValue = cut.processEvent(path, value, data, context, Optional.empty());
+    var expectedValue =
+        cut.processEvent(path, value, data, context, AttachmentFieldResolver.DIRECT);
 
     assertThat(expectedValue).isEqualTo(value);
     assertThat(data.getContentId()).isEqualTo(contentId);
@@ -127,7 +131,8 @@ class MarkAsDeletedAttachmentEventTest {
     var data = Attachments.create();
     data.setContentId(contentId);
 
-    var expectedValue = cut.processEvent(null, value, data, context, Optional.empty());
+    var expectedValue =
+        cut.processEvent(null, value, data, context, AttachmentFieldResolver.DIRECT);
 
     assertThat(expectedValue).isEqualTo(value);
     // Attachment service should still be called to mark as deleted
@@ -148,7 +153,8 @@ class MarkAsDeletedAttachmentEventTest {
     // Set a different contentId in the path values
     currentData.put(Attachments.CONTENT_ID, newContentId);
 
-    var expectedValue = cut.processEvent(path, value, data, context, Optional.empty());
+    var expectedValue =
+        cut.processEvent(path, value, data, context, AttachmentFieldResolver.DIRECT);
 
     assertThat(expectedValue).isEqualTo(value);
     // Attachment service should be called to mark old content as deleted
@@ -181,7 +187,8 @@ class MarkAsDeletedAttachmentEventTest {
     data.setContentId("old-content-id");
     when(context.getEvent()).thenReturn(DraftService.EVENT_DRAFT_PATCH);
 
-    cut.processEvent(path, null, data, context, Optional.of("profilePicture"));
+    cut.processEvent(
+        path, null, data, context, AttachmentFieldResolver.of(Optional.of("profilePicture")));
 
     // All prefixed fields should be cleared
     assertThat(values)
@@ -209,7 +216,8 @@ class MarkAsDeletedAttachmentEventTest {
     var data = Attachments.create();
     data.setContentId("old-content-id");
 
-    cut.processEvent(path, null, data, context, Optional.of("profilePicture"));
+    cut.processEvent(
+        path, null, data, context, AttachmentFieldResolver.of(Optional.of("profilePicture")));
 
     // contentId differs from attachment's contentId, so fields should NOT be cleared
     assertThat(values).containsEntry("profilePicture_contentId", "different-new-content-id");

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/UpdateAttachmentEventTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/UpdateAttachmentEventTest.java
@@ -8,12 +8,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.ql.cqn.ResolvedSegment;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.services.EventContext;
 import java.io.InputStream;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,11 +45,14 @@ class UpdateAttachmentEventTest {
     var existingData = Attachments.create();
     var eventContext = mock(EventContext.class);
 
-    cut.processEvent(path, testContentStream, existingData, eventContext, Optional.empty());
+    cut.processEvent(
+        path, testContentStream, existingData, eventContext, AttachmentFieldResolver.DIRECT);
 
     verify(createEvent)
-        .processEvent(path, testContentStream, existingData, eventContext, Optional.empty());
+        .processEvent(
+            path, testContentStream, existingData, eventContext, AttachmentFieldResolver.DIRECT);
     verify(deleteEvent)
-        .processEvent(path, testContentStream, existingData, eventContext, Optional.empty());
+        .processEvent(
+            path, testContentStream, existingData, eventContext, AttachmentFieldResolver.DIRECT);
   }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/AttachmentsServiceImplTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/AttachmentsServiceImplTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.service.model.service.CreateAttachmentInput;
 import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
@@ -99,7 +100,12 @@ class AttachmentsServiceImplTest {
     Map<String, Object> ids = Map.of("ID1", "value1", "id2", "Value2");
     var input =
         new CreateAttachmentInput(
-            ids, mock(CdsEntity.class), "fileName", "mimeType", stream, Optional.empty());
+            ids,
+            mock(CdsEntity.class),
+            "fileName",
+            "mimeType",
+            stream,
+            AttachmentFieldResolver.DIRECT);
 
     var result = cut.createAttachment(input);
 
@@ -132,7 +138,7 @@ class AttachmentsServiceImplTest {
             "fileName",
             "mimeType",
             mock(InputStream.class),
-            Optional.empty());
+            AttachmentFieldResolver.DIRECT);
 
     var result = cut.createAttachment(input);
 
@@ -160,7 +166,7 @@ class AttachmentsServiceImplTest {
             "fileName",
             "mimeType",
             mock(InputStream.class),
-            Optional.of("profileIcon"));
+            AttachmentFieldResolver.of(Optional.of("profileIcon")));
 
     cut.createAttachment(input);
 
@@ -189,7 +195,7 @@ class AttachmentsServiceImplTest {
             "fileName",
             "mimeType",
             mock(InputStream.class),
-            Optional.empty());
+            AttachmentFieldResolver.DIRECT);
 
     cut.createAttachment(input);
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/AttachmentsServiceImplHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/AttachmentsServiceImplHandlerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.StatusCode;
 import com.sap.cds.feature.attachments.generated.test.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.handler.transaction.EndTransactionMalwareScanProvider;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
@@ -151,7 +152,8 @@ class AttachmentsServiceImplHandlerTest {
   void malwareScannerRegisteredForEndOfTransaction() {
     var listener = mock(ChangeSetListener.class);
     var entity = mock(CdsEntity.class);
-    when(malwareScanProvider.getChangeSetListener(entity, "contentId", Optional.empty()))
+    when(malwareScanProvider.getChangeSetListener(
+            entity, "contentId", AttachmentFieldResolver.DIRECT))
         .thenReturn(listener);
     var createContext = AttachmentCreateEventContext.create();
     createContext.setAttachmentIds(Map.of(Attachments.ID, "contentId"));
@@ -162,14 +164,16 @@ class AttachmentsServiceImplHandlerTest {
     cut.createAttachment(createContext);
     cut.afterCreateAttachment(createContext);
 
-    verify(malwareScanProvider).getChangeSetListener(entity, "contentId", Optional.empty());
+    verify(malwareScanProvider)
+        .getChangeSetListener(entity, "contentId", AttachmentFieldResolver.DIRECT);
   }
 
   @Test
   void malwareScannerRegisteredWithInlinePrefixFromContext() {
     var listener = mock(ChangeSetListener.class);
     var entity = mock(CdsEntity.class);
-    when(malwareScanProvider.getChangeSetListener(entity, "contentId", Optional.of("profileIcon")))
+    when(malwareScanProvider.getChangeSetListener(
+            entity, "contentId", AttachmentFieldResolver.of(Optional.of("profileIcon"))))
         .thenReturn(listener);
     var createContext = AttachmentCreateEventContext.create();
     createContext.setAttachmentIds(Map.of(Attachments.ID, "contentId"));
@@ -182,7 +186,8 @@ class AttachmentsServiceImplHandlerTest {
     cut.afterCreateAttachment(createContext);
 
     verify(malwareScanProvider)
-        .getChangeSetListener(entity, "contentId", Optional.of("profileIcon"));
+        .getChangeSetListener(
+            entity, "contentId", AttachmentFieldResolver.of(Optional.of("profileIcon")));
   }
 
   private void closeChangeSetContext() throws Exception {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/transaction/EndTransactionMalwareScanRunnerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/transaction/EndTransactionMalwareScanRunnerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.helper.LogObserver;
 import com.sap.cds.feature.attachments.service.malware.AttachmentMalwareScanner;
 import com.sap.cds.reflect.CdsEntity;
@@ -71,7 +72,11 @@ class EndTransactionMalwareScanRunnerTest {
     attachmentMalwareScanner = mock(AttachmentMalwareScanner.class);
     cut =
         new EndTransactionMalwareScanRunner(
-            attachmentEntity, contentId, Optional.empty(), attachmentMalwareScanner, runtime);
+            attachmentEntity,
+            contentId,
+            AttachmentFieldResolver.DIRECT,
+            attachmentMalwareScanner,
+            runtime);
     observer = LogObserver.create(cut.getClass().getName());
   }
 
@@ -89,7 +94,7 @@ class EndTransactionMalwareScanRunnerTest {
               return null;
             })
         .when(attachmentMalwareScanner)
-        .scanAttachment(attachmentEntity, contentId, Optional.empty());
+        .scanAttachment(attachmentEntity, contentId, AttachmentFieldResolver.DIRECT);
 
     cut.afterClose(false);
 
@@ -112,12 +117,13 @@ class EndTransactionMalwareScanRunnerTest {
               return null;
             })
         .when(attachmentMalwareScanner)
-        .scanAttachment(attachmentEntity, contentId, Optional.empty());
+        .scanAttachment(attachmentEntity, contentId, AttachmentFieldResolver.DIRECT);
 
     cut.afterClose(true);
 
     Awaitility.await().until(executionDone::get);
-    verify(attachmentMalwareScanner).scanAttachment(attachmentEntity, contentId, Optional.empty());
+    verify(attachmentMalwareScanner)
+        .scanAttachment(attachmentEntity, contentId, AttachmentFieldResolver.DIRECT);
     assertThat(usedThread.get()).isNotEmpty().isNotEqualTo(Thread.currentThread().getName());
   }
 
@@ -128,7 +134,7 @@ class EndTransactionMalwareScanRunnerTest {
               throw new RuntimeException("Some exception");
             })
         .when(attachmentMalwareScanner)
-        .scanAttachment(attachmentEntity, contentId, Optional.empty());
+        .scanAttachment(attachmentEntity, contentId, AttachmentFieldResolver.DIRECT);
     observer.start();
 
     cut.afterClose(true);
@@ -147,12 +153,13 @@ class EndTransactionMalwareScanRunnerTest {
               return null;
             })
         .when(attachmentMalwareScanner)
-        .scanAttachment(attachmentEntity, contentId, Optional.empty());
+        .scanAttachment(attachmentEntity, contentId, AttachmentFieldResolver.DIRECT);
 
     cut.scanAsync(attachmentEntity, contentId, Optional.empty());
 
     Awaitility.await().until(executionDone::get);
-    verify(attachmentMalwareScanner).scanAttachment(attachmentEntity, contentId, Optional.empty());
+    verify(attachmentMalwareScanner)
+        .scanAttachment(attachmentEntity, contentId, AttachmentFieldResolver.DIRECT);
     assertThat(usedThread.get()).isNotEmpty().isNotEqualTo(Thread.currentThread().getName());
   }
 
@@ -163,7 +170,7 @@ class EndTransactionMalwareScanRunnerTest {
               throw new RuntimeException("Some exception");
             })
         .when(attachmentMalwareScanner)
-        .scanAttachment(attachmentEntity, contentId, Optional.empty());
+        .scanAttachment(attachmentEntity, contentId, AttachmentFieldResolver.DIRECT);
     observer.start();
 
     cut.scanAsync(attachmentEntity, contentId, Optional.empty());

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/DefaultAttachmentMalwareScannerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/DefaultAttachmentMalwareScannerTest.java
@@ -17,6 +17,7 @@ import com.sap.cds.Result;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.StatusCode;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Attachment_;
+import com.sap.cds.feature.attachments.handler.common.AttachmentFieldResolver;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.client.MalwareScanClient;
@@ -72,7 +73,7 @@ class DefaultAttachmentMalwareScannerTest {
     var entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME);
     when(persistenceService.run(any(CqnSelect.class))).thenReturn(result);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", AttachmentFieldResolver.DIRECT);
 
     verify(persistenceService).run(selectCaptor.capture());
     var select = selectCaptor.getValue();
@@ -85,7 +86,7 @@ class DefaultAttachmentMalwareScannerTest {
     var entity = runtime.getCdsModel().findEntity(getTestServiceAttachmentName());
     mockSelectResult(Attachments.create(), MalwareScanResultStatus.CLEAN);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", AttachmentFieldResolver.DIRECT);
 
     verify(persistenceService, times(2)).run(selectCaptor.capture());
     var selects = selectCaptor.getAllValues();
@@ -111,7 +112,7 @@ class DefaultAttachmentMalwareScannerTest {
     when(result.single(Attachments.class)).thenReturn(cdsData);
     when(malwareScanClient.scanContent(any())).thenReturn(MalwareScanResultStatus.CLEAN);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", AttachmentFieldResolver.DIRECT);
 
     verify(malwareScanClient).scanContent(content);
     verify(persistenceService, times(2)).run(selectCaptor.capture());
@@ -131,7 +132,8 @@ class DefaultAttachmentMalwareScannerTest {
     when(result.rowCount()).thenReturn(2L);
 
     assertThrows(
-        IllegalStateException.class, () -> cut.scanAttachment(entity, "", Optional.empty()));
+        IllegalStateException.class,
+        () -> cut.scanAttachment(entity, "", AttachmentFieldResolver.DIRECT));
   }
 
   @ParameterizedTest
@@ -140,7 +142,7 @@ class DefaultAttachmentMalwareScannerTest {
     var entity = runtime.getCdsModel().findEntity(getTestServiceAttachmentName());
     mockSelectResult(Attachments.create(), status);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", AttachmentFieldResolver.DIRECT);
 
     verifyPersistenceServiceCalledCorrectlyForReadAndUpdate(status);
   }
@@ -154,7 +156,7 @@ class DefaultAttachmentMalwareScannerTest {
     when(malwareScanClient.scanContent(any()))
         .thenThrow(new ServiceException("Error reading attachment"));
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", AttachmentFieldResolver.DIRECT);
 
     verifyPersistenceServiceCalledCorrectlyForReadAndUpdate(MalwareScanResultStatus.FAILED);
   }
@@ -168,7 +170,7 @@ class DefaultAttachmentMalwareScannerTest {
     when(attachmentService.readAttachment(any()))
         .thenThrow(new ServiceException("Error reading attachment"));
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", AttachmentFieldResolver.DIRECT);
 
     verifyPersistenceServiceCalledCorrectlyForReadAndUpdate(MalwareScanResultStatus.FAILED);
   }
@@ -181,7 +183,7 @@ class DefaultAttachmentMalwareScannerTest {
     data.put("content", content);
     mockSelectResult(data, MalwareScanResultStatus.CLEAN);
 
-    cut.scanAttachment(entity.orElseThrow(), "", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "", AttachmentFieldResolver.DIRECT);
 
     verify(malwareScanClient, times(1)).scanContent(content);
     verifyNoInteractions(attachmentService);
@@ -197,7 +199,7 @@ class DefaultAttachmentMalwareScannerTest {
     var content = mock(InputStream.class);
     when(attachmentService.readAttachment(contentId)).thenReturn(content);
 
-    cut.scanAttachment(entity.orElseThrow(), "", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "", AttachmentFieldResolver.DIRECT);
 
     verify(attachmentService, times(1)).readAttachment(contentId);
     verify(malwareScanClient, times(1)).scanContent(content);
@@ -213,7 +215,7 @@ class DefaultAttachmentMalwareScannerTest {
     var content = mock(InputStream.class);
     when(attachmentService.readAttachment(contentId)).thenReturn(content);
 
-    cut.scanAttachment(entity.orElseThrow(), "", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "", AttachmentFieldResolver.DIRECT);
 
     verify(attachmentService, times(1)).readAttachment(contentId);
     verify(malwareScanClient, times(1)).scanContent(content);
@@ -232,7 +234,7 @@ class DefaultAttachmentMalwareScannerTest {
         .thenReturn(Attachments.create());
     when(malwareScanClient.scanContent(any())).thenReturn(MalwareScanResultStatus.CLEAN);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", AttachmentFieldResolver.DIRECT);
 
     verify(persistenceService, times(2)).run(updateCaptor.capture());
     var updateList = updateCaptor.getAllValues();
@@ -251,7 +253,7 @@ class DefaultAttachmentMalwareScannerTest {
     when(result.rowCount()).thenReturn(1L);
     when(result.single(Attachments.class)).thenReturn(Attachments.create());
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", AttachmentFieldResolver.DIRECT);
 
     verifyNoInteractions(malwareScanClient);
     verify(persistenceService, times(2)).run(updateCaptor.capture());
@@ -286,7 +288,7 @@ class DefaultAttachmentMalwareScannerTest {
         .thenReturn(draftUpdateResult)
         .thenReturn(activeUpdateResult);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", AttachmentFieldResolver.DIRECT);
 
     // Scan should happen once from draft content
     verify(malwareScanClient).scanContent(content);
@@ -308,7 +310,7 @@ class DefaultAttachmentMalwareScannerTest {
     when(emptyResult.rowCount()).thenReturn(0L);
     when(persistenceService.run(any(CqnSelect.class))).thenReturn(emptyResult);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", AttachmentFieldResolver.DIRECT);
 
     verifyNoInteractions(malwareScanClient);
     verify(persistenceService, times(0)).run(any(CqnUpdate.class));
@@ -370,14 +372,13 @@ class DefaultAttachmentMalwareScannerTest {
 
   @Test
   void resolveColumnWithPrefixConcatenates() {
-    String result =
-        DefaultAttachmentMalwareScanner.resolveColumn("contentId", Optional.of("avatar"));
+    String result = AttachmentFieldResolver.of(Optional.of("avatar")).resolve("contentId");
     assertThat(result).isEqualTo("avatar_contentId");
   }
 
   @Test
   void resolveColumnWithoutPrefixReturnsFieldName() {
-    String result = DefaultAttachmentMalwareScanner.resolveColumn("contentId", Optional.empty());
+    String result = AttachmentFieldResolver.DIRECT.resolve("contentId");
     assertThat(result).isEqualTo("contentId");
   }
 }


### PR DESCRIPTION
## Summary
- Introduce `AttachmentFieldResolver` record to centralize field name resolution for both composition-based and inline (single) attachments
- Replace 3 duplicate `resolveField`/`resolveColumn` private helpers and 6+ inline `inlinePrefix.map(p -> p + "_" + field)` lambdas across ~20 source files with calls to the new resolver
- Update `ModifyAttachmentEvent` interface, `CreateAttachmentInput` record, `EndTransactionMalwareScanProvider`/`Runner`, and `AttachmentMalwareScanner` to accept `AttachmentFieldResolver` instead of `Optional<String> inlinePrefix`

## Test plan
- [x] All 869 existing tests pass (468 unit + 7 fs + 73 oss + 290 integration + 31 mt)
- [x] `mvn clean verify` passes with all quality gates (JaCoCo, Pitest, SpotBugs, PMD, Spotless)
- [x] Existing `resolveColumn` tests in `DefaultAttachmentMalwareScannerTest` migrated to use `AttachmentFieldResolver` directly
- [x] Inline attachment integration tests continue to pass (draft and non-draft scenarios)