### PR TITLE
Add inline attachment support for non-draft handlers

### DIFF
--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandler.java
@@ -59,5 +59,13 @@ public class DeleteAttachmentsHandler implements EventHandler {
     CdsDataProcessor.create()
         .addConverter(ApplicationHandlerHelper.MEDIA_CONTENT_FILTER, converter)
         .process(attachments, context.getTarget());
+
+    List<Attachments> inlineAttachments =
+        attachmentsReader.readInlineAttachments(context.getTarget(), context.getCqn());
+    for (Attachments inlineAttachment : inlineAttachments) {
+      if (inlineAttachment.getContentId() != null) {
+        deleteEvent.processEvent(null, null, inlineAttachment, context);
+      }
+    }
   }
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
@@ -15,6 +15,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.Att
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.BeforeReadItemsModifier;
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.LazyProxyInputStream;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.AsyncMalwareScanExecutor;
 import com.sap.cds.ql.CQL;
@@ -111,9 +112,10 @@ public class ReadAttachmentsHandler implements EventHandler {
   @After
   @HandlerOrder(HandlerOrder.EARLY)
   void processAfter(CdsReadEventContext context, List<CdsData> data) {
-    if (ApplicationHandlerHelper.containsContentField(context.getTarget(), data)) {
-      logger.debug(
-          "Processing after {} event for entity {}", context.getEvent(), context.getTarget());
+    CdsEntity target = context.getTarget();
+
+    if (ApplicationHandlerHelper.containsContentField(target, data)) {
+      logger.debug("Processing after {} event for entity {}", context.getEvent(), target);
 
       Converter converter =
           (path, element, value) -> {
@@ -133,7 +135,44 @@ public class ReadAttachmentsHandler implements EventHandler {
 
       CdsDataProcessor.create()
           .addConverter(ApplicationHandlerHelper.MEDIA_CONTENT_FILTER, converter)
-          .process(data, context.getTarget());
+          .process(data, target);
+    }
+
+    processInlineAfterRead(target, data);
+  }
+
+  private void processInlineAfterRead(CdsEntity target, List<CdsData> data) {
+    List<String> inlinePrefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(target);
+    if (inlinePrefixes.isEmpty()) {
+      return;
+    }
+
+    logger.debug("Processing inline attachments for entity {}", target.getQualifiedName());
+
+    for (CdsData row : data) {
+      for (String prefix : inlinePrefixes) {
+        String contentField = InlineAttachmentHelper.buildInlineFieldName(prefix, "content");
+        String contentIdField =
+            InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.CONTENT_ID);
+        String statusField =
+            InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.STATUS);
+
+        if (!row.containsKey(contentField)) {
+          continue;
+        }
+
+        Object contentValue = row.get(contentField);
+        String contentId = (String) row.get(contentIdField);
+        String status = (String) row.get(statusField);
+
+        if (nonNull(contentId)) {
+          Supplier<InputStream> supplier =
+              nonNull(contentValue) && contentValue instanceof InputStream existingContent
+                  ? () -> existingContent
+                  : () -> attachmentService.readAttachment(contentId);
+          row.put(contentField, new LazyProxyInputStream(supplier, statusValidator, status));
+        }
+      }
     }
   }
 
@@ -142,6 +181,11 @@ public class ReadAttachmentsHandler implements EventHandler {
     List<String> associationNames = new ArrayList<>();
     if (ApplicationHandlerHelper.isMediaEntity(entity)) {
       associationNames.add(associationName);
+    }
+
+    List<String> inlinePrefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+    for (String prefix : inlinePrefixes) {
+      associationNames.add(BeforeReadItemsModifier.INLINE_PREFIX + prefix);
     }
 
     Map<String, CdsEntity> annotatedEntities =

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandler.java
@@ -87,9 +87,13 @@ public class UpdateAttachmentsHandler implements EventHandler {
       CqnSelect select = CqnUtils.toSelect(context.getCqn(), context.getTarget());
       List<Attachments> attachments =
           attachmentsReader.readAttachments(context.getModel(), target, select);
+      List<Attachments> inlineAttachments = attachmentsReader.readInlineAttachments(target, select);
+
+      List<Attachments> allAttachments = new java.util.ArrayList<>(attachments);
+      allAttachments.addAll(inlineAttachments);
 
       ModifyApplicationHandlerHelper.handleAttachmentForEntities(
-          target, data, attachments, eventFactory, context, defaultMaxSize);
+          target, data, allAttachments, eventFactory, context, defaultMaxSize);
 
       if (!associationsAreUnchanged) {
         deleteRemovedAttachments(attachments, data, target, context.getUserInfo());

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
@@ -11,6 +11,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.M
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEventFactory;
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.CountingInputStream;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.reflect.CdsAnnotation;
 import com.sap.cds.reflect.CdsEntity;
@@ -63,6 +64,83 @@ public final class ModifyApplicationHandlerHelper {
     CdsDataProcessor.create()
         .addConverter(ApplicationHandlerHelper.MEDIA_CONTENT_FILTER, converter)
         .process(data, entity);
+
+    handleInlineAttachments(
+        entity, data, existingAttachments, eventFactory, eventContext, defaultMaxSize);
+  }
+
+  private static void handleInlineAttachments(
+      CdsEntity entity,
+      List<CdsData> data,
+      List<Attachments> existingAttachments,
+      ModifyAttachmentEventFactory eventFactory,
+      EventContext eventContext,
+      String defaultMaxSize) {
+    List<String> inlinePrefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+    if (inlinePrefixes.isEmpty()) {
+      return;
+    }
+
+    for (CdsData row : data) {
+      for (String prefix : inlinePrefixes) {
+        String contentField = InlineAttachmentHelper.buildInlineFieldName(prefix, "content");
+        if (!row.containsKey(contentField)) {
+          continue;
+        }
+        Object contentValue = row.get(contentField);
+        InputStream content = contentValue instanceof InputStream is ? is : null;
+        String contentIdField =
+            InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.CONTENT_ID);
+        String contentId = (String) row.get(contentIdField);
+
+        Attachments existingAttachment =
+            findExistingInlineAttachment(entity, row, existingAttachments);
+
+        String contentLength = eventContext.getParameterInfo().getHeader("Content-Length");
+        String maxSizeStr = defaultMaxSize;
+        eventContext.put("attachment.MaxSize", maxSizeStr);
+        ServiceException tooLargeException =
+            new ServiceException(
+                ExtendedErrorStatuses.CONTENT_TOO_LARGE,
+                "File size exceeds the limit of {}.",
+                maxSizeStr);
+
+        if (contentLength != null) {
+          try {
+            if (Long.parseLong(contentLength) > FileSizeUtils.parseFileSizeToBytes(maxSizeStr)) {
+              throw tooLargeException;
+            }
+          } catch (NumberFormatException e) {
+            throw new ServiceException(ErrorStatuses.BAD_REQUEST, "Invalid Content-Length header");
+          }
+        }
+
+        CountingInputStream wrappedContent =
+            content != null ? new CountingInputStream(content, maxSizeStr) : null;
+        ModifyAttachmentEvent eventToProcess =
+            eventFactory.getEvent(wrappedContent, contentId, existingAttachment);
+        try {
+          InputStream result =
+              eventToProcess.processEvent(null, wrappedContent, existingAttachment, eventContext);
+          row.put(contentField, result);
+        } catch (Exception e) {
+          if (wrappedContent != null && wrappedContent.isLimitExceeded()) {
+            throw tooLargeException;
+          }
+          throw e;
+        }
+      }
+    }
+  }
+
+  private static Attachments findExistingInlineAttachment(
+      CdsEntity entity, CdsData row, List<Attachments> existingAttachments) {
+    Map<String, Object> keys = ApplicationHandlerHelper.extractKeys(row, entity);
+    Map<String, Object> cleanKeys = ApplicationHandlerHelper.removeDraftKey(keys);
+    return existingAttachments.stream()
+        .filter(existing -> ApplicationHandlerHelper.areKeysInData(cleanKeys, existing))
+        .findAny()
+        .orElse(Attachments.create());
   }
 
   /**

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/readhelper/BeforeReadItemsModifier.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/readhelper/BeforeReadItemsModifier.java
@@ -1,10 +1,11 @@
 /*
- * © 2024-2025 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
  */
 package com.sap.cds.feature.attachments.handler.applicationservice.readhelper;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
 import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.Expand;
 import com.sap.cds.ql.cqn.CqnSelectListItem;
@@ -24,6 +25,13 @@ public class BeforeReadItemsModifier implements Modifier {
 
   private static final String ROOT_ASSOCIATION = "";
 
+  /**
+   * Prefix used to mark inline attachment entries in the media associations list. Entries of the
+   * form {@code "inline:prefix"} indicate that the prefix refers to an inline (flattened)
+   * attachment field rather than a composition association.
+   */
+  public static final String INLINE_PREFIX = "inline:";
+
   private final List<String> mediaAssociations;
 
   public BeforeReadItemsModifier(List<String> mediaAssociations) {
@@ -36,6 +44,8 @@ public class BeforeReadItemsModifier implements Modifier {
         new ArrayList<>(items.stream().filter(item -> !item.isExpand()).toList());
     List<CqnSelectListItem> result = addContentIdItem(items);
     newItems.addAll(result);
+
+    enhanceWithInlineFields(items, newItems);
 
     return newItems;
   }
@@ -78,6 +88,34 @@ public class BeforeReadItemsModifier implements Modifier {
       listToEnhance.add(CQL.get(Attachments.CONTENT_ID));
       listToEnhance.add(CQL.get(Attachments.STATUS));
       listToEnhance.add(CQL.get(Attachments.SCANNED_AT));
+    }
+  }
+
+  private void enhanceWithInlineFields(
+      List<CqnSelectListItem> originalItems, List<CqnSelectListItem> newItems) {
+    for (String entry : mediaAssociations) {
+      if (!entry.startsWith(INLINE_PREFIX)) {
+        continue;
+      }
+      String prefix = entry.substring(INLINE_PREFIX.length());
+      String contentFieldName = InlineAttachmentHelper.buildInlineFieldName(prefix, "content");
+      String contentIdFieldName =
+          InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.CONTENT_ID);
+
+      boolean hasContentField =
+          originalItems.stream().anyMatch(item -> isItemRefFieldWithName(item, contentFieldName));
+      boolean hasContentIdField =
+          originalItems.stream().anyMatch(item -> isItemRefFieldWithName(item, contentIdFieldName));
+
+      if (hasContentField && !hasContentIdField) {
+        logger.debug("Adding inline attachment fields for prefix '{}' to select items", prefix);
+        newItems.add(
+            CQL.get(InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.CONTENT_ID)));
+        newItems.add(
+            CQL.get(InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.STATUS)));
+        newItems.add(
+            CQL.get(InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.SCANNED_AT)));
+      }
     }
   }
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/ApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/ApplicationHandlerHelper.java
@@ -37,7 +37,7 @@ public final class ApplicationHandlerHelper {
               && element.findAnnotation(ANNOTATION_CORE_MEDIA_TYPE).isPresent();
 
   /**
-   * Checks if the data contains a content field.
+   * Checks if the data contains a content field, including inline attachment content fields.
    *
    * @param entity The {@link CdsEntity entity} type of the given the data to check
    * @param data The data to check
@@ -48,7 +48,23 @@ public final class ApplicationHandlerHelper {
     CdsDataProcessor.create()
         .addValidator(MEDIA_CONTENT_FILTER, (path, element, value) -> isIncluded.set(true))
         .process(data, entity);
-    return isIncluded.get();
+    if (isIncluded.get()) {
+      return true;
+    }
+    return containsInlineContentField(entity, data);
+  }
+
+  /**
+   * Checks if the data contains any inline attachment content fields.
+   *
+   * @param entity the entity to inspect
+   * @param data the data to check
+   * @return {@code true} if inline content fields are present in the data
+   */
+  public static boolean containsInlineContentField(CdsEntity entity, List<? extends CdsData> data) {
+    List<String> inlineContentElements = InlineAttachmentHelper.findInlineContentElements(entity);
+    return inlineContentElements.stream()
+        .anyMatch(contentField -> data.stream().anyMatch(d -> d.containsKey(contentField)));
   }
 
   /**

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AssociationCascader.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AssociationCascader.java
@@ -28,6 +28,14 @@ public class AssociationCascader {
     NodeTree tree = findEntityPath(model, entity);
     List<String> result = new ArrayList<>();
     collect(model, tree, result);
+
+    if (InlineAttachmentHelper.hasInlineAttachments(entity)) {
+      String entityName = entity.getQualifiedName();
+      if (!result.contains(entityName)) {
+        result.add(entityName);
+      }
+    }
+
     return result;
   }
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AttachmentsReader.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AttachmentsReader.java
@@ -53,9 +53,28 @@ public class AttachmentsReader {
     statement.where().ifPresent(select::where);
 
     Result result = persistence.run(select);
-    List<Attachments> attachments = result.listOf(Attachments.class);
+    List<Attachments> attachments = new ArrayList<>(result.listOf(Attachments.class));
     logResultData(entity, attachments);
     return attachments;
+  }
+
+  /**
+   * Reads inline attachment state (contentId, status, scannedAt) from the database for entities
+   * that have inline attachment fields.
+   *
+   * @param entity the entity to query
+   * @param statement the filterable statement providing the entity ref and where clause
+   * @return a list of {@link Attachments} with unprefixed field names, or empty if no inline
+   *     attachments exist
+   */
+  public List<Attachments> readInlineAttachments(
+      CdsEntity entity, CqnFilterableStatement statement) {
+    List<String> inlinePrefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+    if (inlinePrefixes.isEmpty()) {
+      return List.of();
+    }
+    return InlineAttachmentHelper.readInlineAttachmentState(
+        persistence, entity, statement, inlinePrefixes);
   }
 
   private List<Expand<?>> buildExpandList(NodeTree root) {

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/InlineAttachmentHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/InlineAttachmentHelper.java
@@ -107,15 +107,8 @@ public final class InlineAttachmentHelper {
           entity.keyElements().forEach(key -> keys.put(key.getName(), row.get(key.getName())));
 
           for (String prefix : prefixes) {
-            Attachments att = Attachments.create();
+            Attachments att = toAttachments(row, prefix);
             att.putAll(keys);
-            att.setContentId(
-                (String) row.get(buildInlineFieldName(prefix, Attachments.CONTENT_ID)));
-            att.setStatus((String) row.get(buildInlineFieldName(prefix, Attachments.STATUS)));
-            Object scannedAt = row.get(buildInlineFieldName(prefix, Attachments.SCANNED_AT));
-            if (scannedAt instanceof java.time.Instant instant) {
-              att.setScannedAt(instant);
-            }
             attachments.add(att);
           }
         });
@@ -156,6 +149,29 @@ public final class InlineAttachmentHelper {
     return findInlineAttachmentPrefixes(entity).stream()
         .map(prefix -> buildInlineFieldName(prefix, "content"))
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Maps a row with prefixed inline attachment fields to an {@link Attachments} instance with
+   * unprefixed field names (contentId, status, scannedAt, content).
+   *
+   * @param row the source row containing prefixed fields
+   * @param prefix the inline attachment prefix (e.g. {@code "avatar"})
+   * @return an {@link Attachments} with unprefixed field names
+   */
+  public static Attachments toAttachments(Map<String, Object> row, String prefix) {
+    Attachments att = Attachments.create();
+    att.setContentId((String) row.get(buildInlineFieldName(prefix, Attachments.CONTENT_ID)));
+    att.setStatus((String) row.get(buildInlineFieldName(prefix, Attachments.STATUS)));
+    Object scannedAt = row.get(buildInlineFieldName(prefix, Attachments.SCANNED_AT));
+    if (scannedAt instanceof java.time.Instant instant) {
+      att.setScannedAt(instant);
+    }
+    Object content = row.get(buildInlineFieldName(prefix, Attachments.CONTENT));
+    if (content instanceof java.io.InputStream is) {
+      att.setContent(is);
+    }
+    return att;
   }
 
   private InlineAttachmentHelper() {

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/InlineAttachmentHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/InlineAttachmentHelper.java
@@ -1,0 +1,164 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.handler.common;
+
+import com.sap.cds.Result;
+import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.ql.CQL;
+import com.sap.cds.ql.Select;
+import com.sap.cds.ql.cqn.CqnFilterableStatement;
+import com.sap.cds.reflect.CdsEntity;
+import com.sap.cds.services.persistence.PersistenceService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for detecting and reading inline attachment fields. Inline attachments are
+ * structured type fields (e.g. {@code avatar : Attachment}) that get flattened by the CDS compiler
+ * into prefixed columns (e.g. {@code avatar_content}, {@code avatar_contentId}).
+ */
+public final class InlineAttachmentHelper {
+
+  private static final String ANNOTATION_IS_MEDIA_DATA = "_is_media_data";
+  private static final String ANNOTATION_CORE_MEDIA_TYPE = "Core.MediaType";
+  private static final String CONTENT_SUFFIX = "_content";
+
+  /**
+   * Finds the prefixes of inline attachment elements on the given entity. An inline attachment is
+   * identified by a flat element named {@code prefix_content} that carries both the
+   * {@code @_is_media_data} and {@code @Core.MediaType} annotations, where the entity itself is not
+   * a media entity (i.e. not annotated with {@code @_is_media_data}).
+   *
+   * @param entity the entity to inspect
+   * @return a list of inline attachment prefixes (e.g. {@code ["avatar", "profilePicture"]})
+   */
+  public static List<String> findInlineAttachmentPrefixes(CdsEntity entity) {
+    if (ApplicationHandlerHelper.isMediaEntity(entity)) {
+      return List.of();
+    }
+    List<String> prefixes = new ArrayList<>();
+    entity
+        .elements()
+        .forEach(
+            element -> {
+              String name = element.getName();
+              if (name.endsWith(CONTENT_SUFFIX)
+                  && element.getAnnotationValue(ANNOTATION_IS_MEDIA_DATA, false)
+                  && element.findAnnotation(ANNOTATION_CORE_MEDIA_TYPE).isPresent()) {
+                String prefix = name.substring(0, name.length() - CONTENT_SUFFIX.length());
+                prefixes.add(prefix);
+              }
+            });
+    return prefixes;
+  }
+
+  /**
+   * Returns whether the entity has any inline attachment elements.
+   *
+   * @param entity the entity to check
+   * @return {@code true} if inline attachment prefixes exist
+   */
+  public static boolean hasInlineAttachments(CdsEntity entity) {
+    return !findInlineAttachmentPrefixes(entity).isEmpty();
+  }
+
+  /**
+   * Reads the current state (contentId, status, scannedAt) of inline attachment fields from the
+   * database. The returned list contains one {@link Attachments} per inline attachment per row,
+   * with fields mapped to unprefixed names (e.g. {@code avatar_contentId} becomes {@code
+   * contentId}).
+   *
+   * @param persistence the persistence service
+   * @param entity the entity to query
+   * @param statement the filterable statement providing the entity ref and where clause
+   * @param prefixes the inline attachment prefixes to read
+   * @return a list of {@link Attachments} with unprefixed field names and entity keys
+   */
+  public static List<Attachments> readInlineAttachmentState(
+      PersistenceService persistence,
+      CdsEntity entity,
+      CqnFilterableStatement statement,
+      List<String> prefixes) {
+    if (prefixes.isEmpty()) {
+      return List.of();
+    }
+
+    List<com.sap.cds.ql.cqn.CqnSelectListItem> columns = new ArrayList<>();
+    entity.keyElements().forEach(key -> columns.add(CQL.get(key.getName())));
+    for (String prefix : prefixes) {
+      columns.add(CQL.get(buildInlineFieldName(prefix, Attachments.CONTENT_ID)));
+      columns.add(CQL.get(buildInlineFieldName(prefix, Attachments.STATUS)));
+      columns.add(CQL.get(buildInlineFieldName(prefix, Attachments.SCANNED_AT)));
+    }
+
+    Select<?> select = Select.from(statement.ref()).columns(columns);
+    statement.where().ifPresent(select::where);
+
+    Result result = persistence.run(select);
+
+    List<Attachments> attachments = new ArrayList<>();
+    result.forEach(
+        row -> {
+          Map<String, Object> keys = new HashMap<>();
+          entity.keyElements().forEach(key -> keys.put(key.getName(), row.get(key.getName())));
+
+          for (String prefix : prefixes) {
+            Attachments att = Attachments.create();
+            att.putAll(keys);
+            att.setContentId(
+                (String) row.get(buildInlineFieldName(prefix, Attachments.CONTENT_ID)));
+            att.setStatus((String) row.get(buildInlineFieldName(prefix, Attachments.STATUS)));
+            Object scannedAt = row.get(buildInlineFieldName(prefix, Attachments.SCANNED_AT));
+            if (scannedAt instanceof java.time.Instant instant) {
+              att.setScannedAt(instant);
+            }
+            attachments.add(att);
+          }
+        });
+
+    return attachments;
+  }
+
+  /**
+   * Builds a flattened inline field name from the element prefix and the field name.
+   *
+   * @param prefix the inline attachment prefix (e.g. {@code "avatar"})
+   * @param fieldName the attachment field name (e.g. {@code "contentId"})
+   * @return the combined name (e.g. {@code "avatar_contentId"})
+   */
+  public static String buildInlineFieldName(String prefix, String fieldName) {
+    return prefix + "_" + fieldName;
+  }
+
+  /**
+   * Extracts the inline attachment prefix from a flattened element name that ends with {@code
+   * _content}.
+   *
+   * @param elementName the flattened element name (e.g. {@code "avatar_content"})
+   * @return the prefix (e.g. {@code "avatar"})
+   */
+  static String extractPrefix(String elementName) {
+    return elementName.substring(0, elementName.length() - CONTENT_SUFFIX.length());
+  }
+
+  /**
+   * Returns the element names of all inline attachment content fields on the given entity, as
+   * identified by {@link #findInlineAttachmentPrefixes}.
+   *
+   * @param entity the entity to inspect
+   * @return element names like {@code ["avatar_content", "profilePicture_content"]}
+   */
+  public static List<String> findInlineContentElements(CdsEntity entity) {
+    return findInlineAttachmentPrefixes(entity).stream()
+        .map(prefix -> buildInlineFieldName(prefix, "content"))
+        .collect(Collectors.toList());
+  }
+
+  private InlineAttachmentHelper() {
+    // avoid instantiation
+  }
+}

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
@@ -13,6 +13,7 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachmen
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
 import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.cqn.CqnDelete;
 import com.sap.cds.reflect.CdsAssociationType;
@@ -77,6 +78,8 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
       CdsDataProcessor.create()
           .addValidator(contentIdFilter, validator)
           .process(draftAttachments, context.getTarget());
+
+      handleInlineDraftCancel(context, draftEntity, activeEntity);
     } else {
       logger.debug(
           "Skipping processing before {} event for entity {}",
@@ -122,6 +125,10 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
       return true;
     }
 
+    if (InlineAttachmentHelper.hasInlineAttachments(entity)) {
+      return true;
+    }
+
     return entity
         .compositions()
         .map(element -> element.getType().as(CdsAssociationType.class))
@@ -146,5 +153,37 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
       DraftCancelEventContext context, CdsStructuredType activeEntity) {
     List<Attachments> attachments = readAttachments(context, activeEntity, true);
     return ApplicationHandlerHelper.condenseAttachments(attachments, context.getTarget());
+  }
+
+  private void handleInlineDraftCancel(
+      DraftCancelEventContext context, CdsEntity draftEntity, CdsEntity activeEntity) {
+    List<String> prefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(draftEntity);
+    if (prefixes.isEmpty()) {
+      return;
+    }
+
+    CqnDelete draftCqn =
+        CQL.copy(
+            context.getCqn(), new ModifierToCreateFlatCQN(false, draftEntity.getQualifiedName()));
+    List<Attachments> draftInline = attachmentsReader.readInlineAttachments(draftEntity, draftCqn);
+
+    CqnDelete activeCqn =
+        CQL.copy(
+            context.getCqn(), new ModifierToCreateFlatCQN(true, activeEntity.getQualifiedName()));
+    List<Attachments> activeInline =
+        attachmentsReader.readInlineAttachments(activeEntity, activeCqn);
+
+    for (Attachments draftAtt : draftInline) {
+      String draftContentId = draftAtt.getContentId();
+      if (draftContentId == null) {
+        continue;
+      }
+
+      Optional<Attachments> activeMatch =
+          activeInline.stream().filter(a -> draftContentId.equals(a.getContentId())).findAny();
+      if (activeMatch.isEmpty()) {
+        deleteEvent.processEvent(null, null, draftAtt, context);
+      }
+    }
   }
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandler.java
@@ -11,8 +11,11 @@ import com.sap.cds.CdsDataProcessor.Converter;
 import com.sap.cds.Result;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.handler.applicationservice.helper.ModifyApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEventFactory;
+import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.CountingInputStream;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
 import com.sap.cds.ql.Select;
 import com.sap.cds.ql.cqn.CqnSelect;
 import com.sap.cds.reflect.CdsEntity;
@@ -25,6 +28,7 @@ import com.sap.cds.services.handler.annotations.ServiceName;
 import com.sap.cds.services.persistence.PersistenceService;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,5 +79,52 @@ public class DraftPatchAttachmentsHandler implements EventHandler {
     CdsDataProcessor.create()
         .addConverter(ApplicationHandlerHelper.MEDIA_CONTENT_FILTER, converter)
         .process(data, context.getTarget());
+
+    handleInlineDraftPatch(context, data);
+  }
+
+  private void handleInlineDraftPatch(
+      DraftPatchEventContext context, List<? extends CdsData> data) {
+    CdsEntity entity = context.getTarget();
+    List<String> inlinePrefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+    if (inlinePrefixes.isEmpty()) {
+      return;
+    }
+
+    CdsEntity draftEntity = DraftUtils.getDraftEntity(entity);
+
+    for (CdsData row : data) {
+      for (String prefix : inlinePrefixes) {
+        String contentField = InlineAttachmentHelper.buildInlineFieldName(prefix, "content");
+        if (!row.containsKey(contentField)) {
+          continue;
+        }
+
+        Object contentValue = row.get(contentField);
+        InputStream content = contentValue instanceof InputStream is ? is : null;
+
+        Map<String, Object> keys = ApplicationHandlerHelper.extractKeys(row, entity);
+        CqnSelect select = Select.from(draftEntity).matching(keys);
+        Result result = persistence.run(select);
+
+        Attachments existingAttachment =
+            result.first().isPresent()
+                ? readExistingInlineState(result, prefix)
+                : Attachments.create();
+
+        CountingInputStream wrappedContent =
+            content != null ? new CountingInputStream(content, defaultMaxSize) : null;
+        ModifyAttachmentEvent eventToProcess =
+            eventFactory.getEvent(
+                wrappedContent, existingAttachment.getContentId(), existingAttachment);
+        InputStream processed =
+            eventToProcess.processEvent(null, wrappedContent, existingAttachment, context);
+        row.put(contentField, processed);
+      }
+    }
+  }
+
+  private static Attachments readExistingInlineState(Result result, String prefix) {
+    return InlineAttachmentHelper.toAttachments(result.single(), prefix);
   }
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/DefaultAttachmentMalwareScanner.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/DefaultAttachmentMalwareScanner.java
@@ -9,6 +9,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.sap.cds.Result;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.StatusCode;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.client.MalwareScanClient;
 import com.sap.cds.feature.attachments.service.malware.client.MalwareScanResultStatus;
@@ -23,7 +24,9 @@ import com.sap.cds.services.persistence.PersistenceService;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,9 +76,11 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
         contentId,
         attachmentEntity.getQualifiedName());
 
-    List<SelectionResult> selectionResults = selectData(attachmentEntity, contentId);
+    String inlinePrefix = findInlinePrefix(attachmentEntity);
+    List<SelectionResult> selectionResults = selectData(attachmentEntity, contentId, inlinePrefix);
 
-    MalwareScanResultStatus status = findAndScanAttachments(selectionResults, contentId);
+    MalwareScanResultStatus status =
+        findAndScanAttachments(selectionResults, contentId, inlinePrefix);
 
     if (status == null) {
       logger.debug("Attachment {} not found in any entity, skipping update.", contentId);
@@ -85,16 +90,23 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
     // Update ALL candidate entities. This ensures the scan result is persisted
     // even if the attachment moved between draft and active tables during the scan.
     for (SelectionResult result : selectionResults) {
-      updateData(result.entity, contentId, status);
+      updateData(result.entity, contentId, status, inlinePrefix);
     }
   }
 
   private MalwareScanResultStatus findAndScanAttachments(
-      List<SelectionResult> selectionResults, String contentId) {
+      List<SelectionResult> selectionResults, String contentId, String inlinePrefix) {
     return selectionResults.stream()
         .filter(result -> validateAndFilter(result, contentId))
         .findFirst()
-        .map(result -> scanDocument(result.result().single(Attachments.class), result.entity))
+        .map(
+            result -> {
+              Attachments attachment =
+                  inlinePrefix != null
+                      ? InlineAttachmentHelper.toAttachments(result.result().single(), inlinePrefix)
+                      : result.result().single(Attachments.class);
+              return scanDocument(attachment, result.entity);
+            })
         .orElse(null);
   }
 
@@ -120,41 +132,41 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
     return true;
   }
 
-  private List<SelectionResult> selectData(CdsEntity attachmentEntity, String contentId) {
+  private List<SelectionResult> selectData(
+      CdsEntity attachmentEntity, String contentId, String inlinePrefix) {
     List<SelectionResult> result = new ArrayList<>();
     try {
       CdsEntity entity = (CdsEntity) attachmentEntity.getTargetOf(Drafts.SIBLING_ENTITY);
-      Result selectionResult = readData(contentId, entity);
+      Result selectionResult = readData(contentId, entity, inlinePrefix);
       result.add(new SelectionResult(entity, selectionResult));
     } catch (CdsElementNotFoundException ignored) {
       // no sibling found nothing to select
     }
-    Result selectionResult = readData(contentId, attachmentEntity);
+    Result selectionResult = readData(contentId, attachmentEntity, inlinePrefix);
     result.add(new SelectionResult(attachmentEntity, selectionResult));
 
     return result;
   }
 
-  private Result readData(String contentId, CdsEntity entity) {
+  private Result readData(String contentId, CdsEntity entity, String inlinePrefix) {
+    String contentIdCol = fieldName(inlinePrefix, Attachments.CONTENT_ID);
+    String contentCol = fieldName(inlinePrefix, Attachments.CONTENT);
+    String statusCol = fieldName(inlinePrefix, Attachments.STATUS);
+
     CqnSelect select =
         Select.from(entity)
-            .columns(Attachments.CONTENT_ID, Attachments.CONTENT, Attachments.STATUS)
+            .columns(contentIdCol, contentCol, statusCol)
             .where(
-                e ->
-                    e.get(Attachments.CONTENT_ID)
-                        .eq(contentId)
-                        .and(e.get(Attachments.STATUS).ne(StatusCode.CLEAN)));
+                e -> e.get(contentIdCol).eq(contentId).and(e.get(statusCol).ne(StatusCode.CLEAN)));
 
     Result result = persistenceService.run(select);
-    result
-        .streamOf(Attachments.class)
-        .forEach(
-            attachment ->
-                logger.debug(
-                    "Found attachment {} in entity {} with status {}.",
-                    attachment.getContentId(),
-                    entity.getQualifiedName(),
-                    attachment.getStatus()));
+    result.forEach(
+        row ->
+            logger.debug(
+                "Found attachment {} in entity {} with status {}.",
+                row.get(contentIdCol),
+                entity.getQualifiedName(),
+                row.get(statusCol)));
     return result;
   }
 
@@ -180,20 +192,27 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
   }
 
   private void updateData(
-      CdsEntity attachmentEntity, String contentId, MalwareScanResultStatus status) {
-    Attachments updateData = Attachments.create();
-    updateData.setStatus(mapStatus(status));
-    updateData.setScannedAt(Instant.now());
+      CdsEntity attachmentEntity,
+      String contentId,
+      MalwareScanResultStatus status,
+      String inlinePrefix) {
+    String contentIdCol = fieldName(inlinePrefix, Attachments.CONTENT_ID);
+    String statusCol = fieldName(inlinePrefix, Attachments.STATUS);
+    String scannedAtCol = fieldName(inlinePrefix, Attachments.SCANNED_AT);
+
+    Map<String, Object> updateData = new HashMap<>();
+    updateData.put(statusCol, mapStatus(status));
+    updateData.put(scannedAtCol, Instant.now());
 
     CqnUpdate update =
         Update.entity(attachmentEntity)
             .data(updateData)
-            .where(entry -> entry.get(Attachments.CONTENT_ID).eq(contentId));
+            .where(entry -> entry.get(contentIdCol).eq(contentId));
     Result result = persistenceService.run(update);
 
     logger.debug(
         "Updated scan status to {} of attachment {} in entity {} -> Row count {}.",
-        updateData.getStatus(),
+        updateData.get(statusCol),
         contentId,
         attachmentEntity.getQualifiedName(),
         result.rowCount());
@@ -206,6 +225,24 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
       case INFECTED, ENCRYPTED -> StatusCode.INFECTED;
       default -> StatusCode.FAILED;
     };
+  }
+
+  /**
+   * Determines the inline attachment prefix for the entity, or {@code null} if the entity has a
+   * direct {@code contentId} element (composition case).
+   */
+  private static String findInlinePrefix(CdsEntity entity) {
+    if (entity.findElement(Attachments.CONTENT_ID).isPresent()) {
+      return null;
+    }
+    List<String> prefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+    return prefixes.isEmpty() ? null : prefixes.get(0);
+  }
+
+  private static String fieldName(String inlinePrefix, String field) {
+    return inlinePrefix != null
+        ? InlineAttachmentHelper.buildInlineFieldName(inlinePrefix, field)
+        : field;
   }
 
   private record SelectionResult(CdsEntity entity, Result result) {}

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
@@ -1,6 +1,7 @@
 using {
     sap.attachments.MediaData,
-    sap.attachments.Attachments
+    sap.attachments.Attachments,
+    sap.attachments.Attachment
 } from './attachments';
 
 annotate MediaData with @UI.MediaResource: {Stream: content} {
@@ -19,6 +20,26 @@ annotate MediaData with @UI.MediaResource: {Stream: content} {
         UI.MultiLineText
         );
     status    @(title: '{i18n>attachment_status}', Common.Text : statusNav.name, Common.TextArrangement : #TextOnly);
+    contentId @(UI.Hidden: true);
+    scannedAt @(UI.Hidden: true);
+}
+
+annotate Attachment with @UI.MediaResource: {Stream: content} {
+    content   @(
+        title                           : '{i18n>attachment_content}',
+        Core.MediaType                  : mimeType,
+        Core.ContentDisposition.Filename: fileName,
+        Core.ContentDisposition.Type    : 'inline'
+    );
+    mimeType  @(
+        title: '{i18n>attachment_mimeType}',
+        Core.IsMediaType
+    );
+    fileName  @(
+        title: '{i18n>attachment_fileName}',
+        UI.MultiLineText
+        );
+    status    @(title: '{i18n>attachment_status}');
     contentId @(UI.Hidden: true);
     scannedAt @(UI.Hidden: true);
 }

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
@@ -30,6 +30,15 @@ entity ScanStates : CodeList {
         criticality : Integer     @UI.Hidden;
 }
 
+type Attachment @(_is_media_data) {
+    content   : LargeBinary;
+    mimeType  : String;
+    fileName  : String(5000);
+    contentId : String     @readonly;
+    status    : StatusCode default 'Unscanned' @readonly;
+    scannedAt : Timestamp  @readonly;
+};
+
 aspect Attachments : cuid, managed, MediaData {
     note : String(5000);
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
@@ -22,6 +22,8 @@ import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Events;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Events_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
@@ -369,6 +371,110 @@ class CreateAttachmentsHandlerTest {
       helper.verify(
           () -> AttachmentValidationHelper.validateMediaAttachments(entity, data, runtime));
     }
+  }
+
+  @Test
+  void inlineAttachmentContentTriggersEventProcessing() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    var testStream = mock(InputStream.class);
+    row.setAvatarContent(testStream);
+    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
+
+    cut.processBefore(createContext, List.of(row));
+
+    ArgumentCaptor<InputStream> streamCaptor = ArgumentCaptor.forClass(InputStream.class);
+    verify(eventFactory).getEvent(streamCaptor.capture(), eq((String) null), any());
+    InputStream captured = streamCaptor.getValue();
+    assertThat(captured).isInstanceOf(CountingInputStream.class);
+    assertThat(((CountingInputStream) captured).getDelegate()).isSameAs(testStream);
+  }
+
+  @Test
+  void inlineAttachmentWithNoContentNoProcessing() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    row.setTitle("just a title");
+
+    cut.processBefore(createContext, List.of(row));
+
+    verifyNoInteractions(eventFactory);
+  }
+
+  @Test
+  void inlineAttachmentWithNullContentValueProcessed() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    row.put(InlineOnlyTable.AVATAR_CONTENT, null);
+    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
+
+    cut.processBefore(createContext, List.of(row));
+
+    verify(eventFactory).getEvent(eq(null), eq((String) null), any());
+  }
+
+  @Test
+  void inlineAttachmentContentLengthExceedsLimitThrows() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    row.setAvatarContent(mock(InputStream.class));
+    ParameterInfo paramInfo = mock(ParameterInfo.class);
+    when(paramInfo.getHeader("Content-Length")).thenReturn("999999999999");
+    when(createContext.getParameterInfo()).thenReturn(paramInfo);
+
+    List<CdsData> data = List.of(row);
+    assertThrows(ServiceException.class, () -> cut.processBefore(createContext, data));
+  }
+
+  @Test
+  void inlineAttachmentInvalidContentLengthThrows() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    row.setAvatarContent(mock(InputStream.class));
+    ParameterInfo paramInfo = mock(ParameterInfo.class);
+    when(paramInfo.getHeader("Content-Length")).thenReturn("not-a-number");
+    when(createContext.getParameterInfo()).thenReturn(paramInfo);
+
+    List<CdsData> data = List.of(row);
+    assertThrows(ServiceException.class, () -> cut.processBefore(createContext, data));
+  }
+
+  @Test
+  void inlineAttachmentLimitExceededDuringProcessingThrows() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    var testStream = mock(InputStream.class);
+    row.setAvatarContent(testStream);
+    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
+    when(event.processEvent(any(), any(), any(), any())).thenThrow(new RuntimeException("test"));
+
+    List<CdsData> data = List.of(row);
+    var exception =
+        assertThrows(RuntimeException.class, () -> cut.processBefore(createContext, data));
+    assertThat(exception.getMessage()).isEqualTo("test");
+  }
+
+  @Test
+  void inlineAttachmentContentLengthWithinLimitProcesses() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    var testStream = mock(InputStream.class);
+    row.setAvatarContent(testStream);
+    ParameterInfo paramInfo = mock(ParameterInfo.class);
+    when(paramInfo.getHeader("Content-Length")).thenReturn("100");
+    when(createContext.getParameterInfo()).thenReturn(paramInfo);
+    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
+
+    cut.processBefore(createContext, List.of(row));
+
+    verify(event).processEvent(any(), any(), any(), any());
   }
 
   private void getEntityAndMockContext(String cdsName) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandlerTest.java
@@ -17,6 +17,7 @@ import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Roots;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Roots_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
@@ -110,6 +111,37 @@ class DeleteAttachmentsHandlerTest {
             any(Path.class), eq(inputStream), eq(Attachments.of(attachment2)), eq(context));
     assertThat(attachment1.getContent()).isNull();
     assertThat(attachment2.getContent()).isNull();
+  }
+
+  @Test
+  void inlineAttachmentDataExistsServiceIsCalled() {
+    var entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    when(context.getTarget()).thenReturn(entity);
+    when(context.getModel()).thenReturn(runtime.getCdsModel());
+    var inlineAttachment = Attachments.create();
+    inlineAttachment.setContentId("inline-doc-id");
+    when(attachmentsReader.readInlineAttachments(entity, context.getCqn()))
+        .thenReturn(List.of(inlineAttachment));
+
+    cut.processBefore(context);
+
+    verify(modifyAttachmentEvent)
+        .processEvent(eq(null), eq(null), eq(inlineAttachment), eq(context));
+  }
+
+  @Test
+  void inlineAttachmentWithoutContentIdNotDeleted() {
+    var entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    when(context.getTarget()).thenReturn(entity);
+    when(context.getModel()).thenReturn(runtime.getCdsModel());
+    var inlineAttachment = Attachments.create();
+    // no contentId set
+    when(attachmentsReader.readInlineAttachments(entity, context.getCqn()))
+        .thenReturn(List.of(inlineAttachment));
+
+    cut.processBefore(context);
+
+    verifyNoInteractions(modifyAttachmentEvent);
   }
 
   private Attachment buildAttachment(String id, InputStream inputStream) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
@@ -19,6 +19,8 @@ import com.sap.cds.feature.attachments.generated.test.cds4j.sap.attachments.Atta
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.EventItems;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.EventItems_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
@@ -459,6 +461,95 @@ class ReadAttachmentsHandlerTest {
 
     verifyNoInteractions(asyncMalwareScanExecutor);
     verifyNoInteractions(persistenceService);
+  }
+
+  @Test
+  void fieldNamesCorrectReadForInlineOnlyEntity() {
+    var select = Select.from(InlineOnlyTable_.class).columns(InlineOnlyTable_::ID);
+    mockEventContext(InlineOnlyTable_.CDS_NAME, select);
+
+    cut.processBefore(readEventContext);
+  }
+
+  @Test
+  void inlineAttachmentContentWrappedWithLazyProxy() {
+    mockEventContext(InlineOnlyTable_.CDS_NAME, mock(CqnSelect.class));
+
+    var row = InlineOnlyTable.create();
+    row.setId(UUID.randomUUID().toString());
+    row.setAvatarContentId("inline-content-id");
+    row.setAvatarStatus(StatusCode.CLEAN);
+    row.setAvatarContent(null);
+
+    cut.processAfter(readEventContext, List.of(row));
+
+    assertThat(row.getAvatarContent()).isInstanceOf(LazyProxyInputStream.class);
+    verifyNoInteractions(attachmentService);
+  }
+
+  @Test
+  void inlineAttachmentWithoutContentIdNotWrapped() {
+    mockEventContext(InlineOnlyTable_.CDS_NAME, mock(CqnSelect.class));
+
+    var row = InlineOnlyTable.create();
+    row.setId(UUID.randomUUID().toString());
+    row.put(InlineOnlyTable.AVATAR_CONTENT, null);
+
+    cut.processAfter(readEventContext, List.of(row));
+
+    assertThat(row.getAvatarContent()).isNull();
+    verifyNoInteractions(attachmentService);
+  }
+
+  @Test
+  void inlineAttachmentWithExistingStreamIsWrapped() throws IOException {
+    var testString = "inline-test";
+    try (var testStream = new ByteArrayInputStream(testString.getBytes(StandardCharsets.UTF_8))) {
+      mockEventContext(InlineOnlyTable_.CDS_NAME, mock(CqnSelect.class));
+      when(attachmentService.readAttachment(any())).thenReturn(testStream);
+
+      var row = InlineOnlyTable.create();
+      row.setId(UUID.randomUUID().toString());
+      row.setAvatarContentId("inline-content-id");
+      row.setAvatarStatus(StatusCode.CLEAN);
+      row.setAvatarContent(testStream);
+
+      cut.processAfter(readEventContext, List.of(row));
+
+      assertThat(row.getAvatarContent()).isInstanceOf(LazyProxyInputStream.class);
+      verifyNoInteractions(attachmentService);
+      byte[] bytes = row.getAvatarContent().readAllBytes();
+      assertThat(bytes).isEqualTo(testString.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  void inlineAttachmentRowWithoutContentFieldSkipped() {
+    mockEventContext(InlineOnlyTable_.CDS_NAME, mock(CqnSelect.class));
+
+    var row = InlineOnlyTable.create();
+    row.setId(UUID.randomUUID().toString());
+    row.setTitle("test");
+    // avatar_content not present in data at all
+
+    cut.processAfter(readEventContext, List.of(row));
+
+    verifyNoInteractions(attachmentService);
+  }
+
+  @Test
+  void inlineAttachmentNotProcessedForEntityWithoutInline() {
+    mockEventContext(Attachment_.CDS_NAME, mock(CqnSelect.class));
+
+    var attachment = Attachments.create();
+    attachment.setContentId("some ID");
+    attachment.setContent(null);
+    attachment.setStatus(StatusCode.CLEAN);
+    attachment.setScannedAt(Instant.now());
+
+    cut.processAfter(readEventContext, List.of(attachment));
+
+    assertThat(attachment.getContent()).isInstanceOf(LazyProxyInputStream.class);
   }
 
   private void mockEventContext(String entityName, CqnSelect select) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandlerTest.java
@@ -17,6 +17,8 @@ import com.sap.cds.CdsData;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
 import com.sap.cds.feature.attachments.handler.applicationservice.helper.ModifyApplicationHandlerHelper;
@@ -494,6 +496,61 @@ class UpdateAttachmentsHandlerTest {
     verify(attachmentService).markAttachmentAsDeleted(deletionInputCaptor.capture());
     assertThat(deletionInputCaptor.getValue().contentId()).isEqualTo(attachment.getContentId());
     assertThat(deletionInputCaptor.getValue().userInfo()).isEqualTo(userInfo);
+  }
+
+  @Test
+  void inlineAttachmentContentTriggersEventProcessing() {
+    var id = getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var testStream = mock(InputStream.class);
+    var row = InlineOnlyTable.create();
+    row.setId(id);
+    row.setAvatarContent(testStream);
+    when(attachmentsReader.readAttachments(any(), any(), any(CqnFilterableStatement.class)))
+        .thenReturn(List.of());
+    when(attachmentsReader.readInlineAttachments(any(), any(CqnFilterableStatement.class)))
+        .thenReturn(List.of());
+
+    cut.processBefore(updateContext, List.of(row));
+
+    ArgumentCaptor<InputStream> streamCaptor = ArgumentCaptor.forClass(InputStream.class);
+    verify(eventFactory).getEvent(streamCaptor.capture(), eq((String) null), any());
+    InputStream captured = streamCaptor.getValue();
+    assertThat(captured).isInstanceOf(CountingInputStream.class);
+    assertThat(((CountingInputStream) captured).getDelegate()).isSameAs(testStream);
+  }
+
+  @Test
+  void inlineAttachmentWithNoContentNoProcessing() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId(UUID.randomUUID().toString());
+    row.setTitle("just a title update");
+
+    cut.processBefore(updateContext, List.of(row));
+
+    verifyNoInteractions(eventFactory);
+    verifyNoInteractions(attachmentsReader);
+    verifyNoInteractions(attachmentService);
+  }
+
+  @Test
+  void inlineAttachmentWithExistingAttachmentMatchedByKeys() {
+    var id = getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var testStream = mock(InputStream.class);
+    var row = InlineOnlyTable.create();
+    row.setId(id);
+    row.setAvatarContent(testStream);
+    var existingAttachment = Attachments.create();
+    existingAttachment.put("ID", id);
+    existingAttachment.setContentId("existing-doc-id");
+    when(attachmentsReader.readAttachments(any(), any(), any(CqnFilterableStatement.class)))
+        .thenReturn(List.of());
+    when(attachmentsReader.readInlineAttachments(any(), any(CqnFilterableStatement.class)))
+        .thenReturn(List.of(existingAttachment));
+
+    cut.processBefore(updateContext, List.of(row));
+
+    verify(eventFactory).getEvent(any(), eq((String) null), eq(existingAttachment));
   }
 
   private RootTable fillRootData(InputStream testStream, String id) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/readhelper/BeforeReadItemsModifierTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/readhelper/BeforeReadItemsModifierTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
 import com.sap.cds.ql.Select;
@@ -135,6 +136,100 @@ class BeforeReadItemsModifierTest {
         Select.from(Attachment_.class).columns(Attachment_::content, Attachment_::contentId);
 
     runTestForDirectSelect(select, 1);
+  }
+
+  @Test
+  void inlineSelectExtendsWithContentIdAndStatusAndScannedAt() {
+    CqnSelect select =
+        Select.from(InlineOnlyTable_.class)
+            .columns(InlineOnlyTable_::ID, InlineOnlyTable_::avatar_content);
+
+    cut = new BeforeReadItemsModifier(List.of(BeforeReadItemsModifier.INLINE_PREFIX + "avatar"));
+    List<CqnSelectListItem> resultItems = cut.items(select.items());
+
+    long contentIdCount =
+        resultItems.stream()
+            .filter(
+                item ->
+                    item.isRef()
+                        && item.asRef().displayName().equals("avatar_" + Attachments.CONTENT_ID))
+            .count();
+    long statusCount =
+        resultItems.stream()
+            .filter(
+                item ->
+                    item.isRef()
+                        && item.asRef().displayName().equals("avatar_" + Attachments.STATUS))
+            .count();
+    long scannedAtCount =
+        resultItems.stream()
+            .filter(
+                item ->
+                    item.isRef()
+                        && item.asRef().displayName().equals("avatar_" + Attachments.SCANNED_AT))
+            .count();
+    assertThat(contentIdCount).isEqualTo(1);
+    assertThat(statusCount).isEqualTo(1);
+    assertThat(scannedAtCount).isEqualTo(1);
+  }
+
+  @Test
+  void inlineSelectDoesNotExtendIfNoContentField() {
+    CqnSelect select = Select.from(InlineOnlyTable_.class).columns(InlineOnlyTable_::ID);
+
+    cut = new BeforeReadItemsModifier(List.of(BeforeReadItemsModifier.INLINE_PREFIX + "avatar"));
+    List<CqnSelectListItem> resultItems = cut.items(select.items());
+
+    long contentIdCount =
+        resultItems.stream()
+            .filter(
+                item ->
+                    item.isRef()
+                        && item.asRef().displayName().equals("avatar_" + Attachments.CONTENT_ID))
+            .count();
+    assertThat(contentIdCount).isZero();
+  }
+
+  @Test
+  void inlineSelectDoesNotExtendIfContentIdAlreadyPresent() {
+    CqnSelect select =
+        Select.from(InlineOnlyTable_.class)
+            .columns(
+                InlineOnlyTable_::ID,
+                InlineOnlyTable_::avatar_content,
+                InlineOnlyTable_::avatar_contentId);
+
+    cut = new BeforeReadItemsModifier(List.of(BeforeReadItemsModifier.INLINE_PREFIX + "avatar"));
+    List<CqnSelectListItem> resultItems = cut.items(select.items());
+
+    long contentIdCount =
+        resultItems.stream()
+            .filter(
+                item ->
+                    item.isRef()
+                        && item.asRef().displayName().equals("avatar_" + Attachments.CONTENT_ID))
+            .count();
+    // already present, should not be duplicated
+    assertThat(contentIdCount).isEqualTo(1);
+  }
+
+  @Test
+  void inlineSelectDoesNotExtendForNonInlinePrefix() {
+    CqnSelect select =
+        Select.from(InlineOnlyTable_.class)
+            .columns(InlineOnlyTable_::ID, InlineOnlyTable_::avatar_content);
+
+    cut = new BeforeReadItemsModifier(List.of("attachments"));
+    List<CqnSelectListItem> resultItems = cut.items(select.items());
+
+    long contentIdCount =
+        resultItems.stream()
+            .filter(
+                item ->
+                    item.isRef()
+                        && item.asRef().displayName().equals("avatar_" + Attachments.CONTENT_ID))
+            .count();
+    assertThat(contentIdCount).isZero();
   }
 
   private void runTestForExpand(

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AssociationCascaderTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AssociationCascaderTest.java
@@ -40,6 +40,7 @@ class AssociationCascaderTest {
 
     assertThat(result)
         .containsExactlyInAnyOrder(
+            RootTable_.CDS_NAME,
             "unit.test.TestService.RootTable.attachments",
             Attachment_.CDS_NAME,
             "unit.test.TestService.Items.itemAttachments",
@@ -53,8 +54,10 @@ class AssociationCascaderTest {
 
     var result = cut.findMediaEntityNames(runtime.getCdsModel(), entity);
 
-    // RootTable and Items should NOT be included (they have children)
-    assertThat(result).doesNotContain(RootTable_.CDS_NAME).doesNotContain(Items_.CDS_NAME);
+    // Items should NOT be included (it is a non-leaf node without inline attachments)
+    // RootTable IS included because it has inline attachments (profilePicture)
+    assertThat(result).doesNotContain(Items_.CDS_NAME);
+    assertThat(result).contains(RootTable_.CDS_NAME);
   }
 
   @Test

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AttachmentsReaderTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AttachmentsReaderTest.java
@@ -5,16 +5,21 @@ package com.sap.cds.feature.attachments.handler.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
 import com.sap.cds.Result;
+import com.sap.cds.Row;
+import com.sap.cds.Struct;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
+import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.feature.attachments.helper.LogObserver;
 import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.Delete;
@@ -189,6 +194,57 @@ class AttachmentsReaderTest {
     assertThat(traceEvents.get(0).getFormattedMessage())
         .contains("IsActiveEntity=true")
         .contains("ID=" + dataEntry.get("ID"));
+  }
+
+  @Test
+  void readInlineAttachmentsReturnsEmptyForMediaEntity() {
+    var mediaEntity =
+        RuntimeHelper.runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+    CqnDelete statement = Delete.from(Attachment_.CDS_NAME).byId("test");
+
+    var result = cut.readInlineAttachments(mediaEntity, statement);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void readInlineAttachmentsReturnsEmptyForEntityWithoutInline() {
+    var itemsEntity = RuntimeHelper.runtime.getCdsModel().findEntity(Items_.CDS_NAME).orElseThrow();
+    CqnDelete statement = Delete.from(Items_.CDS_NAME).byId("test");
+
+    var result = cut.readInlineAttachments(itemsEntity, statement);
+
+    assertThat(result).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void readInlineAttachmentsReturnsDataForInlineEntity() {
+    var inlineEntity =
+        RuntimeHelper.runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    CqnDelete statement = Delete.from(InlineOnlyTable_.CDS_NAME).byId("test");
+
+    java.util.Map<String, Object> map = new HashMap<>();
+    map.put("ID", "test");
+    map.put("avatar_contentId", "doc-123");
+    map.put("avatar_status", "Clean");
+    map.put("avatar_scannedAt", null);
+    Row row = Struct.access(map).as(Row.class);
+    Result inlineResult = mock(Result.class);
+    doAnswer(
+            invocation -> {
+              java.util.function.Consumer<Row> consumer = invocation.getArgument(0);
+              List.of(row).forEach(consumer);
+              return null;
+            })
+        .when(inlineResult)
+        .forEach(any(java.util.function.Consumer.class));
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(inlineResult);
+
+    var result = cut.readInlineAttachments(inlineEntity, statement);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getContentId()).isEqualTo("doc-123");
   }
 
   private HashMap<String, Object> buildDefaultKeyMap() {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/InlineAttachmentHelperTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/InlineAttachmentHelperTest.java
@@ -1,0 +1,387 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.handler.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sap.cds.Result;
+import com.sap.cds.Row;
+import com.sap.cds.Struct;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
+import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
+import com.sap.cds.ql.Delete;
+import com.sap.cds.ql.cqn.CqnSelect;
+import com.sap.cds.reflect.CdsEntity;
+import com.sap.cds.services.persistence.PersistenceService;
+import com.sap.cds.services.runtime.CdsRuntime;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class InlineAttachmentHelperTest {
+
+  private static CdsRuntime runtime;
+
+  @BeforeAll
+  static void classSetup() {
+    runtime = RuntimeHelper.runtime;
+  }
+
+  @Test
+  void findInlineAttachmentPrefixes_returnsPrefix_forInlineOnlyEntity() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+
+    assertThat(result).containsExactly("avatar");
+  }
+
+  @Test
+  void findInlineAttachmentPrefixes_returnsPrefix_forRootTableWithInline() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(RootTable_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+
+    assertThat(result).containsExactly("profilePicture");
+  }
+
+  @Test
+  void findInlineAttachmentPrefixes_returnsEmpty_forMediaEntity() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void findInlineAttachmentPrefixes_returnsEmpty_forEntityWithoutInline() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Items_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void hasInlineAttachments_returnsTrue_forInlineOnlyEntity() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    assertThat(InlineAttachmentHelper.hasInlineAttachments(entity)).isTrue();
+  }
+
+  @Test
+  void hasInlineAttachments_returnsTrue_forRootTableWithInline() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(RootTable_.CDS_NAME).orElseThrow();
+
+    assertThat(InlineAttachmentHelper.hasInlineAttachments(entity)).isTrue();
+  }
+
+  @Test
+  void hasInlineAttachments_returnsFalse_forMediaEntity() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+
+    assertThat(InlineAttachmentHelper.hasInlineAttachments(entity)).isFalse();
+  }
+
+  @Test
+  void hasInlineAttachments_returnsFalse_forEntityWithoutInline() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Items_.CDS_NAME).orElseThrow();
+
+    assertThat(InlineAttachmentHelper.hasInlineAttachments(entity)).isFalse();
+  }
+
+  @Test
+  void buildInlineFieldName_combinesPrefixAndField() {
+    assertThat(InlineAttachmentHelper.buildInlineFieldName("avatar", "contentId"))
+        .isEqualTo("avatar_contentId");
+  }
+
+  @Test
+  void buildInlineFieldName_combinesLongerPrefix() {
+    assertThat(InlineAttachmentHelper.buildInlineFieldName("profilePicture", "status"))
+        .isEqualTo("profilePicture_status");
+  }
+
+  @Test
+  void extractPrefix_removesContentSuffix() {
+    assertThat(InlineAttachmentHelper.extractPrefix("avatar_content")).isEqualTo("avatar");
+  }
+
+  @Test
+  void extractPrefix_handlesLongerPrefix() {
+    assertThat(InlineAttachmentHelper.extractPrefix("profilePicture_content"))
+        .isEqualTo("profilePicture");
+  }
+
+  @Test
+  void findInlineContentElements_returnsContentFields_forInlineOnlyEntity() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineContentElements(entity);
+
+    assertThat(result).containsExactly("avatar_content");
+  }
+
+  @Test
+  void findInlineContentElements_returnsContentFields_forRootTable() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(RootTable_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineContentElements(entity);
+
+    assertThat(result).containsExactly("profilePicture_content");
+  }
+
+  @Test
+  void findInlineContentElements_returnsEmpty_forMediaEntity() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineContentElements(entity);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void findInlineContentElements_returnsEmpty_forEntityWithoutInline() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Items_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineContentElements(entity);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void readInlineAttachmentState_returnsEmptyForEmptyPrefixes() {
+    PersistenceService persistence = mock(PersistenceService.class);
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    var statement = Delete.from(InlineOnlyTable_.CDS_NAME);
+
+    var result =
+        InlineAttachmentHelper.readInlineAttachmentState(persistence, entity, statement, List.of());
+
+    assertThat(result).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void readInlineAttachmentState_readsAndMapsFields() {
+    PersistenceService persistence = mock(PersistenceService.class);
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    var id = UUID.randomUUID().toString();
+    var statement = Delete.from(InlineOnlyTable_.CDS_NAME).byId(id);
+
+    Row row =
+        createRow(
+            "ID",
+            id,
+            "avatar_contentId",
+            "doc-123",
+            "avatar_status",
+            "Clean",
+            "avatar_scannedAt",
+            Instant.parse("2025-01-01T00:00:00Z"));
+
+    Result result = mock(Result.class);
+    doAnswer(
+            invocation -> {
+              Consumer<Row> consumer = invocation.getArgument(0);
+              List.of(row).forEach(consumer);
+              return null;
+            })
+        .when(result)
+        .forEach(any(Consumer.class));
+    when(persistence.run(any(CqnSelect.class))).thenReturn(result);
+
+    var attachments =
+        InlineAttachmentHelper.readInlineAttachmentState(
+            persistence, entity, statement, List.of("avatar"));
+
+    assertThat(attachments).hasSize(1);
+    var att = attachments.get(0);
+    assertThat(att.getContentId()).isEqualTo("doc-123");
+    assertThat(att.getStatus()).isEqualTo("Clean");
+    assertThat(att.getScannedAt()).isEqualTo(Instant.parse("2025-01-01T00:00:00Z"));
+    assertThat(att.get("ID")).isEqualTo(id);
+
+    ArgumentCaptor<CqnSelect> selectCaptor = ArgumentCaptor.forClass(CqnSelect.class);
+    verify(persistence).run(selectCaptor.capture());
+    var select = selectCaptor.getValue();
+    assertThat(select.toString()).contains("avatar_contentId");
+    assertThat(select.toString()).contains("avatar_status");
+    assertThat(select.toString()).contains("avatar_scannedAt");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void readInlineAttachmentState_handlesNullScannedAt() {
+    PersistenceService persistence = mock(PersistenceService.class);
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    var statement = Delete.from(InlineOnlyTable_.CDS_NAME);
+
+    Row row =
+        createRow(
+            "ID",
+            "id-1",
+            "avatar_contentId",
+            "doc-456",
+            "avatar_status",
+            "Unscanned",
+            "avatar_scannedAt",
+            null);
+
+    Result result = mock(Result.class);
+    doAnswer(
+            invocation -> {
+              Consumer<Row> consumer = invocation.getArgument(0);
+              List.of(row).forEach(consumer);
+              return null;
+            })
+        .when(result)
+        .forEach(any(Consumer.class));
+    when(persistence.run(any(CqnSelect.class))).thenReturn(result);
+
+    var attachments =
+        InlineAttachmentHelper.readInlineAttachmentState(
+            persistence, entity, statement, List.of("avatar"));
+
+    assertThat(attachments).hasSize(1);
+    assertThat(attachments.get(0).getScannedAt()).isNull();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void readInlineAttachmentState_handlesNonInstantScannedAt() {
+    PersistenceService persistence = mock(PersistenceService.class);
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    var statement = Delete.from(InlineOnlyTable_.CDS_NAME);
+
+    Row row =
+        createRow(
+            "ID",
+            "id-1",
+            "avatar_contentId",
+            "doc-789",
+            "avatar_status",
+            "Clean",
+            "avatar_scannedAt",
+            "not-an-instant");
+
+    Result result = mock(Result.class);
+    doAnswer(
+            invocation -> {
+              Consumer<Row> consumer = invocation.getArgument(0);
+              List.of(row).forEach(consumer);
+              return null;
+            })
+        .when(result)
+        .forEach(any(Consumer.class));
+    when(persistence.run(any(CqnSelect.class))).thenReturn(result);
+
+    var attachments =
+        InlineAttachmentHelper.readInlineAttachmentState(
+            persistence, entity, statement, List.of("avatar"));
+
+    assertThat(attachments).hasSize(1);
+    assertThat(attachments.get(0).getScannedAt()).isNull();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void readInlineAttachmentState_multipleRows() {
+    PersistenceService persistence = mock(PersistenceService.class);
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    var statement = Delete.from(InlineOnlyTable_.CDS_NAME);
+
+    Row row1 =
+        createRow(
+            "ID",
+            "id-1",
+            "avatar_contentId",
+            "doc-1",
+            "avatar_status",
+            "Clean",
+            "avatar_scannedAt",
+            Instant.now());
+    Row row2 =
+        createRow(
+            "ID",
+            "id-2",
+            "avatar_contentId",
+            "doc-2",
+            "avatar_status",
+            "Infected",
+            "avatar_scannedAt",
+            Instant.now());
+
+    Result result = mock(Result.class);
+    doAnswer(
+            invocation -> {
+              Consumer<Row> consumer = invocation.getArgument(0);
+              List.of(row1, row2).forEach(consumer);
+              return null;
+            })
+        .when(result)
+        .forEach(any(Consumer.class));
+    when(persistence.run(any(CqnSelect.class))).thenReturn(result);
+
+    var attachments =
+        InlineAttachmentHelper.readInlineAttachmentState(
+            persistence, entity, statement, List.of("avatar"));
+
+    assertThat(attachments).hasSize(2);
+    assertThat(attachments.get(0).getContentId()).isEqualTo("doc-1");
+    assertThat(attachments.get(1).getContentId()).isEqualTo("doc-2");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void readInlineAttachmentState_withWhereClause() {
+    PersistenceService persistence = mock(PersistenceService.class);
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    var id = UUID.randomUUID().toString();
+    var statement = Delete.from(InlineOnlyTable_.CDS_NAME).byId(id);
+
+    Result result = mock(Result.class);
+    doAnswer(
+            invocation -> {
+              Consumer<Row> consumer = invocation.getArgument(0);
+              List.<Row>of().forEach(consumer);
+              return null;
+            })
+        .when(result)
+        .forEach(any(Consumer.class));
+    when(persistence.run(any(CqnSelect.class))).thenReturn(result);
+
+    var attachments =
+        InlineAttachmentHelper.readInlineAttachmentState(
+            persistence, entity, statement, List.of("avatar"));
+
+    assertThat(attachments).isEmpty();
+
+    ArgumentCaptor<CqnSelect> selectCaptor = ArgumentCaptor.forClass(CqnSelect.class);
+    verify(persistence).run(selectCaptor.capture());
+    var select = selectCaptor.getValue();
+    assertThat(select.toString()).contains(id);
+  }
+
+  private static Row createRow(Object... keyValues) {
+    java.util.Map<String, Object> map = new java.util.HashMap<>();
+    for (int i = 0; i < keyValues.length; i += 2) {
+      map.put((String) keyValues[i], keyValues[i + 1]);
+    }
+    return Struct.access(map).as(Row.class);
+  }
+}

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
@@ -90,6 +90,7 @@ class DraftCancelAttachmentsHandlerTest {
     when(mockEntity.getQualifiedName()).thenReturn("TestService.RegularEntity");
     when(mockEntity.getAnnotationValue("_is_media_data", false)).thenReturn(false);
     when(mockEntity.compositions()).thenReturn(java.util.stream.Stream.empty());
+    when(mockEntity.elements()).thenReturn(java.util.stream.Stream.empty());
 
     when(eventContext.getTarget()).thenReturn(mockEntity);
     when(eventContext.getCqn()).thenReturn(Delete.from("RegularEntity"));
@@ -297,6 +298,76 @@ class DraftCancelAttachmentsHandlerTest {
     cut.processBeforeDraftCancel(eventContext);
 
     // Should not call deleteEvent since keys don't match
+    verifyNoInteractions(deleteContentAttachmentEvent);
+  }
+
+  @Test
+  void deepSearchReturnsTrueForEntityWithInlineAttachments() {
+    // RootTable has profilePicture inline attachment - deepSearchForAttachments should return true
+    getEntityAndMockContext(RootTable_.CDS_NAME);
+    CqnDelete delete = Delete.from(RootTable_.class);
+    when(eventContext.getCqn()).thenReturn(delete);
+    when(eventContext.getModel()).thenReturn(runtime.getCdsModel());
+    when(eventContext.getEvent()).thenReturn("DRAFT_CANCEL");
+
+    cut.processBeforeDraftCancel(eventContext);
+
+    // Should have processed - readAttachments is called meaning deepSearch returned true
+    verify(attachmentsReader, atLeastOnce()).readAttachments(any(), any(), any());
+  }
+
+  @Test
+  void inlineDraftCancelDeletesChangedContent() {
+    getEntityAndMockContext(RootTable_.CDS_NAME);
+    CqnDelete delete = Delete.from(RootTable_.class);
+    when(eventContext.getCqn()).thenReturn(delete);
+    when(eventContext.getModel()).thenReturn(runtime.getCdsModel());
+    when(eventContext.getEvent()).thenReturn("DRAFT_CANCEL");
+
+    // Draft inline attachment has a different contentId than active
+    Attachments draftInline = Attachments.create();
+    draftInline.setContentId("draft-content-id");
+
+    Attachments activeInline = Attachments.create();
+    activeInline.setContentId("active-content-id");
+
+    CdsEntity target = eventContext.getTarget();
+    CdsEntity sibling = target.getTargetOf(Drafts.SIBLING_ENTITY);
+    when(attachmentsReader.readInlineAttachments(eq(sibling), any()))
+        .thenReturn(List.of(draftInline));
+    when(attachmentsReader.readInlineAttachments(eq(target), any()))
+        .thenReturn(List.of(activeInline));
+
+    cut.processBeforeDraftCancel(eventContext);
+
+    verify(deleteContentAttachmentEvent)
+        .processEvent(eq(null), eq(null), eq(draftInline), eq(eventContext));
+  }
+
+  @Test
+  void inlineDraftCancelNoDeleteWhenContentIdMatches() {
+    getEntityAndMockContext(RootTable_.CDS_NAME);
+    CqnDelete delete = Delete.from(RootTable_.class);
+    when(eventContext.getCqn()).thenReturn(delete);
+    when(eventContext.getModel()).thenReturn(runtime.getCdsModel());
+    when(eventContext.getEvent()).thenReturn("DRAFT_CANCEL");
+
+    String sameContentId = UUID.randomUUID().toString();
+    Attachments draftInline = Attachments.create();
+    draftInline.setContentId(sameContentId);
+
+    Attachments activeInline = Attachments.create();
+    activeInline.setContentId(sameContentId);
+
+    CdsEntity target = eventContext.getTarget();
+    CdsEntity sibling = target.getTargetOf(Drafts.SIBLING_ENTITY);
+    when(attachmentsReader.readInlineAttachments(eq(sibling), any()))
+        .thenReturn(List.of(draftInline));
+    when(attachmentsReader.readInlineAttachments(eq(target), any()))
+        .thenReturn(List.of(activeInline));
+
+    cut.processBeforeDraftCancel(eventContext);
+
     verifyNoInteractions(deleteContentAttachmentEvent);
   }
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandlerTest.java
@@ -7,10 +7,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.sap.cds.Result;
+import com.sap.cds.ResultBuilder;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Events;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Events_;
@@ -34,7 +36,9 @@ import com.sap.cds.services.persistence.PersistenceService;
 import com.sap.cds.services.request.ParameterInfo;
 import com.sap.cds.services.runtime.CdsRuntime;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -173,6 +177,38 @@ class DraftPatchAttachmentsHandlerTest {
 
     assertThat(beforeAnnotation.event()).isEmpty();
     assertThat(handlerOrderAnnotation.value()).isEqualTo(HandlerOrder.LATE);
+  }
+
+  @Test
+  void inlineAttachmentContentIsProcessed() {
+    getEntityAndMockContext(RootTable_.CDS_NAME);
+    var content = mock(InputStream.class);
+    Map<String, Object> data = new HashMap<>();
+    data.put("ID", UUID.randomUUID().toString());
+    data.put(RootTable_.PROFILE_PICTURE_CONTENT, content);
+
+    Map<String, Object> existingRow = new HashMap<>();
+    existingRow.put(RootTable_.PROFILE_PICTURE_CONTENT_ID, "old-content-id");
+    existingRow.put(RootTable_.PROFILE_PICTURE_STATUS, "Unscanned");
+    var result = ResultBuilder.selectedRows(List.of(existingRow)).result();
+    when(persistence.run(any(CqnSelect.class))).thenReturn(result);
+
+    cut.processBeforeDraftPatch(eventContext, List.of(Attachments.of(data)));
+
+    verify(eventFactory).getEvent(any(), eq("old-content-id"), any());
+    verify(event).processEvent(any(), any(), any(), eq(eventContext));
+  }
+
+  @Test
+  void inlineAttachmentContentNotInDataIsSkipped() {
+    getEntityAndMockContext(RootTable_.CDS_NAME);
+    Map<String, Object> data = new HashMap<>();
+    data.put("ID", UUID.randomUUID().toString());
+    data.put("title", "new title");
+
+    cut.processBeforeDraftPatch(eventContext, List.of(Attachments.of(data)));
+
+    verify(eventFactory, never()).getEvent(any(), any(), any());
   }
 
   private RootTable buildRooWithAttachment(Attachments attachments) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/DefaultAttachmentMalwareScannerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/DefaultAttachmentMalwareScannerTest.java
@@ -14,9 +14,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.sap.cds.Result;
+import com.sap.cds.ResultBuilder;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.StatusCode;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.client.MalwareScanClient;
@@ -27,6 +29,9 @@ import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.persistence.PersistenceService;
 import com.sap.cds.services.runtime.CdsRuntime;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -328,6 +333,59 @@ class DefaultAttachmentMalwareScannerTest {
     assertEquals(
         StatusCode.CLEAN,
         DefaultAttachmentMalwareScanner.mapStatus(MalwareScanResultStatus.NO_SCANNER));
+  }
+
+  @Test
+  void inlineAttachmentSelectUsesPrefixedColumns() {
+    var entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME);
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(result);
+
+    cut.scanAttachment(entity.orElseThrow(), "ID");
+
+    verify(persistenceService).run(selectCaptor.capture());
+    var select = selectCaptor.getValue();
+    assertThat(select.where()).isPresent();
+    assertThat(select.where().get().toString())
+        .contains("avatar_contentId")
+        .contains("avatar_status");
+  }
+
+  @Test
+  void inlineAttachmentUpdateUsesPrefixedColumns() {
+    var entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME);
+    Map<String, Object> inlineData = new HashMap<>();
+    inlineData.put("avatar_contentId", "ID");
+    inlineData.put("avatar_status", StatusCode.UNSCANNED);
+    inlineData.put("avatar_content", null);
+    var realResult = ResultBuilder.selectedRows(List.of(inlineData)).result();
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(realResult);
+    when(malwareScanClient.scanContent(any())).thenReturn(MalwareScanResultStatus.CLEAN);
+
+    cut.scanAttachment(entity.orElseThrow(), "ID");
+
+    verify(persistenceService).run(updateCaptor.capture());
+    var update = updateCaptor.getValue();
+    assertThat(update.entries()).hasSize(1);
+    assertThat(update.entries().get(0)).containsKey("avatar_status");
+    assertThat(update.entries().get(0)).containsKey("avatar_scannedAt");
+    assertThat(update.entries().get(0).get("avatar_status")).isEqualTo(StatusCode.CLEAN);
+  }
+
+  @Test
+  void inlineAttachmentContentTakenFromDatabase() {
+    var entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME);
+    var content = mock(InputStream.class);
+    Map<String, Object> inlineData = new HashMap<>();
+    inlineData.put("avatar_contentId", "test-id");
+    inlineData.put("avatar_content", content);
+    inlineData.put("avatar_status", StatusCode.UNSCANNED);
+    var realResult = ResultBuilder.selectedRows(List.of(inlineData)).result();
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(realResult);
+    when(malwareScanClient.scanContent(any())).thenReturn(MalwareScanResultStatus.CLEAN);
+
+    cut.scanAttachment(entity.orElseThrow(), "test-id");
+
+    verify(malwareScanClient).scanContent(content);
   }
 
   private void verifyPersistenceServiceCalledCorrectlyForReadAndUpdate(

--- a/cds-feature-attachments/src/test/resources/cds/db-model.cds
+++ b/cds-feature-attachments/src/test/resources/cds/db-model.cds
@@ -2,6 +2,7 @@ namespace unit.test;
 
 using {cuid} from '@sap/cds/common';
 using {sap.attachments.Attachments} from '../../../main/resources/cds/com.sap.cds/cds-feature-attachments';
+using {sap.attachments.Attachment as InlineAttachment} from '../../../main/resources/cds/com.sap.cds/cds-feature-attachments';
 using from '@sap/cds/srv/outbox';
 
 entity Attachment : Attachments {
@@ -9,9 +10,15 @@ entity Attachment : Attachments {
 
 entity Roots : cuid {
     title              : String;
+    profilePicture     : InlineAttachment;
     itemTable          : Composition of many Items
                              on itemTable.rootId = $self.ID;
     attachments        : Composition of many Attachments;
+}
+
+entity InlineOnly : cuid {
+    title  : String;
+    avatar : InlineAttachment;
 }
 
 entity Items : cuid {

--- a/cds-feature-attachments/src/test/resources/cds/service.cds
+++ b/cds-feature-attachments/src/test/resources/cds/service.cds
@@ -5,4 +5,6 @@ using unit.test as db from './db-model';
 service TestService {
     @odata.draft.enabled
     entity RootTable as projection on db.Roots;
+
+    entity InlineOnlyTable as projection on db.InlineOnly;
 }


### PR DESCRIPTION
## Summary

- Adds support for handling attachments declared inline via CDS structured types (e.g. `avatar : Attachment`) alongside the existing composition-based pattern
- New `InlineAttachmentHelper` utility detects and works with flattened inline attachment fields (`prefix_content`, `prefix_contentId`, `prefix_status`, `prefix_scannedAt`)
- Extends all non-draft application service handlers (Create/Read/Update/Delete) and supporting classes (`ApplicationHandlerHelper`, `AssociationCascader`, `AttachmentsReader`, `BeforeReadItemsModifier`, `ModifyApplicationHandlerHelper`) to process inline attachments through the same pipeline as composition attachments

## Test plan

- [ ] 454 unit tests pass (0 failures, 0 errors)
- [ ] New `InlineAttachmentHelperTest` with 22 tests covering detection, field name building, prefix extraction, and DB read/map logic
- [ ] New inline test cases added to `CreateAttachmentsHandlerTest`, `ReadAttachmentsHandlerTest`, `UpdateAttachmentsHandlerTest`, `DeleteAttachmentsHandlerTest`, `BeforeReadItemsModifierTest`, `AssociationCascaderTest`, `AttachmentsReaderTest`
- [ ] JaCoCo coverage thresholds may need minor adjustment for branches/complexity (coverage at 94.58%/94.76% vs 95% threshold)
- [ ] Run full `mvn clean install` including PMD, SpotBugs, Pitest
- [ ] Verify integration tests pass with inline attachment entities