### PR TITLE
Add inline attachment support

### DIFF
--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -182,7 +182,9 @@ public class Registration implements CdsRuntimeConfiguration {
     if (hasDraftServices) {
       configurer.eventHandler(
           new DraftPatchAttachmentsHandler(persistenceService, eventFactory, defaultMaxSize));
-      configurer.eventHandler(new DraftCancelAttachmentsHandler(attachmentsReader, deleteEvent));
+      configurer.eventHandler(
+          new DraftCancelAttachmentsHandler(
+              attachmentsReader, deleteEvent, outboxedAttachmentService));
       configurer.eventHandler(new DraftActiveAttachmentsHandler(storage));
     } else {
       logger.debug("No draft service is available. Draft event handlers will not be registered.");

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandler.java
@@ -63,8 +63,9 @@ public class CreateAttachmentsHandler implements EventHandler {
     // before the attachment's readonly fields are removed by the runtime, preserve
     // them in a custom
     // field in data
-    ReadonlyDataContextEnhancer.preserveReadonlyFields(
-        context.getTarget(), data, storageReader.get());
+    boolean isDraft = storageReader.get();
+    ReadonlyDataContextEnhancer.preserveReadonlyFields(context.getTarget(), data, isDraft);
+    ReadonlyDataContextEnhancer.preserveInlineReadonlyFields(context.getTarget(), data, isDraft);
   }
 
   @Before(event = {CqnService.EVENT_CREATE, DraftService.EVENT_DRAFT_NEW})
@@ -80,6 +81,7 @@ public class CreateAttachmentsHandler implements EventHandler {
     if (ApplicationHandlerHelper.containsContentField(context.getTarget(), data)) {
       logger.debug(
           "Processing before {} event for entity {}", context.getEvent(), context.getTarget());
+      ReadonlyDataContextEnhancer.restoreInlineReadonlyFields(data);
       ModifyApplicationHandlerHelper.handleAttachmentForEntities(
           context.getTarget(), data, new ArrayList<>(), eventFactory, context, defaultMaxSize);
     }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandler.java
@@ -59,5 +59,13 @@ public class DeleteAttachmentsHandler implements EventHandler {
     CdsDataProcessor.create()
         .addConverter(ApplicationHandlerHelper.MEDIA_CONTENT_FILTER, converter)
         .process(attachments, context.getTarget());
+
+    List<Attachments> inlineAttachments =
+        attachmentsReader.readInlineAttachments(context.getTarget(), context.getCqn());
+    for (Attachments inlineAttachment : inlineAttachments) {
+      if (inlineAttachment.getContentId() != null) {
+        deleteEvent.processEvent(null, null, inlineAttachment, context);
+      }
+    }
   }
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
@@ -15,6 +15,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.Att
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.BeforeReadItemsModifier;
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.LazyProxyInputStream;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.AsyncMalwareScanExecutor;
 import com.sap.cds.ql.CQL;
@@ -111,9 +112,10 @@ public class ReadAttachmentsHandler implements EventHandler {
   @After
   @HandlerOrder(HandlerOrder.EARLY)
   void processAfter(CdsReadEventContext context, List<CdsData> data) {
-    if (ApplicationHandlerHelper.containsContentField(context.getTarget(), data)) {
-      logger.debug(
-          "Processing after {} event for entity {}", context.getEvent(), context.getTarget());
+    CdsEntity target = context.getTarget();
+
+    if (ApplicationHandlerHelper.containsContentField(target, data)) {
+      logger.debug("Processing after {} event for entity {}", context.getEvent(), target);
 
       Converter converter =
           (path, element, value) -> {
@@ -133,7 +135,44 @@ public class ReadAttachmentsHandler implements EventHandler {
 
       CdsDataProcessor.create()
           .addConverter(ApplicationHandlerHelper.MEDIA_CONTENT_FILTER, converter)
-          .process(data, context.getTarget());
+          .process(data, target);
+    }
+
+    processInlineAfterRead(target, data);
+  }
+
+  private void processInlineAfterRead(CdsEntity target, List<CdsData> data) {
+    List<String> inlinePrefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(target);
+    if (inlinePrefixes.isEmpty()) {
+      return;
+    }
+
+    logger.debug("Processing inline attachments for entity {}", target.getQualifiedName());
+
+    for (CdsData row : data) {
+      for (String prefix : inlinePrefixes) {
+        String contentField = InlineAttachmentHelper.buildInlineFieldName(prefix, "content");
+        String contentIdField =
+            InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.CONTENT_ID);
+        String statusField =
+            InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.STATUS);
+
+        if (!row.containsKey(contentField)) {
+          continue;
+        }
+
+        Object contentValue = row.get(contentField);
+        String contentId = (String) row.get(contentIdField);
+        String status = (String) row.get(statusField);
+
+        if (nonNull(contentId)) {
+          Supplier<InputStream> supplier =
+              nonNull(contentValue) && contentValue instanceof InputStream existingContent
+                  ? () -> existingContent
+                  : () -> attachmentService.readAttachment(contentId);
+          row.put(contentField, new LazyProxyInputStream(supplier, statusValidator, status));
+        }
+      }
     }
   }
 
@@ -142,6 +181,11 @@ public class ReadAttachmentsHandler implements EventHandler {
     List<String> associationNames = new ArrayList<>();
     if (ApplicationHandlerHelper.isMediaEntity(entity)) {
       associationNames.add(associationName);
+    }
+
+    List<String> inlinePrefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+    for (String prefix : inlinePrefixes) {
+      associationNames.add(BeforeReadItemsModifier.INLINE_PREFIX + prefix);
     }
 
     Map<String, CdsEntity> annotatedEntities =

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandler.java
@@ -68,8 +68,9 @@ public class UpdateAttachmentsHandler implements EventHandler {
     // before the attachment's readonly fields are removed by the runtime, preserve
     // them in a custom
     // field in data
-    ReadonlyDataContextEnhancer.preserveReadonlyFields(
-        context.getTarget(), data, storageReader.get());
+    boolean isDraft = storageReader.get();
+    ReadonlyDataContextEnhancer.preserveReadonlyFields(context.getTarget(), data, isDraft);
+    ReadonlyDataContextEnhancer.preserveInlineReadonlyFields(context.getTarget(), data, isDraft);
   }
 
   @Before
@@ -82,6 +83,8 @@ public class UpdateAttachmentsHandler implements EventHandler {
 
     if (containsContent || !associationsAreUnchanged) {
       logger.debug("Processing before {} event for entity {}", context.getEvent(), target);
+
+      ReadonlyDataContextEnhancer.restoreInlineReadonlyFields(data);
 
       // Query database only for validation (single query for all attachments)
       CqnSelect select = CqnUtils.toSelect(context.getCqn(), context.getTarget());

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandler.java
@@ -87,9 +87,13 @@ public class UpdateAttachmentsHandler implements EventHandler {
       CqnSelect select = CqnUtils.toSelect(context.getCqn(), context.getTarget());
       List<Attachments> attachments =
           attachmentsReader.readAttachments(context.getModel(), target, select);
+      List<Attachments> inlineAttachments = attachmentsReader.readInlineAttachments(target, select);
+
+      List<Attachments> allAttachments = new java.util.ArrayList<>(attachments);
+      allAttachments.addAll(inlineAttachments);
 
       ModifyApplicationHandlerHelper.handleAttachmentForEntities(
-          target, data, attachments, eventFactory, context, defaultMaxSize);
+          target, data, allAttachments, eventFactory, context, defaultMaxSize);
 
       if (!associationsAreUnchanged) {
         deleteRemovedAttachments(attachments, data, target, context.getUserInfo());

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
@@ -87,57 +87,113 @@ public final class ModifyApplicationHandlerHelper {
         if (!row.containsKey(contentField)) {
           continue;
         }
-        Object contentValue = row.get(contentField);
-        InputStream content = contentValue instanceof InputStream is ? is : null;
-        String contentIdField =
-            InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.CONTENT_ID);
-        String contentId = (String) row.get(contentIdField);
 
         Attachments existingAttachment =
             findExistingInlineAttachment(entity, row, existingAttachments);
 
-        String contentLength = eventContext.getParameterInfo().getHeader("Content-Length");
-        String maxSizeStr = defaultMaxSize;
-        eventContext.put("attachment.MaxSize", maxSizeStr);
-        ServiceException tooLargeException =
-            new ServiceException(
-                ExtendedErrorStatuses.CONTENT_TOO_LARGE,
-                "File size exceeds the limit of {}.",
-                maxSizeStr);
-
-        if (contentLength != null) {
-          try {
-            if (Long.parseLong(contentLength) > FileSizeUtils.parseFileSizeToBytes(maxSizeStr)) {
-              throw tooLargeException;
-            }
-          } catch (NumberFormatException e) {
-            throw new ServiceException(ErrorStatuses.BAD_REQUEST, "Invalid Content-Length header");
-          }
-        }
-
-        CountingInputStream wrappedContent =
-            content != null ? new CountingInputStream(content, maxSizeStr) : null;
-        ModifyAttachmentEvent eventToProcess =
-            eventFactory.getEvent(wrappedContent, contentId, existingAttachment);
-        try {
-          InputStream result =
-              eventToProcess.processEvent(null, wrappedContent, existingAttachment, eventContext);
-          row.put(contentField, result);
-        } catch (Exception e) {
-          if (wrappedContent != null && wrappedContent.isLimitExceeded()) {
-            throw tooLargeException;
-          }
-          throw e;
-        }
+        processInlineAttachmentRow(
+            row, prefix, existingAttachment, entity, eventFactory, eventContext, defaultMaxSize);
       }
     }
   }
 
-  private static Attachments findExistingInlineAttachment(
+  /**
+   * Processes a single inline attachment field within a data row. This method handles content size
+   * validation, delegates to the event factory, and writes back attachment metadata (contentId,
+   * status, scannedAt) to the row.
+   *
+   * @param row the data row containing the inline attachment field
+   * @param prefix the inline attachment prefix (e.g. "avatar")
+   * @param existingAttachment the existing attachment state from the database
+   * @param entity the target entity
+   * @param eventFactory the event factory for processing
+   * @param eventContext the current event context
+   * @param defaultMaxSize the default max size to use when no annotation is present
+   */
+  public static void processInlineAttachmentRow(
+      CdsData row,
+      String prefix,
+      Attachments existingAttachment,
+      CdsEntity entity,
+      ModifyAttachmentEventFactory eventFactory,
+      EventContext eventContext,
+      String defaultMaxSize) {
+    String contentField = InlineAttachmentHelper.buildInlineFieldName(prefix, "content");
+    Object contentValue = row.get(contentField);
+    InputStream content = contentValue instanceof InputStream is ? is : null;
+    String contentIdField =
+        InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.CONTENT_ID);
+    String contentId = (String) row.get(contentIdField);
+
+    String contentLength = eventContext.getParameterInfo().getHeader("Content-Length");
+    String maxSizeStr = defaultMaxSize;
+    eventContext.put("attachment.MaxSize", maxSizeStr);
+    ServiceException tooLargeException =
+        new ServiceException(
+            ExtendedErrorStatuses.CONTENT_TOO_LARGE,
+            "File size exceeds the limit of {}.",
+            maxSizeStr);
+
+    if (contentLength != null) {
+      try {
+        if (Long.parseLong(contentLength) > FileSizeUtils.parseFileSizeToBytes(maxSizeStr)) {
+          throw tooLargeException;
+        }
+      } catch (NumberFormatException e) {
+        throw new ServiceException(ErrorStatuses.BAD_REQUEST, "Invalid Content-Length header");
+      }
+    }
+
+    CountingInputStream wrappedContent =
+        content != null ? new CountingInputStream(content, maxSizeStr) : null;
+
+    Map<String, Object> keys = ApplicationHandlerHelper.extractKeys(row, entity);
+    Map<String, Object> cleanKeys = ApplicationHandlerHelper.removeDraftKey(keys);
+
+    try {
+      InputStream result =
+          eventFactory.processInlineEvent(
+              wrappedContent, contentId, existingAttachment, eventContext, entity, cleanKeys);
+      row.put(contentField, result);
+
+      // Only write back metadata when the event actually modified the attachment.
+      // For doNothing (e.g. during draft activation), existingAttachment stays empty
+      // and we must not overwrite already-restored values in the row.
+      if (existingAttachment.containsKey(Attachments.CONTENT_ID)) {
+        row.put(
+            InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.CONTENT_ID),
+            existingAttachment.getContentId());
+        row.put(
+            InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.STATUS),
+            existingAttachment.getStatus());
+        if (existingAttachment.getScannedAt() != null) {
+          row.put(
+              InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.SCANNED_AT),
+              existingAttachment.getScannedAt());
+        }
+      }
+    } catch (Exception e) {
+      if (wrappedContent != null && wrappedContent.isLimitExceeded()) {
+        throw tooLargeException;
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Finds the existing inline attachment for a given row by matching entity keys.
+   *
+   * @param entity the entity to extract keys from
+   * @param row the data row
+   * @param existingAttachments the list of existing attachments to search
+   * @return the matching attachment, or an empty {@link Attachments} if none found
+   */
+  public static Attachments findExistingInlineAttachment(
       CdsEntity entity, CdsData row, List<Attachments> existingAttachments) {
     Map<String, Object> keys = ApplicationHandlerHelper.extractKeys(row, entity);
     Map<String, Object> cleanKeys = ApplicationHandlerHelper.removeDraftKey(keys);
     return existingAttachments.stream()
+        .filter(existing -> existing.containsKey(Attachments.CONTENT_ID))
         .filter(existing -> ApplicationHandlerHelper.areKeysInData(cleanKeys, existing))
         .findAny()
         .orElse(Attachments.create());

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
@@ -153,7 +153,14 @@ public final class ModifyApplicationHandlerHelper {
     try {
       InputStream result =
           eventFactory.processInlineEvent(
-              wrappedContent, contentId, existingAttachment, eventContext, entity, cleanKeys);
+              wrappedContent,
+              contentId,
+              existingAttachment,
+              eventContext,
+              entity,
+              cleanKeys,
+              row,
+              prefix);
       row.put(contentField, result);
 
       // Only write back metadata when the event actually modified the attachment.

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
@@ -11,6 +11,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.M
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEventFactory;
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.CountingInputStream;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.reflect.CdsAnnotation;
 import com.sap.cds.reflect.CdsEntity;
@@ -63,6 +64,83 @@ public final class ModifyApplicationHandlerHelper {
     CdsDataProcessor.create()
         .addConverter(ApplicationHandlerHelper.MEDIA_CONTENT_FILTER, converter)
         .process(data, entity);
+
+    handleInlineAttachments(
+        entity, data, existingAttachments, eventFactory, eventContext, defaultMaxSize);
+  }
+
+  private static void handleInlineAttachments(
+      CdsEntity entity,
+      List<CdsData> data,
+      List<Attachments> existingAttachments,
+      ModifyAttachmentEventFactory eventFactory,
+      EventContext eventContext,
+      String defaultMaxSize) {
+    List<String> inlinePrefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+    if (inlinePrefixes.isEmpty()) {
+      return;
+    }
+
+    for (CdsData row : data) {
+      for (String prefix : inlinePrefixes) {
+        String contentField = InlineAttachmentHelper.buildInlineFieldName(prefix, "content");
+        if (!row.containsKey(contentField)) {
+          continue;
+        }
+        Object contentValue = row.get(contentField);
+        InputStream content = contentValue instanceof InputStream is ? is : null;
+        String contentIdField =
+            InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.CONTENT_ID);
+        String contentId = (String) row.get(contentIdField);
+
+        Attachments existingAttachment =
+            findExistingInlineAttachment(entity, row, existingAttachments);
+
+        String contentLength = eventContext.getParameterInfo().getHeader("Content-Length");
+        String maxSizeStr = defaultMaxSize;
+        eventContext.put("attachment.MaxSize", maxSizeStr);
+        ServiceException tooLargeException =
+            new ServiceException(
+                ExtendedErrorStatuses.CONTENT_TOO_LARGE,
+                "File size exceeds the limit of {}.",
+                maxSizeStr);
+
+        if (contentLength != null) {
+          try {
+            if (Long.parseLong(contentLength) > FileSizeUtils.parseFileSizeToBytes(maxSizeStr)) {
+              throw tooLargeException;
+            }
+          } catch (NumberFormatException e) {
+            throw new ServiceException(ErrorStatuses.BAD_REQUEST, "Invalid Content-Length header");
+          }
+        }
+
+        CountingInputStream wrappedContent =
+            content != null ? new CountingInputStream(content, maxSizeStr) : null;
+        ModifyAttachmentEvent eventToProcess =
+            eventFactory.getEvent(wrappedContent, contentId, existingAttachment);
+        try {
+          InputStream result =
+              eventToProcess.processEvent(null, wrappedContent, existingAttachment, eventContext);
+          row.put(contentField, result);
+        } catch (Exception e) {
+          if (wrappedContent != null && wrappedContent.isLimitExceeded()) {
+            throw tooLargeException;
+          }
+          throw e;
+        }
+      }
+    }
+  }
+
+  private static Attachments findExistingInlineAttachment(
+      CdsEntity entity, CdsData row, List<Attachments> existingAttachments) {
+    Map<String, Object> keys = ApplicationHandlerHelper.extractKeys(row, entity);
+    Map<String, Object> cleanKeys = ApplicationHandlerHelper.removeDraftKey(keys);
+    return existingAttachments.stream()
+        .filter(existing -> ApplicationHandlerHelper.areKeysInData(cleanKeys, existing))
+        .findAny()
+        .orElse(Attachments.create());
   }
 
   /**

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancer.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancer.java
@@ -8,8 +8,11 @@ import com.sap.cds.CdsDataProcessor;
 import com.sap.cds.CdsDataProcessor.Validator;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
 import com.sap.cds.reflect.CdsEntity;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -19,6 +22,7 @@ import java.util.Objects;
 public final class ReadonlyDataContextEnhancer {
 
   private static final String DRAFT_READONLY_CONTEXT = "DRAFT_READONLY_CONTEXT";
+  private static final String INLINE_READONLY_CONTEXT = "INLINE_READONLY_CONTEXT";
 
   /**
    * Preserves the readonly fields of an {@link Attachments attachment} in a custom field with the
@@ -64,6 +68,66 @@ public final class ReadonlyDataContextEnhancer {
       data.put(Attachments.STATUS, readOnlyData.get(Attachments.STATUS));
       data.put(Attachments.SCANNED_AT, readOnlyData.get(Attachments.SCANNED_AT));
       data.remove(DRAFT_READONLY_CONTEXT);
+    }
+  }
+
+  /**
+   * Preserves the inline attachment readonly fields (contentId, status, scannedAt) in a custom
+   * context field so they survive the runtime's readonly field stripping during draft activation.
+   *
+   * @param target the target entity
+   * @param data the data rows to preserve fields from
+   * @param isDraft true if this is a draft activation
+   */
+  public static void preserveInlineReadonlyFields(
+      CdsEntity target, List<CdsData> data, boolean isDraft) {
+    List<String> prefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(target);
+    if (prefixes.isEmpty()) {
+      return;
+    }
+    for (CdsData row : data) {
+      if (isDraft) {
+        Map<String, Object> backup = new HashMap<>();
+        for (String prefix : prefixes) {
+          String contentIdField =
+              InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.CONTENT_ID);
+          String statusField =
+              InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.STATUS);
+          String scannedAtField =
+              InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.SCANNED_AT);
+          if (row.containsKey(contentIdField)) {
+            backup.put(contentIdField, row.get(contentIdField));
+          }
+          if (row.containsKey(statusField)) {
+            backup.put(statusField, row.get(statusField));
+          }
+          if (row.containsKey(scannedAtField)) {
+            backup.put(scannedAtField, row.get(scannedAtField));
+          }
+        }
+        if (!backup.isEmpty()) {
+          row.put(INLINE_READONLY_CONTEXT, backup);
+        }
+      } else {
+        row.remove(INLINE_READONLY_CONTEXT);
+      }
+    }
+  }
+
+  /**
+   * Restores inline attachment readonly fields that were preserved by {@link
+   * #preserveInlineReadonlyFields}.
+   *
+   * @param data the data rows to restore inline readonly fields to
+   */
+  @SuppressWarnings("unchecked")
+  public static void restoreInlineReadonlyFields(List<CdsData> data) {
+    for (CdsData row : data) {
+      Object backupObj = row.get(INLINE_READONLY_CONTEXT);
+      if (backupObj instanceof Map<?, ?> backup) {
+        ((Map<String, Object>) backup).forEach(row::put);
+        row.remove(INLINE_READONLY_CONTEXT);
+      }
     }
   }
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/mimeTypeValidation/MediaTypeResolver.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/mimeTypeValidation/MediaTypeResolver.java
@@ -41,7 +41,8 @@ public final class MediaTypeResolver {
 
   public static Optional<CdsAnnotation<Object>> getAcceptableMediaTypesAnnotation(
       CdsEntity entity) {
-    return Optional.ofNullable(entity.getElement(CONTENT_ELEMENT))
+    return entity
+        .findElement(CONTENT_ELEMENT)
         .flatMap(element -> element.findAnnotation(ACCEPTABLE_MEDIA_TYPES_ANNOTATION));
   }
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEvent.java
@@ -41,6 +41,14 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
     this.listenerProvider = requireNonNull(listenerProvider, "listenerProvider must not be null");
   }
 
+  AttachmentService getAttachmentService() {
+    return attachmentService;
+  }
+
+  ListenerProvider getListenerProvider() {
+    return listenerProvider;
+  }
+
   @Override
   public InputStream processEvent(
       Path path, InputStream content, Attachments attachment, EventContext eventContext) {

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/MarkAsDeletedAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/MarkAsDeletedAttachmentEvent.java
@@ -31,6 +31,10 @@ public class MarkAsDeletedAttachmentEvent implements ModifyAttachmentEvent {
         requireNonNull(attachmentService, "attachmentService must not be null");
   }
 
+  AttachmentService getAttachmentService() {
+    return attachmentService;
+  }
+
   @Override
   public InputStream processEvent(
       Path path, InputStream content, Attachments attachment, EventContext eventContext) {

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEventFactory.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEventFactory.java
@@ -1,5 +1,5 @@
 /*
- * © 2024-2025 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
  */
 package com.sap.cds.feature.attachments.handler.applicationservice.modifyevents;
 
@@ -8,9 +8,18 @@ import static java.util.Objects.requireNonNull;
 import com.sap.cds.CdsData;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.service.AttachmentService;
+import com.sap.cds.feature.attachments.service.model.service.AttachmentModificationResult;
+import com.sap.cds.feature.attachments.service.model.service.CreateAttachmentInput;
+import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
+import com.sap.cds.reflect.CdsEntity;
+import com.sap.cds.services.EventContext;
+import com.sap.cds.services.draft.DraftService;
 import java.io.InputStream;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The class {@link ModifyAttachmentEventFactory} is a factory class that creates the corresponding
@@ -26,6 +35,8 @@ import java.util.Optional;
  * </ul>
  */
 public class ModifyAttachmentEventFactory {
+
+  private static final Logger logger = LoggerFactory.getLogger(ModifyAttachmentEventFactory.class);
 
   private final CreateAttachmentEvent createEvent;
   private final UpdateAttachmentEvent updateEvent;
@@ -58,6 +69,101 @@ public class ModifyAttachmentEventFactory {
             ? handleExistingContentId(content, contentId, attachment.getContentId())
             : handleNonExistingContentId(content, attachment.getContentId());
     return event.orElse(doNothingEvent);
+  }
+
+  /**
+   * Processes an inline attachment event without requiring a {@link com.sap.cds.ql.cqn.Path}. This
+   * method determines the appropriate action (create, update, delete, or nothing) and calls the
+   * attachment service directly.
+   *
+   * @param content the content stream (may be null for delete operations)
+   * @param contentId the content id from request data (usually null for inline)
+   * @param existingAttachment the existing attachment state from the database
+   * @param eventContext the current event context
+   * @param entity the target entity
+   * @param keys the entity keys
+   * @return the result content stream, or null
+   */
+  public InputStream processInlineEvent(
+      InputStream content,
+      String contentId,
+      Attachments existingAttachment,
+      EventContext eventContext,
+      CdsEntity entity,
+      Map<String, Object> keys) {
+    ModifyAttachmentEvent event = getEvent(content, contentId, existingAttachment);
+
+    if (event == doNothingEvent) {
+      return content;
+    }
+
+    if (event == updateEvent) {
+      markAsDeletedIfNeeded(existingAttachment, eventContext, entity);
+      return createInlineAttachment(content, existingAttachment, eventContext, entity, keys);
+    }
+
+    if (event == createEvent) {
+      return createInlineAttachment(content, existingAttachment, eventContext, entity, keys);
+    }
+
+    if (event == deleteEvent) {
+      markAsDeletedIfNeeded(existingAttachment, eventContext, entity);
+      existingAttachment.setContentId(null);
+      existingAttachment.setStatus(null);
+      existingAttachment.setScannedAt(null);
+      return null;
+    }
+
+    return content;
+  }
+
+  private InputStream createInlineAttachment(
+      InputStream content,
+      Attachments existingAttachment,
+      EventContext eventContext,
+      CdsEntity entity,
+      Map<String, Object> keys) {
+    logger.debug(
+        "Calling attachment service with create event for inline attachment on entity {}",
+        entity.getQualifiedName());
+
+    String mimeType = (String) existingAttachment.get(Attachments.MIME_TYPE);
+    String fileName = (String) existingAttachment.get(Attachments.FILE_NAME);
+
+    CreateAttachmentInput createInput =
+        new CreateAttachmentInput(keys, entity, fileName, mimeType, content);
+    AttachmentModificationResult result =
+        createEvent.getAttachmentService().createAttachment(createInput);
+
+    eventContext
+        .getChangeSetContext()
+        .register(
+            createEvent
+                .getListenerProvider()
+                .provideListener(result.contentId(), eventContext.getCdsRuntime()));
+
+    existingAttachment.setContentId(result.contentId());
+    existingAttachment.setStatus(result.status());
+    if (result.scannedAt() != null) {
+      existingAttachment.setScannedAt(result.scannedAt());
+    }
+
+    return result.isInternalStored() ? content : null;
+  }
+
+  private void markAsDeletedIfNeeded(
+      Attachments existingAttachment, EventContext eventContext, CdsEntity entity) {
+    if (existingAttachment.getContentId() != null
+        && !DraftService.EVENT_DRAFT_PATCH.equals(eventContext.getEvent())) {
+      logger.debug(
+          "Calling attachment service with mark as delete event for inline attachment on entity {}",
+          entity.getQualifiedName());
+      deleteEvent
+          .getAttachmentService()
+          .markAttachmentAsDeleted(
+              new MarkAsDeletedInput(
+                  existingAttachment.getContentId(), eventContext.getUserInfo()));
+    }
   }
 
   private Optional<ModifyAttachmentEvent> handleExistingContentId(

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEventFactory.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEventFactory.java
@@ -7,6 +7,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.sap.cds.CdsData;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.model.service.AttachmentModificationResult;
 import com.sap.cds.feature.attachments.service.model.service.CreateAttachmentInput;
@@ -90,7 +91,9 @@ public class ModifyAttachmentEventFactory {
       Attachments existingAttachment,
       EventContext eventContext,
       CdsEntity entity,
-      Map<String, Object> keys) {
+      Map<String, Object> keys,
+      CdsData row,
+      String prefix) {
     ModifyAttachmentEvent event = getEvent(content, contentId, existingAttachment);
 
     if (event == doNothingEvent) {
@@ -99,11 +102,13 @@ public class ModifyAttachmentEventFactory {
 
     if (event == updateEvent) {
       markAsDeletedIfNeeded(existingAttachment, eventContext, entity);
-      return createInlineAttachment(content, existingAttachment, eventContext, entity, keys);
+      return createInlineAttachment(
+          content, existingAttachment, eventContext, entity, keys, row, prefix);
     }
 
     if (event == createEvent) {
-      return createInlineAttachment(content, existingAttachment, eventContext, entity, keys);
+      return createInlineAttachment(
+          content, existingAttachment, eventContext, entity, keys, row, prefix);
     }
 
     if (event == deleteEvent) {
@@ -122,13 +127,25 @@ public class ModifyAttachmentEventFactory {
       Attachments existingAttachment,
       EventContext eventContext,
       CdsEntity entity,
-      Map<String, Object> keys) {
+      Map<String, Object> keys,
+      CdsData row,
+      String prefix) {
     logger.debug(
         "Calling attachment service with create event for inline attachment on entity {}",
         entity.getQualifiedName());
 
-    String mimeType = (String) existingAttachment.get(Attachments.MIME_TYPE);
-    String fileName = (String) existingAttachment.get(Attachments.FILE_NAME);
+    String mimeType =
+        getInlineFieldValue(
+            Attachments.MIME_TYPE,
+            row,
+            InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.MIME_TYPE),
+            existingAttachment);
+    String fileName =
+        getInlineFieldValue(
+            Attachments.FILE_NAME,
+            row,
+            InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.FILE_NAME),
+            existingAttachment);
 
     CreateAttachmentInput createInput =
         new CreateAttachmentInput(keys, entity, fileName, mimeType, content);
@@ -190,5 +207,11 @@ public class ModifyAttachmentEventFactory {
       }
     }
     return Optional.ofNullable(event);
+  }
+
+  private static String getInlineFieldValue(
+      String fieldName, CdsData row, String prefixedFieldName, Attachments existing) {
+    Object fromRow = row.get(prefixedFieldName);
+    return (String) (fromRow != null ? fromRow : existing.get(fieldName));
   }
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/readhelper/BeforeReadItemsModifier.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/readhelper/BeforeReadItemsModifier.java
@@ -1,10 +1,11 @@
 /*
- * © 2024-2025 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
  */
 package com.sap.cds.feature.attachments.handler.applicationservice.readhelper;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
 import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.Expand;
 import com.sap.cds.ql.cqn.CqnSelectListItem;
@@ -24,6 +25,13 @@ public class BeforeReadItemsModifier implements Modifier {
 
   private static final String ROOT_ASSOCIATION = "";
 
+  /**
+   * Prefix used to mark inline attachment entries in the media associations list. Entries of the
+   * form {@code "inline:prefix"} indicate that the prefix refers to an inline (flattened)
+   * attachment field rather than a composition association.
+   */
+  public static final String INLINE_PREFIX = "inline:";
+
   private final List<String> mediaAssociations;
 
   public BeforeReadItemsModifier(List<String> mediaAssociations) {
@@ -36,6 +44,8 @@ public class BeforeReadItemsModifier implements Modifier {
         new ArrayList<>(items.stream().filter(item -> !item.isExpand()).toList());
     List<CqnSelectListItem> result = addContentIdItem(items);
     newItems.addAll(result);
+
+    enhanceWithInlineFields(items, newItems);
 
     return newItems;
   }
@@ -78,6 +88,34 @@ public class BeforeReadItemsModifier implements Modifier {
       listToEnhance.add(CQL.get(Attachments.CONTENT_ID));
       listToEnhance.add(CQL.get(Attachments.STATUS));
       listToEnhance.add(CQL.get(Attachments.SCANNED_AT));
+    }
+  }
+
+  private void enhanceWithInlineFields(
+      List<CqnSelectListItem> originalItems, List<CqnSelectListItem> newItems) {
+    for (String entry : mediaAssociations) {
+      if (!entry.startsWith(INLINE_PREFIX)) {
+        continue;
+      }
+      String prefix = entry.substring(INLINE_PREFIX.length());
+      String contentFieldName = InlineAttachmentHelper.buildInlineFieldName(prefix, "content");
+      String contentIdFieldName =
+          InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.CONTENT_ID);
+
+      boolean hasContentField =
+          originalItems.stream().anyMatch(item -> isItemRefFieldWithName(item, contentFieldName));
+      boolean hasContentIdField =
+          originalItems.stream().anyMatch(item -> isItemRefFieldWithName(item, contentIdFieldName));
+
+      if (hasContentField && !hasContentIdField) {
+        logger.debug("Adding inline attachment fields for prefix '{}' to select items", prefix);
+        newItems.add(
+            CQL.get(InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.CONTENT_ID)));
+        newItems.add(
+            CQL.get(InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.STATUS)));
+        newItems.add(
+            CQL.get(InlineAttachmentHelper.buildInlineFieldName(prefix, Attachments.SCANNED_AT)));
+      }
     }
   }
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/ApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/ApplicationHandlerHelper.java
@@ -37,7 +37,7 @@ public final class ApplicationHandlerHelper {
               && element.findAnnotation(ANNOTATION_CORE_MEDIA_TYPE).isPresent();
 
   /**
-   * Checks if the data contains a content field.
+   * Checks if the data contains a content field, including inline attachment content fields.
    *
    * @param entity The {@link CdsEntity entity} type of the given the data to check
    * @param data The data to check
@@ -48,7 +48,23 @@ public final class ApplicationHandlerHelper {
     CdsDataProcessor.create()
         .addValidator(MEDIA_CONTENT_FILTER, (path, element, value) -> isIncluded.set(true))
         .process(data, entity);
-    return isIncluded.get();
+    if (isIncluded.get()) {
+      return true;
+    }
+    return containsInlineContentField(entity, data);
+  }
+
+  /**
+   * Checks if the data contains any inline attachment content fields.
+   *
+   * @param entity the entity to inspect
+   * @param data the data to check
+   * @return {@code true} if inline content fields are present in the data
+   */
+  public static boolean containsInlineContentField(CdsEntity entity, List<? extends CdsData> data) {
+    List<String> inlineContentElements = InlineAttachmentHelper.findInlineContentElements(entity);
+    return inlineContentElements.stream()
+        .anyMatch(contentField -> data.stream().anyMatch(d -> d.containsKey(contentField)));
   }
 
   /**

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AssociationCascader.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AssociationCascader.java
@@ -28,6 +28,14 @@ public class AssociationCascader {
     NodeTree tree = findEntityPath(model, entity);
     List<String> result = new ArrayList<>();
     collect(model, tree, result);
+
+    if (InlineAttachmentHelper.hasInlineAttachments(entity)) {
+      String entityName = entity.getQualifiedName();
+      if (!result.contains(entityName)) {
+        result.add(entityName);
+      }
+    }
+
     return result;
   }
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AttachmentsReader.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AttachmentsReader.java
@@ -53,9 +53,28 @@ public class AttachmentsReader {
     statement.where().ifPresent(select::where);
 
     Result result = persistence.run(select);
-    List<Attachments> attachments = result.listOf(Attachments.class);
+    List<Attachments> attachments = new ArrayList<>(result.listOf(Attachments.class));
     logResultData(entity, attachments);
     return attachments;
+  }
+
+  /**
+   * Reads inline attachment state (contentId, status, scannedAt) from the database for entities
+   * that have inline attachment fields.
+   *
+   * @param entity the entity to query
+   * @param statement the filterable statement providing the entity ref and where clause
+   * @return a list of {@link Attachments} with unprefixed field names, or empty if no inline
+   *     attachments exist
+   */
+  public List<Attachments> readInlineAttachments(
+      CdsEntity entity, CqnFilterableStatement statement) {
+    List<String> inlinePrefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+    if (inlinePrefixes.isEmpty()) {
+      return List.of();
+    }
+    return InlineAttachmentHelper.readInlineAttachmentState(
+        persistence, entity, statement, inlinePrefixes);
   }
 
   private List<Expand<?>> buildExpandList(NodeTree root) {

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/InlineAttachmentHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/InlineAttachmentHelper.java
@@ -1,0 +1,164 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.handler.common;
+
+import com.sap.cds.Result;
+import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.ql.CQL;
+import com.sap.cds.ql.Select;
+import com.sap.cds.ql.cqn.CqnFilterableStatement;
+import com.sap.cds.reflect.CdsEntity;
+import com.sap.cds.services.persistence.PersistenceService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for detecting and reading inline attachment fields. Inline attachments are
+ * structured type fields (e.g. {@code avatar : Attachment}) that get flattened by the CDS compiler
+ * into prefixed columns (e.g. {@code avatar_content}, {@code avatar_contentId}).
+ */
+public final class InlineAttachmentHelper {
+
+  private static final String ANNOTATION_IS_MEDIA_DATA = "_is_media_data";
+  private static final String ANNOTATION_CORE_MEDIA_TYPE = "Core.MediaType";
+  private static final String CONTENT_SUFFIX = "_content";
+
+  /**
+   * Finds the prefixes of inline attachment elements on the given entity. An inline attachment is
+   * identified by a flat element named {@code prefix_content} that carries both the
+   * {@code @_is_media_data} and {@code @Core.MediaType} annotations, where the entity itself is not
+   * a media entity (i.e. not annotated with {@code @_is_media_data}).
+   *
+   * @param entity the entity to inspect
+   * @return a list of inline attachment prefixes (e.g. {@code ["avatar", "profilePicture"]})
+   */
+  public static List<String> findInlineAttachmentPrefixes(CdsEntity entity) {
+    if (ApplicationHandlerHelper.isMediaEntity(entity)) {
+      return List.of();
+    }
+    List<String> prefixes = new ArrayList<>();
+    entity
+        .elements()
+        .forEach(
+            element -> {
+              String name = element.getName();
+              if (name.endsWith(CONTENT_SUFFIX)
+                  && element.getAnnotationValue(ANNOTATION_IS_MEDIA_DATA, false)
+                  && element.findAnnotation(ANNOTATION_CORE_MEDIA_TYPE).isPresent()) {
+                String prefix = name.substring(0, name.length() - CONTENT_SUFFIX.length());
+                prefixes.add(prefix);
+              }
+            });
+    return prefixes;
+  }
+
+  /**
+   * Returns whether the entity has any inline attachment elements.
+   *
+   * @param entity the entity to check
+   * @return {@code true} if inline attachment prefixes exist
+   */
+  public static boolean hasInlineAttachments(CdsEntity entity) {
+    return !findInlineAttachmentPrefixes(entity).isEmpty();
+  }
+
+  /**
+   * Reads the current state (contentId, status, scannedAt) of inline attachment fields from the
+   * database. The returned list contains one {@link Attachments} per inline attachment per row,
+   * with fields mapped to unprefixed names (e.g. {@code avatar_contentId} becomes {@code
+   * contentId}).
+   *
+   * @param persistence the persistence service
+   * @param entity the entity to query
+   * @param statement the filterable statement providing the entity ref and where clause
+   * @param prefixes the inline attachment prefixes to read
+   * @return a list of {@link Attachments} with unprefixed field names and entity keys
+   */
+  public static List<Attachments> readInlineAttachmentState(
+      PersistenceService persistence,
+      CdsEntity entity,
+      CqnFilterableStatement statement,
+      List<String> prefixes) {
+    if (prefixes.isEmpty()) {
+      return List.of();
+    }
+
+    List<com.sap.cds.ql.cqn.CqnSelectListItem> columns = new ArrayList<>();
+    entity.keyElements().forEach(key -> columns.add(CQL.get(key.getName())));
+    for (String prefix : prefixes) {
+      columns.add(CQL.get(buildInlineFieldName(prefix, Attachments.CONTENT_ID)));
+      columns.add(CQL.get(buildInlineFieldName(prefix, Attachments.STATUS)));
+      columns.add(CQL.get(buildInlineFieldName(prefix, Attachments.SCANNED_AT)));
+    }
+
+    Select<?> select = Select.from(statement.ref()).columns(columns);
+    statement.where().ifPresent(select::where);
+
+    Result result = persistence.run(select);
+
+    List<Attachments> attachments = new ArrayList<>();
+    result.forEach(
+        row -> {
+          Map<String, Object> keys = new HashMap<>();
+          entity.keyElements().forEach(key -> keys.put(key.getName(), row.get(key.getName())));
+
+          for (String prefix : prefixes) {
+            Attachments att = Attachments.create();
+            att.putAll(keys);
+            att.setContentId(
+                (String) row.get(buildInlineFieldName(prefix, Attachments.CONTENT_ID)));
+            att.setStatus((String) row.get(buildInlineFieldName(prefix, Attachments.STATUS)));
+            Object scannedAt = row.get(buildInlineFieldName(prefix, Attachments.SCANNED_AT));
+            if (scannedAt instanceof java.time.Instant instant) {
+              att.setScannedAt(instant);
+            }
+            attachments.add(att);
+          }
+        });
+
+    return attachments;
+  }
+
+  /**
+   * Builds a flattened inline field name from the element prefix and the field name.
+   *
+   * @param prefix the inline attachment prefix (e.g. {@code "avatar"})
+   * @param fieldName the attachment field name (e.g. {@code "contentId"})
+   * @return the combined name (e.g. {@code "avatar_contentId"})
+   */
+  public static String buildInlineFieldName(String prefix, String fieldName) {
+    return prefix + "_" + fieldName;
+  }
+
+  /**
+   * Extracts the inline attachment prefix from a flattened element name that ends with {@code
+   * _content}.
+   *
+   * @param elementName the flattened element name (e.g. {@code "avatar_content"})
+   * @return the prefix (e.g. {@code "avatar"})
+   */
+  static String extractPrefix(String elementName) {
+    return elementName.substring(0, elementName.length() - CONTENT_SUFFIX.length());
+  }
+
+  /**
+   * Returns the element names of all inline attachment content fields on the given entity, as
+   * identified by {@link #findInlineAttachmentPrefixes}.
+   *
+   * @param entity the entity to inspect
+   * @return element names like {@code ["avatar_content", "profilePicture_content"]}
+   */
+  public static List<String> findInlineContentElements(CdsEntity entity) {
+    return findInlineAttachmentPrefixes(entity).stream()
+        .map(prefix -> buildInlineFieldName(prefix, "content"))
+        .collect(Collectors.toList());
+  }
+
+  private InlineAttachmentHelper() {
+    // avoid instantiation
+  }
+}

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
@@ -13,6 +13,9 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachmen
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
+import com.sap.cds.feature.attachments.service.AttachmentService;
+import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
 import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.cqn.CqnDelete;
 import com.sap.cds.reflect.CdsAssociationType;
@@ -49,12 +52,17 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
 
   private final AttachmentsReader attachmentsReader;
   private final MarkAsDeletedAttachmentEvent deleteEvent;
+  private final AttachmentService attachmentService;
 
   public DraftCancelAttachmentsHandler(
-      AttachmentsReader attachmentsReader, MarkAsDeletedAttachmentEvent deleteEvent) {
+      AttachmentsReader attachmentsReader,
+      MarkAsDeletedAttachmentEvent deleteEvent,
+      AttachmentService attachmentService) {
     this.attachmentsReader =
         requireNonNull(attachmentsReader, "attachmentsReader must not be null");
     this.deleteEvent = requireNonNull(deleteEvent, "deleteEvent must not be null");
+    this.attachmentService =
+        requireNonNull(attachmentService, "attachmentService must not be null");
   }
 
   @Before
@@ -77,11 +85,45 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
       CdsDataProcessor.create()
           .addValidator(contentIdFilter, validator)
           .process(draftAttachments, context.getTarget());
+
+      cancelInlineAttachments(context, draftEntity, activeEntity);
     } else {
       logger.debug(
           "Skipping processing before {} event for entity {}",
           context.getEvent(),
           context.getTarget());
+    }
+  }
+
+  private void cancelInlineAttachments(
+      DraftCancelEventContext context, CdsEntity draftEntity, CdsEntity activeEntity) {
+    if (!InlineAttachmentHelper.hasInlineAttachments(context.getTarget())) {
+      return;
+    }
+    CqnDelete draftCqn =
+        CQL.copy(
+            context.getCqn(), new ModifierToCreateFlatCQN(false, draftEntity.getQualifiedName()));
+    List<Attachments> draftInline = attachmentsReader.readInlineAttachments(draftEntity, draftCqn);
+
+    CqnDelete activeCqn =
+        CQL.copy(
+            context.getCqn(), new ModifierToCreateFlatCQN(true, activeEntity.getQualifiedName()));
+    List<Attachments> activeInline =
+        attachmentsReader.readInlineAttachments(activeEntity, activeCqn);
+
+    for (Attachments draftAtt : draftInline) {
+      String draftContentId = draftAtt.getContentId();
+      if (draftContentId == null) {
+        continue;
+      }
+      boolean existsInActive =
+          activeInline.stream()
+              .anyMatch(activeAtt -> draftContentId.equals(activeAtt.getContentId()));
+      if (!existsInActive) {
+        logger.debug("Marking inline attachment {} as deleted during draft cancel", draftContentId);
+        attachmentService.markAttachmentAsDeleted(
+            new MarkAsDeletedInput(draftContentId, context.getUserInfo()));
+      }
     }
   }
 
@@ -119,6 +161,10 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
     visited.add(entity.getQualifiedName());
 
     if (ApplicationHandlerHelper.isMediaEntity(entity)) {
+      return true;
+    }
+
+    if (InlineAttachmentHelper.hasInlineAttachments(entity)) {
       return true;
     }
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandler.java
@@ -13,6 +13,7 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachmen
 import com.sap.cds.feature.attachments.handler.applicationservice.helper.ModifyApplicationHandlerHelper;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEventFactory;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.InlineAttachmentHelper;
 import com.sap.cds.ql.Select;
 import com.sap.cds.ql.cqn.CqnSelect;
 import com.sap.cds.reflect.CdsEntity;
@@ -25,6 +26,7 @@ import com.sap.cds.services.handler.annotations.ServiceName;
 import com.sap.cds.services.persistence.PersistenceService;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,5 +77,38 @@ public class DraftPatchAttachmentsHandler implements EventHandler {
     CdsDataProcessor.create()
         .addConverter(ApplicationHandlerHelper.MEDIA_CONTENT_FILTER, converter)
         .process(data, context.getTarget());
+
+    handleInlineAttachments(context, data);
+  }
+
+  private void handleInlineAttachments(
+      DraftPatchEventContext context, List<? extends CdsData> data) {
+    CdsEntity entity = context.getTarget();
+    List<String> inlinePrefixes = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+    if (inlinePrefixes.isEmpty()) {
+      return;
+    }
+
+    for (CdsData row : data) {
+      for (String prefix : inlinePrefixes) {
+        String contentField = InlineAttachmentHelper.buildInlineFieldName(prefix, "content");
+        if (!row.containsKey(contentField)) {
+          continue;
+        }
+
+        Map<String, Object> keys = ApplicationHandlerHelper.extractKeys(row, entity);
+
+        CdsEntity draftEntity = DraftUtils.getDraftEntity(entity);
+        List<Attachments> existingInline =
+            InlineAttachmentHelper.readInlineAttachmentState(
+                persistence, draftEntity, Select.from(draftEntity).matching(keys), List.of(prefix));
+        Attachments existingAttachment =
+            ModifyApplicationHandlerHelper.findExistingInlineAttachment(
+                entity, row, existingInline);
+
+        ModifyApplicationHandlerHelper.processInlineAttachmentRow(
+            row, prefix, existingAttachment, entity, eventFactory, context, defaultMaxSize);
+      }
+    }
   }
 }

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
@@ -27,8 +27,8 @@ annotate MediaData with @UI.MediaResource: {Stream: content} {
 annotate Attachment with @UI.MediaResource: {Stream: content} {
     content   @(
         title                           : '{i18n>attachment_content}',
-        Core.MediaType                  : mimeType,
-        Core.ContentDisposition.Filename: fileName,
+        Core.MediaType                  : 'application/octet-stream',
+        Core.ContentDisposition.Filename: null,
         Core.ContentDisposition.Type    : 'inline'
     );
     mimeType  @(

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
@@ -1,35 +1,15 @@
 using {
+    sap.attachments.Attachment,
     sap.attachments.MediaData,
-    sap.attachments.Attachments,
-    sap.attachments.Attachment
+    sap.attachments.Attachments
 } from './attachments';
 
-annotate MediaData with @UI.MediaResource: {Stream: content} {
+annotate sap.attachments.MediaData with @UI.MediaResource: {Stream: content} {
     content   @(
         title                           : '{i18n>attachment_content}',
-        Core.MediaType                  : mimeType,
-        Core.ContentDisposition.Filename: fileName,
-        Core.ContentDisposition.Type    : 'inline'
-    );
-    mimeType  @(
-        title: '{i18n>attachment_mimeType}',
-        Core.IsMediaType
-    );
-    fileName  @(
-        title: '{i18n>attachment_fileName}',
-        UI.MultiLineText
-        );
-    status    @(title: '{i18n>attachment_status}', Common.Text : statusNav.name, Common.TextArrangement : #TextOnly);
-    contentId @(UI.Hidden: true);
-    scannedAt @(UI.Hidden: true);
-}
-
-annotate Attachment with @UI.MediaResource: {Stream: content} {
-    content   @(
-        title                           : '{i18n>attachment_content}',
+        Core.ContentDisposition.Type    : 'inline',
         Core.MediaType                  : 'application/octet-stream',
-        Core.ContentDisposition.Filename: null,
-        Core.ContentDisposition.Type    : 'inline'
+        odata.draft.skip
     );
     mimeType  @(
         title: '{i18n>attachment_mimeType}',
@@ -37,14 +17,20 @@ annotate Attachment with @UI.MediaResource: {Stream: content} {
     );
     fileName  @(
         title: '{i18n>attachment_fileName}',
-        UI.MultiLineText
+        UI.MultiLineText,
+        readonly
         );
-    status    @(title: '{i18n>attachment_status}');
-    contentId @(UI.Hidden: true);
-    scannedAt @(UI.Hidden: true);
+    status    @(title: '{i18n>attachment_status}', readonly);
+    contentId @(UI.Hidden: true, readonly);
+    scannedAt @(UI.Hidden: true, readonly);
 }
 
-annotate Attachments with @UI: {
+annotate sap.attachments.Attachments with
+@Capabilities: {
+    UpdateRestrictions.NonUpdateableProperties: [content],
+    SortRestrictions: { NonSortableProperties: [content] }
+}
+@UI: {
     HeaderInfo: {
         TypeName      : '{i18n>attachment}',
         TypeNamePlural: '{i18n>attachments}',
@@ -57,7 +43,17 @@ annotate Attachments with @UI: {
         {Value: note,      @HTML5.CssDefaults: {width: '25%'}},
         {Value: up__ID, @UI.Hidden}
     ]
-} {
+}
+@Common: {SideEffects #ContentChanged: {
+    SourceProperties: [content],
+    TargetProperties: ['status']
+}} {
+    content    @(
+        Core.ContentDisposition.Filename: fileName,
+        Core.MediaType: mimeType
+    );
+    mimeType   @Core.IsMediaType;
+    status     @(Common.Text : statusNav.name, Common.TextArrangement : #TextOnly);
     note       @(
         title: '{i18n>attachment_note}',
         UI.MultiLineText
@@ -65,7 +61,6 @@ annotate Attachments with @UI: {
     modifiedAt @(odata.etag);
 }
 
-annotate Attachments with @Common: {SideEffects #ContentChanged: {
-    SourceProperties: [content],
-    TargetProperties: ['status']
-}} {};
+annotate sap.attachments.Attachment with {
+    content @Core.ContentDisposition.Filename: fileName;
+}

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
@@ -1,6 +1,7 @@
 using {
     sap.attachments.MediaData,
-    sap.attachments.Attachments
+    sap.attachments.Attachments,
+    sap.attachments.Attachment
 } from './attachments';
 
 annotate MediaData with @UI.MediaResource: {Stream: content} {
@@ -19,6 +20,26 @@ annotate MediaData with @UI.MediaResource: {Stream: content} {
         UI.MultiLineText
         );
     status    @(title: '{i18n>attachment_status}', Common.Text : statusNav.name, Common.TextArrangement : #TextOnly);
+    contentId @(UI.Hidden: true);
+    scannedAt @(UI.Hidden: true);
+}
+
+annotate Attachment with @UI.MediaResource: {Stream: content} {
+    content   @(
+        title                           : '{i18n>attachment_content}',
+        Core.MediaType                  : mimeType,
+        Core.ContentDisposition.Filename: fileName,
+        Core.ContentDisposition.Type    : 'inline'
+    );
+    mimeType  @(
+        title: '{i18n>attachment_mimeType}',
+        Core.IsMediaType
+    );
+    fileName  @(
+        title: '{i18n>attachment_fileName}',
+        UI.MultiLineText
+        );
+    status    @(title: '{i18n>attachment_status}');
     contentId @(UI.Hidden: true);
     scannedAt @(UI.Hidden: true);
 }

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
@@ -30,6 +30,15 @@ entity ScanStates : CodeList {
         criticality : Integer     @UI.Hidden;
 }
 
+type Attachment @(_is_media_data) {
+    content   : LargeBinary;
+    mimeType  : String;
+    fileName  : String(5000);
+    contentId : String     @readonly;
+    status    : StatusCode default 'Unscanned' @readonly;
+    scannedAt : Timestamp  @readonly;
+};
+
 aspect Attachments : cuid, managed, MediaData {
     note : String(5000);
 }

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
@@ -31,7 +31,7 @@ entity ScanStates : CodeList {
 }
 
 type Attachment @(_is_media_data) {
-    content   : LargeBinary;
+    content   : LargeBinary @Core.ContentDisposition.Filename: null;
     mimeType  : String;
     fileName  : String(5000);
     contentId : String     @readonly;

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
@@ -1,44 +1,44 @@
-namespace sap.attachments;
-
 using {
     cuid,
     managed,
     sap.common.CodeList
 } from '@sap/cds/common';
 
-type StatusCode : String(32) enum {
-    Unscanned;
-    Scanning;
-    Clean;
-    Infected;
-    Failed;
-}
+// The common root-level aspect used in applications like that:
+// using { Attachments } from 'com.sap.cds/cds-feature-attachments'
+aspect Attachments : sap.attachments.Attachments {}
 
-aspect MediaData @(_is_media_data) {
-    content   : LargeBinary; // stored only for db-based services
-    mimeType  : String;
-    fileName  : String(5000);
-    contentId : String     @readonly; // id of attachment in external storage, if database storage is used, same as id
-    status    : StatusCode default 'Unscanned' @readonly;
-    statusNav : Association to one ScanStates on statusNav.code = status;
-    scannedAt : Timestamp  @readonly;
-}
+type Attachment : sap.attachments.Attachment;
 
-entity ScanStates : CodeList {
-    key code        : StatusCode  @Common.Text: name  @Common.TextArrangement: #TextOnly;
-        name        : localized String(64);
-        criticality : Integer     @UI.Hidden;
-}
+context sap.attachments {
 
-type Attachment @(_is_media_data) {
-    content   : LargeBinary @Core.ContentDisposition.Filename: null;
-    mimeType  : String;
-    fileName  : String(5000);
-    contentId : String     @readonly;
-    status    : StatusCode default 'Unscanned' @readonly;
-    scannedAt : Timestamp  @readonly;
-};
+    type StatusCode : String(32) enum {
+        Unscanned;
+        Scanning;
+        Clean;
+        Infected;
+        Failed;
+    }
 
-aspect Attachments : cuid, managed, MediaData {
-    note : String(5000);
+    entity ScanStates : CodeList {
+        key code        : StatusCode  @Common.Text: name  @Common.TextArrangement: #TextOnly;
+            name        : localized String(64);
+            criticality : Integer     @UI.Hidden;
+    }
+
+    aspect MediaData @(_is_media_data) : managed {
+        content   : LargeBinary; // stored only for db-based services
+        mimeType  : String default 'application/octet-stream';
+        fileName  : String(5000);
+        contentId : String     @readonly; // id of attachment in external storage, if database storage is used, same as id
+        status    : StatusCode default 'Unscanned' @readonly;
+        scannedAt : Timestamp  @readonly;
+        note      : String(5000);
+    }
+
+    type Attachment : MediaData {}
+
+    aspect Attachments : cuid, MediaData {
+        statusNav : Association to one ScanStates on statusNav.code = status;
+    }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
@@ -386,7 +386,14 @@ class CreateAttachmentsHandlerTest {
     ArgumentCaptor<InputStream> streamCaptor = ArgumentCaptor.forClass(InputStream.class);
     verify(eventFactory)
         .processInlineEvent(
-            streamCaptor.capture(), eq((String) null), any(), eq(createContext), any(), any());
+            streamCaptor.capture(),
+            eq((String) null),
+            any(),
+            eq(createContext),
+            any(),
+            any(),
+            any(),
+            any());
     InputStream captured = streamCaptor.getValue();
     assertThat(captured).isInstanceOf(CountingInputStream.class);
     assertThat(((CountingInputStream) captured).getDelegate()).isSameAs(testStream);
@@ -414,7 +421,8 @@ class CreateAttachmentsHandlerTest {
     cut.processBefore(createContext, List.of(row));
 
     verify(eventFactory)
-        .processInlineEvent(eq(null), eq((String) null), any(), eq(createContext), any(), any());
+        .processInlineEvent(
+            eq(null), eq((String) null), any(), eq(createContext), any(), any(), any(), any());
   }
 
   @Test
@@ -452,7 +460,7 @@ class CreateAttachmentsHandlerTest {
     row.setId("test-id");
     var testStream = mock(InputStream.class);
     row.setAvatarContent(testStream);
-    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenThrow(new RuntimeException("test"));
 
     List<CdsData> data = List.of(row);
@@ -474,7 +482,8 @@ class CreateAttachmentsHandlerTest {
 
     cut.processBefore(createContext, List.of(row));
 
-    verify(eventFactory).processInlineEvent(any(), any(), any(), eq(createContext), any(), any());
+    verify(eventFactory)
+        .processInlineEvent(any(), any(), any(), eq(createContext), any(), any(), any(), any());
   }
 
   private void getEntityAndMockContext(String cdsName) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
@@ -22,6 +22,8 @@ import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Events;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Events_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
@@ -369,6 +371,110 @@ class CreateAttachmentsHandlerTest {
       helper.verify(
           () -> AttachmentValidationHelper.validateMediaAttachments(entity, data, runtime));
     }
+  }
+
+  @Test
+  void inlineAttachmentContentTriggersEventProcessing() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    var testStream = mock(InputStream.class);
+    row.setAvatarContent(testStream);
+    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
+
+    cut.processBefore(createContext, List.of(row));
+
+    ArgumentCaptor<InputStream> streamCaptor = ArgumentCaptor.forClass(InputStream.class);
+    verify(eventFactory).getEvent(streamCaptor.capture(), eq((String) null), any());
+    InputStream captured = streamCaptor.getValue();
+    assertThat(captured).isInstanceOf(CountingInputStream.class);
+    assertThat(((CountingInputStream) captured).getDelegate()).isSameAs(testStream);
+  }
+
+  @Test
+  void inlineAttachmentWithNoContentNoProcessing() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    row.setTitle("just a title");
+
+    cut.processBefore(createContext, List.of(row));
+
+    verifyNoInteractions(eventFactory);
+  }
+
+  @Test
+  void inlineAttachmentWithNullContentValueProcessed() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    row.put(InlineOnlyTable.AVATAR_CONTENT, null);
+    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
+
+    cut.processBefore(createContext, List.of(row));
+
+    verify(eventFactory).getEvent(eq(null), eq((String) null), any());
+  }
+
+  @Test
+  void inlineAttachmentContentLengthExceedsLimitThrows() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    row.setAvatarContent(mock(InputStream.class));
+    ParameterInfo paramInfo = mock(ParameterInfo.class);
+    when(paramInfo.getHeader("Content-Length")).thenReturn("999999999999");
+    when(createContext.getParameterInfo()).thenReturn(paramInfo);
+
+    List<CdsData> data = List.of(row);
+    assertThrows(ServiceException.class, () -> cut.processBefore(createContext, data));
+  }
+
+  @Test
+  void inlineAttachmentInvalidContentLengthThrows() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    row.setAvatarContent(mock(InputStream.class));
+    ParameterInfo paramInfo = mock(ParameterInfo.class);
+    when(paramInfo.getHeader("Content-Length")).thenReturn("not-a-number");
+    when(createContext.getParameterInfo()).thenReturn(paramInfo);
+
+    List<CdsData> data = List.of(row);
+    assertThrows(ServiceException.class, () -> cut.processBefore(createContext, data));
+  }
+
+  @Test
+  void inlineAttachmentLimitExceededDuringProcessingThrows() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    var testStream = mock(InputStream.class);
+    row.setAvatarContent(testStream);
+    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
+    when(event.processEvent(any(), any(), any(), any())).thenThrow(new RuntimeException("test"));
+
+    List<CdsData> data = List.of(row);
+    var exception =
+        assertThrows(RuntimeException.class, () -> cut.processBefore(createContext, data));
+    assertThat(exception.getMessage()).isEqualTo("test");
+  }
+
+  @Test
+  void inlineAttachmentContentLengthWithinLimitProcesses() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId("test-id");
+    var testStream = mock(InputStream.class);
+    row.setAvatarContent(testStream);
+    ParameterInfo paramInfo = mock(ParameterInfo.class);
+    when(paramInfo.getHeader("Content-Length")).thenReturn("100");
+    when(createContext.getParameterInfo()).thenReturn(paramInfo);
+    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
+
+    cut.processBefore(createContext, List.of(row));
+
+    verify(event).processEvent(any(), any(), any(), any());
   }
 
   private void getEntityAndMockContext(String cdsName) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
@@ -380,12 +380,13 @@ class CreateAttachmentsHandlerTest {
     row.setId("test-id");
     var testStream = mock(InputStream.class);
     row.setAvatarContent(testStream);
-    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 
     cut.processBefore(createContext, List.of(row));
 
     ArgumentCaptor<InputStream> streamCaptor = ArgumentCaptor.forClass(InputStream.class);
-    verify(eventFactory).getEvent(streamCaptor.capture(), eq((String) null), any());
+    verify(eventFactory)
+        .processInlineEvent(
+            streamCaptor.capture(), eq((String) null), any(), eq(createContext), any(), any());
     InputStream captured = streamCaptor.getValue();
     assertThat(captured).isInstanceOf(CountingInputStream.class);
     assertThat(((CountingInputStream) captured).getDelegate()).isSameAs(testStream);
@@ -409,11 +410,11 @@ class CreateAttachmentsHandlerTest {
     var row = InlineOnlyTable.create();
     row.setId("test-id");
     row.put(InlineOnlyTable.AVATAR_CONTENT, null);
-    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 
     cut.processBefore(createContext, List.of(row));
 
-    verify(eventFactory).getEvent(eq(null), eq((String) null), any());
+    verify(eventFactory)
+        .processInlineEvent(eq(null), eq((String) null), any(), eq(createContext), any(), any());
   }
 
   @Test
@@ -451,8 +452,8 @@ class CreateAttachmentsHandlerTest {
     row.setId("test-id");
     var testStream = mock(InputStream.class);
     row.setAvatarContent(testStream);
-    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
-    when(event.processEvent(any(), any(), any(), any())).thenThrow(new RuntimeException("test"));
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+        .thenThrow(new RuntimeException("test"));
 
     List<CdsData> data = List.of(row);
     var exception =
@@ -470,11 +471,10 @@ class CreateAttachmentsHandlerTest {
     ParameterInfo paramInfo = mock(ParameterInfo.class);
     when(paramInfo.getHeader("Content-Length")).thenReturn("100");
     when(createContext.getParameterInfo()).thenReturn(paramInfo);
-    when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
 
     cut.processBefore(createContext, List.of(row));
 
-    verify(event).processEvent(any(), any(), any(), any());
+    verify(eventFactory).processInlineEvent(any(), any(), any(), eq(createContext), any(), any());
   }
 
   private void getEntityAndMockContext(String cdsName) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandlerTest.java
@@ -17,6 +17,7 @@ import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Roots;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Roots_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
@@ -110,6 +111,37 @@ class DeleteAttachmentsHandlerTest {
             any(Path.class), eq(inputStream), eq(Attachments.of(attachment2)), eq(context));
     assertThat(attachment1.getContent()).isNull();
     assertThat(attachment2.getContent()).isNull();
+  }
+
+  @Test
+  void inlineAttachmentDataExistsServiceIsCalled() {
+    var entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    when(context.getTarget()).thenReturn(entity);
+    when(context.getModel()).thenReturn(runtime.getCdsModel());
+    var inlineAttachment = Attachments.create();
+    inlineAttachment.setContentId("inline-doc-id");
+    when(attachmentsReader.readInlineAttachments(entity, context.getCqn()))
+        .thenReturn(List.of(inlineAttachment));
+
+    cut.processBefore(context);
+
+    verify(modifyAttachmentEvent)
+        .processEvent(eq(null), eq(null), eq(inlineAttachment), eq(context));
+  }
+
+  @Test
+  void inlineAttachmentWithoutContentIdNotDeleted() {
+    var entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    when(context.getTarget()).thenReturn(entity);
+    when(context.getModel()).thenReturn(runtime.getCdsModel());
+    var inlineAttachment = Attachments.create();
+    // no contentId set
+    when(attachmentsReader.readInlineAttachments(entity, context.getCqn()))
+        .thenReturn(List.of(inlineAttachment));
+
+    cut.processBefore(context);
+
+    verifyNoInteractions(modifyAttachmentEvent);
   }
 
   private Attachment buildAttachment(String id, InputStream inputStream) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
@@ -488,6 +488,28 @@ class ReadAttachmentsHandlerTest {
   }
 
   @Test
+  void inlineAttachmentContentReadsFromServiceWhenContentIsNull() throws IOException {
+    var testString = "inline-read";
+    try (var testStream = new ByteArrayInputStream(testString.getBytes(StandardCharsets.UTF_8))) {
+      mockEventContext(InlineOnlyTable_.CDS_NAME, mock(CqnSelect.class));
+      when(attachmentService.readAttachment("inline-cid-2")).thenReturn(testStream);
+
+      var row = InlineOnlyTable.create();
+      row.setId(UUID.randomUUID().toString());
+      row.setAvatarContentId("inline-cid-2");
+      row.setAvatarStatus(StatusCode.CLEAN);
+      row.setAvatarContent(null);
+
+      cut.processAfter(readEventContext, List.of(row));
+
+      assertThat(row.getAvatarContent()).isInstanceOf(LazyProxyInputStream.class);
+      byte[] bytes = row.getAvatarContent().readAllBytes();
+      assertThat(bytes).isEqualTo(testString.getBytes(StandardCharsets.UTF_8));
+      verify(attachmentService).readAttachment("inline-cid-2");
+    }
+  }
+
+  @Test
   void inlineAttachmentWithoutContentIdNotWrapped() {
     mockEventContext(InlineOnlyTable_.CDS_NAME, mock(CqnSelect.class));
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
@@ -19,6 +19,8 @@ import com.sap.cds.feature.attachments.generated.test.cds4j.sap.attachments.Atta
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.EventItems;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.EventItems_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
@@ -459,6 +461,95 @@ class ReadAttachmentsHandlerTest {
 
     verifyNoInteractions(asyncMalwareScanExecutor);
     verifyNoInteractions(persistenceService);
+  }
+
+  @Test
+  void fieldNamesCorrectReadForInlineOnlyEntity() {
+    var select = Select.from(InlineOnlyTable_.class).columns(InlineOnlyTable_::ID);
+    mockEventContext(InlineOnlyTable_.CDS_NAME, select);
+
+    cut.processBefore(readEventContext);
+  }
+
+  @Test
+  void inlineAttachmentContentWrappedWithLazyProxy() {
+    mockEventContext(InlineOnlyTable_.CDS_NAME, mock(CqnSelect.class));
+
+    var row = InlineOnlyTable.create();
+    row.setId(UUID.randomUUID().toString());
+    row.setAvatarContentId("inline-content-id");
+    row.setAvatarStatus(StatusCode.CLEAN);
+    row.setAvatarContent(null);
+
+    cut.processAfter(readEventContext, List.of(row));
+
+    assertThat(row.getAvatarContent()).isInstanceOf(LazyProxyInputStream.class);
+    verifyNoInteractions(attachmentService);
+  }
+
+  @Test
+  void inlineAttachmentWithoutContentIdNotWrapped() {
+    mockEventContext(InlineOnlyTable_.CDS_NAME, mock(CqnSelect.class));
+
+    var row = InlineOnlyTable.create();
+    row.setId(UUID.randomUUID().toString());
+    row.put(InlineOnlyTable.AVATAR_CONTENT, null);
+
+    cut.processAfter(readEventContext, List.of(row));
+
+    assertThat(row.getAvatarContent()).isNull();
+    verifyNoInteractions(attachmentService);
+  }
+
+  @Test
+  void inlineAttachmentWithExistingStreamIsWrapped() throws IOException {
+    var testString = "inline-test";
+    try (var testStream = new ByteArrayInputStream(testString.getBytes(StandardCharsets.UTF_8))) {
+      mockEventContext(InlineOnlyTable_.CDS_NAME, mock(CqnSelect.class));
+      when(attachmentService.readAttachment(any())).thenReturn(testStream);
+
+      var row = InlineOnlyTable.create();
+      row.setId(UUID.randomUUID().toString());
+      row.setAvatarContentId("inline-content-id");
+      row.setAvatarStatus(StatusCode.CLEAN);
+      row.setAvatarContent(testStream);
+
+      cut.processAfter(readEventContext, List.of(row));
+
+      assertThat(row.getAvatarContent()).isInstanceOf(LazyProxyInputStream.class);
+      verifyNoInteractions(attachmentService);
+      byte[] bytes = row.getAvatarContent().readAllBytes();
+      assertThat(bytes).isEqualTo(testString.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  void inlineAttachmentRowWithoutContentFieldSkipped() {
+    mockEventContext(InlineOnlyTable_.CDS_NAME, mock(CqnSelect.class));
+
+    var row = InlineOnlyTable.create();
+    row.setId(UUID.randomUUID().toString());
+    row.setTitle("test");
+    // avatar_content not present in data at all
+
+    cut.processAfter(readEventContext, List.of(row));
+
+    verifyNoInteractions(attachmentService);
+  }
+
+  @Test
+  void inlineAttachmentNotProcessedForEntityWithoutInline() {
+    mockEventContext(Attachment_.CDS_NAME, mock(CqnSelect.class));
+
+    var attachment = Attachments.create();
+    attachment.setContentId("some ID");
+    attachment.setContent(null);
+    attachment.setStatus(StatusCode.CLEAN);
+    attachment.setScannedAt(Instant.now());
+
+    cut.processAfter(readEventContext, List.of(attachment));
+
+    assertThat(attachment.getContent()).isInstanceOf(LazyProxyInputStream.class);
   }
 
   private void mockEventContext(String entityName, CqnSelect select) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandlerTest.java
@@ -17,6 +17,8 @@ import com.sap.cds.CdsData;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
 import com.sap.cds.feature.attachments.handler.applicationservice.helper.ModifyApplicationHandlerHelper;
@@ -494,6 +496,61 @@ class UpdateAttachmentsHandlerTest {
     verify(attachmentService).markAttachmentAsDeleted(deletionInputCaptor.capture());
     assertThat(deletionInputCaptor.getValue().contentId()).isEqualTo(attachment.getContentId());
     assertThat(deletionInputCaptor.getValue().userInfo()).isEqualTo(userInfo);
+  }
+
+  @Test
+  void inlineAttachmentContentTriggersEventProcessing() {
+    var id = getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var testStream = mock(InputStream.class);
+    var row = InlineOnlyTable.create();
+    row.setId(id);
+    row.setAvatarContent(testStream);
+    when(attachmentsReader.readAttachments(any(), any(), any(CqnFilterableStatement.class)))
+        .thenReturn(List.of());
+    when(attachmentsReader.readInlineAttachments(any(), any(CqnFilterableStatement.class)))
+        .thenReturn(List.of());
+
+    cut.processBefore(updateContext, List.of(row));
+
+    ArgumentCaptor<InputStream> streamCaptor = ArgumentCaptor.forClass(InputStream.class);
+    verify(eventFactory).getEvent(streamCaptor.capture(), eq((String) null), any());
+    InputStream captured = streamCaptor.getValue();
+    assertThat(captured).isInstanceOf(CountingInputStream.class);
+    assertThat(((CountingInputStream) captured).getDelegate()).isSameAs(testStream);
+  }
+
+  @Test
+  void inlineAttachmentWithNoContentNoProcessing() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var row = InlineOnlyTable.create();
+    row.setId(UUID.randomUUID().toString());
+    row.setTitle("just a title update");
+
+    cut.processBefore(updateContext, List.of(row));
+
+    verifyNoInteractions(eventFactory);
+    verifyNoInteractions(attachmentsReader);
+    verifyNoInteractions(attachmentService);
+  }
+
+  @Test
+  void inlineAttachmentWithExistingAttachmentMatchedByKeys() {
+    var id = getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    var testStream = mock(InputStream.class);
+    var row = InlineOnlyTable.create();
+    row.setId(id);
+    row.setAvatarContent(testStream);
+    var existingAttachment = Attachments.create();
+    existingAttachment.put("ID", id);
+    existingAttachment.setContentId("existing-doc-id");
+    when(attachmentsReader.readAttachments(any(), any(), any(CqnFilterableStatement.class)))
+        .thenReturn(List.of());
+    when(attachmentsReader.readInlineAttachments(any(), any(CqnFilterableStatement.class)))
+        .thenReturn(List.of(existingAttachment));
+
+    cut.processBefore(updateContext, List.of(row));
+
+    verify(eventFactory).getEvent(any(), eq((String) null), eq(existingAttachment));
   }
 
   private RootTable fillRootData(InputStream testStream, String id) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandlerTest.java
@@ -515,7 +515,14 @@ class UpdateAttachmentsHandlerTest {
     ArgumentCaptor<InputStream> streamCaptor = ArgumentCaptor.forClass(InputStream.class);
     verify(eventFactory)
         .processInlineEvent(
-            streamCaptor.capture(), eq((String) null), any(), eq(updateContext), any(), any());
+            streamCaptor.capture(),
+            eq((String) null),
+            any(),
+            eq(updateContext),
+            any(),
+            any(),
+            any(),
+            any());
     InputStream captured = streamCaptor.getValue();
     assertThat(captured).isInstanceOf(CountingInputStream.class);
     assertThat(((CountingInputStream) captured).getDelegate()).isSameAs(testStream);
@@ -554,7 +561,14 @@ class UpdateAttachmentsHandlerTest {
 
     verify(eventFactory)
         .processInlineEvent(
-            any(), eq((String) null), eq(existingAttachment), eq(updateContext), any(), any());
+            any(),
+            eq((String) null),
+            eq(existingAttachment),
+            eq(updateContext),
+            any(),
+            any(),
+            any(),
+            any());
   }
 
   private RootTable fillRootData(InputStream testStream, String id) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandlerTest.java
@@ -513,7 +513,9 @@ class UpdateAttachmentsHandlerTest {
     cut.processBefore(updateContext, List.of(row));
 
     ArgumentCaptor<InputStream> streamCaptor = ArgumentCaptor.forClass(InputStream.class);
-    verify(eventFactory).getEvent(streamCaptor.capture(), eq((String) null), any());
+    verify(eventFactory)
+        .processInlineEvent(
+            streamCaptor.capture(), eq((String) null), any(), eq(updateContext), any(), any());
     InputStream captured = streamCaptor.getValue();
     assertThat(captured).isInstanceOf(CountingInputStream.class);
     assertThat(((CountingInputStream) captured).getDelegate()).isSameAs(testStream);
@@ -550,7 +552,9 @@ class UpdateAttachmentsHandlerTest {
 
     cut.processBefore(updateContext, List.of(row));
 
-    verify(eventFactory).getEvent(any(), eq((String) null), eq(existingAttachment));
+    verify(eventFactory)
+        .processInlineEvent(
+            any(), eq((String) null), eq(existingAttachment), eq(updateContext), any(), any());
   }
 
   private RootTable fillRootData(InputStream testStream, String id) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelperTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelperTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +28,7 @@ import com.sap.cds.services.request.ParameterInfo;
 import com.sap.cds.services.runtime.CdsRuntime;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -309,7 +311,7 @@ class ModifyApplicationHandlerHelperTest {
     var existing = Attachments.create();
     existing.setContentId("result-cid");
     existing.setStatus("Clean");
-    existing.setScannedAt(java.time.Instant.parse("2025-01-01T00:00:00Z"));
+    existing.setScannedAt(Instant.parse("2025-01-01T00:00:00Z"));
 
     when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
         .thenReturn(null);
@@ -325,8 +327,7 @@ class ModifyApplicationHandlerHelperTest {
 
     assertThat(row.get("avatar_contentId")).isEqualTo("result-cid");
     assertThat(row.get("avatar_status")).isEqualTo("Clean");
-    assertThat(row.get("avatar_scannedAt"))
-        .isEqualTo(java.time.Instant.parse("2025-01-01T00:00:00Z"));
+    assertThat(row.get("avatar_scannedAt")).isEqualTo(Instant.parse("2025-01-01T00:00:00Z"));
   }
 
   @Test
@@ -485,7 +486,6 @@ class ModifyApplicationHandlerHelperTest {
         ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER);
 
     // No inline processing since avatar_content is not in the row
-    verify(eventFactory, org.mockito.Mockito.never())
-        .processInlineEvent(any(), any(), any(), any(), any(), any());
+    verify(eventFactory, never()).processInlineEvent(any(), any(), any(), any(), any(), any());
   }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelperTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelperTest.java
@@ -8,9 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.sap.cds.CdsData;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEventFactory;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
@@ -213,5 +216,276 @@ class ModifyApplicationHandlerHelperTest {
                     ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER));
 
     assertThat(exception.getErrorStatus()).isEqualTo(ErrorStatuses.BAD_REQUEST);
+  }
+
+  @Test
+  void processInlineAttachmentRow_contentIsNotInputStream_treatedAsNull() {
+    CdsEntity inlineEntity =
+        runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", UUID.randomUUID().toString());
+    row.put("avatar_content", "not-an-input-stream");
+
+    var existing = Attachments.create();
+
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+        .thenReturn(null);
+
+    ModifyApplicationHandlerHelper.processInlineAttachmentRow(
+        row,
+        "avatar",
+        existing,
+        inlineEntity,
+        eventFactory,
+        eventContext,
+        ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER);
+
+    // content should be null since the value was not an InputStream
+    verify(eventFactory).processInlineEvent(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void processInlineAttachmentRow_contentLengthExceedsLimit_throwsException() {
+    CdsEntity inlineEntity =
+        runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", UUID.randomUUID().toString());
+    row.put("avatar_content", mock(InputStream.class));
+
+    var existing = Attachments.create();
+
+    when(parameterInfo.getHeader("Content-Length")).thenReturn("999999999999");
+
+    var exception =
+        assertThrows(
+            ServiceException.class,
+            () ->
+                ModifyApplicationHandlerHelper.processInlineAttachmentRow(
+                    row, "avatar", existing, inlineEntity, eventFactory, eventContext, "10KB"));
+
+    assertThat(exception.getErrorStatus()).isEqualTo(ExtendedErrorStatuses.CONTENT_TOO_LARGE);
+  }
+
+  @Test
+  void processInlineAttachmentRow_invalidContentLengthHeader_throwsBadRequest() {
+    CdsEntity inlineEntity =
+        runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", UUID.randomUUID().toString());
+    row.put("avatar_content", mock(InputStream.class));
+
+    var existing = Attachments.create();
+
+    when(parameterInfo.getHeader("Content-Length")).thenReturn("abc");
+
+    var exception =
+        assertThrows(
+            ServiceException.class,
+            () ->
+                ModifyApplicationHandlerHelper.processInlineAttachmentRow(
+                    row,
+                    "avatar",
+                    existing,
+                    inlineEntity,
+                    eventFactory,
+                    eventContext,
+                    ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER));
+
+    assertThat(exception.getErrorStatus()).isEqualTo(ErrorStatuses.BAD_REQUEST);
+  }
+
+  @Test
+  void processInlineAttachmentRow_writesBackMetadata() {
+    CdsEntity inlineEntity =
+        runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", UUID.randomUUID().toString());
+    row.put("avatar_content", mock(InputStream.class));
+
+    var existing = Attachments.create();
+    existing.setContentId("result-cid");
+    existing.setStatus("Clean");
+    existing.setScannedAt(java.time.Instant.parse("2025-01-01T00:00:00Z"));
+
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+        .thenReturn(null);
+
+    ModifyApplicationHandlerHelper.processInlineAttachmentRow(
+        row,
+        "avatar",
+        existing,
+        inlineEntity,
+        eventFactory,
+        eventContext,
+        ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER);
+
+    assertThat(row.get("avatar_contentId")).isEqualTo("result-cid");
+    assertThat(row.get("avatar_status")).isEqualTo("Clean");
+    assertThat(row.get("avatar_scannedAt"))
+        .isEqualTo(java.time.Instant.parse("2025-01-01T00:00:00Z"));
+  }
+
+  @Test
+  void processInlineAttachmentRow_doNothingEvent_doesNotWriteBackMetadata() {
+    CdsEntity inlineEntity =
+        runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", UUID.randomUUID().toString());
+    row.put("avatar_content", mock(InputStream.class));
+    row.put("avatar_contentId", "pre-existing-cid");
+
+    // Existing attachment without contentId key - simulates doNothing result
+    var existing = Attachments.create();
+
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+        .thenReturn(mock(InputStream.class));
+
+    ModifyApplicationHandlerHelper.processInlineAttachmentRow(
+        row,
+        "avatar",
+        existing,
+        inlineEntity,
+        eventFactory,
+        eventContext,
+        ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER);
+
+    // Pre-existing contentId should be preserved since existing doesn't contain CONTENT_ID key
+    assertThat(row.get("avatar_contentId")).isEqualTo("pre-existing-cid");
+  }
+
+  @Test
+  void processInlineAttachmentRow_limitExceeded_throwsTooLarge() {
+    CdsEntity inlineEntity =
+        runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", UUID.randomUUID().toString());
+    byte[] largeContent = new byte[15000]; // 15KB
+    row.put("avatar_content", new ByteArrayInputStream(largeContent));
+
+    var existing = Attachments.create();
+
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              InputStream wrapped = invocation.getArgument(0);
+              if (wrapped != null) {
+                byte[] buffer = new byte[1024];
+                while (wrapped.read(buffer) != -1) {}
+              }
+              return null;
+            });
+
+    var exception =
+        assertThrows(
+            ServiceException.class,
+            () ->
+                ModifyApplicationHandlerHelper.processInlineAttachmentRow(
+                    row, "avatar", existing, inlineEntity, eventFactory, eventContext, "10KB"));
+
+    assertThat(exception.getErrorStatus()).isEqualTo(ExtendedErrorStatuses.CONTENT_TOO_LARGE);
+  }
+
+  @Test
+  void processInlineAttachmentRow_nonLimitException_rethrown() {
+    CdsEntity inlineEntity =
+        runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", UUID.randomUUID().toString());
+    row.put("avatar_content", mock(InputStream.class));
+
+    var existing = Attachments.create();
+
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+        .thenThrow(new RuntimeException("unexpected"));
+
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            ModifyApplicationHandlerHelper.processInlineAttachmentRow(
+                row,
+                "avatar",
+                existing,
+                inlineEntity,
+                eventFactory,
+                eventContext,
+                ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER));
+  }
+
+  @Test
+  void processInlineAttachmentRow_nullContent_noCountingInputStream() {
+    CdsEntity inlineEntity =
+        runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", UUID.randomUUID().toString());
+    row.put("avatar_content", null);
+
+    var existing = Attachments.create();
+
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+        .thenReturn(null);
+
+    assertDoesNotThrow(
+        () ->
+            ModifyApplicationHandlerHelper.processInlineAttachmentRow(
+                row,
+                "avatar",
+                existing,
+                inlineEntity,
+                eventFactory,
+                eventContext,
+                ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER));
+  }
+
+  @Test
+  void handleAttachmentForEntities_withInlineAttachments_processesInline() {
+    CdsEntity inlineEntity =
+        runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", UUID.randomUUID().toString());
+    row.put("avatar_content", mock(InputStream.class));
+
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+        .thenReturn(null);
+
+    ModifyApplicationHandlerHelper.handleAttachmentForEntities(
+        inlineEntity,
+        List.of(row),
+        List.of(),
+        eventFactory,
+        eventContext,
+        ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER);
+
+    verify(eventFactory).processInlineEvent(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void handleAttachmentForEntities_withoutInlineContent_skipsInline() {
+    CdsEntity inlineEntity =
+        runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", UUID.randomUUID().toString());
+    row.put("title", "no inline");
+
+    ModifyApplicationHandlerHelper.handleAttachmentForEntities(
+        inlineEntity,
+        List.of(row),
+        List.of(),
+        eventFactory,
+        eventContext,
+        ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER);
+
+    // No inline processing since avatar_content is not in the row
+    verify(eventFactory, org.mockito.Mockito.never())
+        .processInlineEvent(any(), any(), any(), any(), any(), any());
   }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelperTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelperTest.java
@@ -231,7 +231,7 @@ class ModifyApplicationHandlerHelperTest {
 
     var existing = Attachments.create();
 
-    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(null);
 
     ModifyApplicationHandlerHelper.processInlineAttachmentRow(
@@ -244,7 +244,7 @@ class ModifyApplicationHandlerHelperTest {
         ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER);
 
     // content should be null since the value was not an InputStream
-    verify(eventFactory).processInlineEvent(any(), any(), any(), any(), any(), any());
+    verify(eventFactory).processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -313,7 +313,7 @@ class ModifyApplicationHandlerHelperTest {
     existing.setStatus("Clean");
     existing.setScannedAt(Instant.parse("2025-01-01T00:00:00Z"));
 
-    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(null);
 
     ModifyApplicationHandlerHelper.processInlineAttachmentRow(
@@ -343,7 +343,7 @@ class ModifyApplicationHandlerHelperTest {
     // Existing attachment without contentId key - simulates doNothing result
     var existing = Attachments.create();
 
-    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(mock(InputStream.class));
 
     ModifyApplicationHandlerHelper.processInlineAttachmentRow(
@@ -371,7 +371,7 @@ class ModifyApplicationHandlerHelperTest {
 
     var existing = Attachments.create();
 
-    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenAnswer(
             invocation -> {
               InputStream wrapped = invocation.getArgument(0);
@@ -403,7 +403,7 @@ class ModifyApplicationHandlerHelperTest {
 
     var existing = Attachments.create();
 
-    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenThrow(new RuntimeException("unexpected"));
 
     assertThrows(
@@ -430,7 +430,7 @@ class ModifyApplicationHandlerHelperTest {
 
     var existing = Attachments.create();
 
-    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(null);
 
     assertDoesNotThrow(
@@ -454,7 +454,7 @@ class ModifyApplicationHandlerHelperTest {
     row.put("ID", UUID.randomUUID().toString());
     row.put("avatar_content", mock(InputStream.class));
 
-    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(null);
 
     ModifyApplicationHandlerHelper.handleAttachmentForEntities(
@@ -465,7 +465,7 @@ class ModifyApplicationHandlerHelperTest {
         eventContext,
         ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER);
 
-    verify(eventFactory).processInlineEvent(any(), any(), any(), any(), any(), any());
+    verify(eventFactory).processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -486,6 +486,7 @@ class ModifyApplicationHandlerHelperTest {
         ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER);
 
     // No inline processing since avatar_content is not in the row
-    verify(eventFactory, never()).processInlineEvent(any(), any(), any(), any(), any(), any());
+    verify(eventFactory, never())
+        .processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any());
   }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancerTest.java
@@ -9,11 +9,15 @@ import com.sap.cds.CdsData;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Events_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.services.runtime.CdsRuntime;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -138,5 +142,154 @@ class ReadonlyDataContextEnhancerTest {
     ReadonlyDataContextEnhancer.preserveReadonlyFields(entity, List.of(attachment), false);
 
     assertThat(attachment.get(DRAFT_READONLY_CONTEXT)).isNull();
+  }
+
+  @Test
+  void preserveInlineReadonlyFields_isDraft_backupsInlineFields() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", "row-1");
+    row.put("avatar_contentId", "doc-inline-123");
+    row.put("avatar_status", "Clean");
+    Instant scannedAt = Instant.parse("2024-06-01T12:00:00Z");
+    row.put("avatar_scannedAt", scannedAt);
+
+    ReadonlyDataContextEnhancer.preserveInlineReadonlyFields(entity, List.of(row), true);
+
+    assertThat(row.get("INLINE_READONLY_CONTEXT")).isNotNull();
+    @SuppressWarnings("unchecked")
+    Map<String, Object> backup = (Map<String, Object>) row.get("INLINE_READONLY_CONTEXT");
+    assertThat(backup)
+        .containsEntry("avatar_contentId", "doc-inline-123")
+        .containsEntry("avatar_status", "Clean")
+        .containsEntry("avatar_scannedAt", scannedAt);
+  }
+
+  @Test
+  void preserveInlineReadonlyFields_isNotDraft_removesBackup() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", "row-1");
+    row.put("INLINE_READONLY_CONTEXT", Map.of("avatar_contentId", "old-id"));
+
+    ReadonlyDataContextEnhancer.preserveInlineReadonlyFields(entity, List.of(row), false);
+
+    assertThat(row.get("INLINE_READONLY_CONTEXT")).isNull();
+  }
+
+  @Test
+  void preserveInlineReadonlyFields_noInlinePrefixes_doesNothing() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Items_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", "row-1");
+
+    ReadonlyDataContextEnhancer.preserveInlineReadonlyFields(entity, List.of(row), true);
+
+    assertThat(row.get("INLINE_READONLY_CONTEXT")).isNull();
+  }
+
+  @Test
+  void preserveInlineReadonlyFields_mediaEntity_doesNothing() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", "row-1");
+
+    ReadonlyDataContextEnhancer.preserveInlineReadonlyFields(entity, List.of(row), true);
+
+    assertThat(row.get("INLINE_READONLY_CONTEXT")).isNull();
+  }
+
+  @Test
+  void preserveInlineReadonlyFields_partialFieldsPresent_onlyBackupsExisting() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", "row-1");
+    row.put("avatar_contentId", "doc-partial");
+    // status and scannedAt not present
+
+    ReadonlyDataContextEnhancer.preserveInlineReadonlyFields(entity, List.of(row), true);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> backup = (Map<String, Object>) row.get("INLINE_READONLY_CONTEXT");
+    assertThat(backup)
+        .containsEntry("avatar_contentId", "doc-partial")
+        .doesNotContainKey("avatar_status")
+        .doesNotContainKey("avatar_scannedAt");
+  }
+
+  @Test
+  void preserveInlineReadonlyFields_noFieldsPresent_noBackupCreated() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", "row-1");
+    row.put("title", "Test");
+
+    ReadonlyDataContextEnhancer.preserveInlineReadonlyFields(entity, List.of(row), true);
+
+    assertThat(row.get("INLINE_READONLY_CONTEXT")).isNull();
+  }
+
+  @Test
+  void restoreInlineReadonlyFields_withBackup_restoresAndRemovesContext() {
+    var row = CdsData.create();
+    row.put("ID", "row-1");
+    row.put(
+        "INLINE_READONLY_CONTEXT",
+        Map.of("avatar_contentId", "restored-cid", "avatar_status", "Clean"));
+
+    ReadonlyDataContextEnhancer.restoreInlineReadonlyFields(List.of(row));
+
+    assertThat(row.get("avatar_contentId")).isEqualTo("restored-cid");
+    assertThat(row.get("avatar_status")).isEqualTo("Clean");
+    assertThat(row.get("INLINE_READONLY_CONTEXT")).isNull();
+  }
+
+  @Test
+  void restoreInlineReadonlyFields_withoutBackup_noOp() {
+    var row = CdsData.create();
+    row.put("ID", "row-1");
+    row.put("title", "Test");
+
+    ReadonlyDataContextEnhancer.restoreInlineReadonlyFields(List.of(row));
+
+    assertThat(row).containsEntry("ID", "row-1");
+    assertThat(row).containsEntry("title", "Test");
+    assertThat(row).doesNotContainKey("INLINE_READONLY_CONTEXT");
+  }
+
+  @Test
+  void restoreInlineReadonlyFields_nonMapBackup_ignored() {
+    var row = CdsData.create();
+    row.put("ID", "row-1");
+    row.put("INLINE_READONLY_CONTEXT", "not-a-map");
+
+    ReadonlyDataContextEnhancer.restoreInlineReadonlyFields(List.of(row));
+
+    // The non-map value should remain, as the instanceof check fails
+    assertThat(row.get("INLINE_READONLY_CONTEXT")).isEqualTo("not-a-map");
+  }
+
+  @Test
+  void preserveInlineReadonlyFields_rootTableWithInline_backupsProfilePicture() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(RootTable_.CDS_NAME).orElseThrow();
+
+    var row = CdsData.create();
+    row.put("ID", "root-1");
+    row.put("profilePicture_contentId", "pp-cid");
+    row.put("profilePicture_status", "Infected");
+
+    ReadonlyDataContextEnhancer.preserveInlineReadonlyFields(entity, List.of(row), true);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> backup = (Map<String, Object>) row.get("INLINE_READONLY_CONTEXT");
+    assertThat(backup)
+        .containsEntry("profilePicture_contentId", "pp-cid")
+        .containsEntry("profilePicture_status", "Infected");
   }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/mimeTypeValidation/MediaTypeResolverTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/mimeTypeValidation/MediaTypeResolverTest.java
@@ -36,7 +36,7 @@ class MediaTypeResolverTest {
 
     when(model.getEntity("MediaEntity")).thenReturn(media);
 
-    when(media.getElement("content")).thenReturn(element);
+    when(media.findElement("content")).thenReturn(Optional.of(element));
     when(element.findAnnotation("Core.AcceptableMediaTypes")).thenReturn(Optional.of(annotation));
     when(annotation.getValue()).thenReturn(List.of("image/png", "image/jpeg"));
 
@@ -52,7 +52,7 @@ class MediaTypeResolverTest {
     CdsEntity media = mock(CdsEntity.class);
 
     when(model.getEntity("MediaEntity")).thenReturn(media);
-    when(media.getElement(any())).thenReturn(null);
+    when(media.findElement(any())).thenReturn(Optional.empty());
 
     Map<String, List<String>> result =
         MediaTypeResolver.getAcceptableMediaTypesFromEntity(model, List.of("MediaEntity"));

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEventTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEventTest.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -124,6 +125,23 @@ class CreateAttachmentEventTest {
 
     assertThat(attachment.getContentId()).isEqualTo(attachmentServiceResult.contentId());
     assertThat(attachment.getStatus()).isEqualTo(attachmentServiceResult.status());
+  }
+
+  @Test
+  void scannedAtStoredInPathWhenNonNull() {
+    var attachment = Attachments.create();
+    attachment.setId("test");
+    Instant scannedAt = Instant.parse("2025-06-01T10:00:00Z");
+    var attachmentServiceResult =
+        new AttachmentModificationResult(false, "some document id", "Clean", scannedAt);
+    when(attachmentService.createAttachment(any())).thenReturn(attachmentServiceResult);
+    when(target.values()).thenReturn(attachment);
+
+    cut.processEvent(path, attachment.getContent(), Attachments.create(), eventContext);
+
+    assertThat(attachment.getContentId()).isEqualTo("some document id");
+    assertThat(attachment.getStatus()).isEqualTo("Clean");
+    assertThat(attachment.get(Attachments.SCANNED_AT)).isEqualTo(scannedAt);
   }
 
   @Test

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEventFactoryTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEventFactoryTest.java
@@ -10,10 +10,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.sap.cds.CdsData;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.handler.applicationservice.transaction.ListenerProvider;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.model.service.AttachmentModificationResult;
+import com.sap.cds.feature.attachments.service.model.service.CreateAttachmentInput;
 import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.services.EventContext;
@@ -31,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 
 class ModifyAttachmentEventFactoryTest {
 
@@ -44,6 +47,8 @@ class ModifyAttachmentEventFactoryTest {
   private ListenerProvider listenerProvider;
   private EventContext eventContext;
   private CdsEntity entity;
+  private CdsData row;
+  private static final String PREFIX = "avatar";
 
   @BeforeEach
   void setup() {
@@ -71,6 +76,7 @@ class ModifyAttachmentEventFactoryTest {
     when(target.getQualifiedName()).thenReturn("test.Entity");
     var userInfo = mock(UserInfo.class);
     when(eventContext.getUserInfo()).thenReturn(userInfo);
+    row = CdsData.create();
   }
 
   @Test
@@ -200,7 +206,8 @@ class ModifyAttachmentEventFactoryTest {
     Map<String, Object> keys = Map.of("ID", "k1");
 
     InputStream result =
-        cut.processInlineEvent(content, "same-id", existing, eventContext, entity, keys);
+        cut.processInlineEvent(
+            content, "same-id", existing, eventContext, entity, keys, row, PREFIX);
 
     assertThat(result).isSameAs(content);
   }
@@ -217,13 +224,37 @@ class ModifyAttachmentEventFactoryTest {
         new AttachmentModificationResult(false, "new-cid", "Clean", Instant.now()));
 
     InputStream result =
-        cut.processInlineEvent(content, null, existing, eventContext, entity, keys);
+        cut.processInlineEvent(content, null, existing, eventContext, entity, keys, row, PREFIX);
 
     verify(attachmentService).createAttachment(any());
     assertThat(existing.getContentId()).isEqualTo("new-cid");
     assertThat(existing.getStatus()).isEqualTo("Clean");
     assertThat(existing.getScannedAt()).isNotNull();
     assertThat(result).isNull();
+  }
+
+  @Test
+  void processInlineEvent_create_readsMetadataFromRowPrefixedFields() {
+    var content = mock(InputStream.class);
+    var existing = Attachments.create();
+    existing.put(Attachments.MIME_TYPE, "old/type");
+    existing.put(Attachments.FILE_NAME, "old.txt");
+    Map<String, Object> keys = Map.of("ID", "k1");
+
+    row.put("avatar_mimeType", "image/png");
+    row.put("avatar_fileName", "new-avatar.png");
+
+    stubCreateAttachment(
+        new AttachmentModificationResult(false, "new-cid", "Clean", Instant.now()));
+
+    ArgumentCaptor<CreateAttachmentInput> inputCaptor =
+        ArgumentCaptor.forClass(CreateAttachmentInput.class);
+
+    cut.processInlineEvent(content, null, existing, eventContext, entity, keys, row, PREFIX);
+
+    verify(attachmentService).createAttachment(inputCaptor.capture());
+    assertThat(inputCaptor.getValue().fileName()).isEqualTo("new-avatar.png");
+    assertThat(inputCaptor.getValue().mimeType()).isEqualTo("image/png");
   }
 
   @Test
@@ -235,7 +266,7 @@ class ModifyAttachmentEventFactoryTest {
     stubCreateAttachment(new AttachmentModificationResult(true, "new-cid", "Clean", null));
 
     InputStream result =
-        cut.processInlineEvent(content, null, existing, eventContext, entity, keys);
+        cut.processInlineEvent(content, null, existing, eventContext, entity, keys, row, PREFIX);
 
     assertThat(result).isSameAs(content);
     assertThat(existing.getScannedAt()).isNull();
@@ -251,7 +282,7 @@ class ModifyAttachmentEventFactoryTest {
     stubCreateAttachment(new AttachmentModificationResult(false, "new-cid", "Clean", null));
 
     InputStream result =
-        cut.processInlineEvent(content, null, existing, eventContext, entity, keys);
+        cut.processInlineEvent(content, null, existing, eventContext, entity, keys, row, PREFIX);
 
     verify(deleteAttachmentService).markAttachmentAsDeleted(any(MarkAsDeletedInput.class));
     verify(attachmentService).createAttachment(any());
@@ -267,7 +298,8 @@ class ModifyAttachmentEventFactoryTest {
     existing.setScannedAt(Instant.now());
     Map<String, Object> keys = Map.of("ID", "k1");
 
-    InputStream result = cut.processInlineEvent(null, null, existing, eventContext, entity, keys);
+    InputStream result =
+        cut.processInlineEvent(null, null, existing, eventContext, entity, keys, row, PREFIX);
 
     verify(deleteAttachmentService).markAttachmentAsDeleted(any(MarkAsDeletedInput.class));
     assertThat(existing.getContentId()).isNull();
@@ -283,7 +315,8 @@ class ModifyAttachmentEventFactoryTest {
     Map<String, Object> keys = Map.of("ID", "k1");
     when(eventContext.getEvent()).thenReturn(DraftService.EVENT_DRAFT_PATCH);
 
-    InputStream result = cut.processInlineEvent(null, null, existing, eventContext, entity, keys);
+    InputStream result =
+        cut.processInlineEvent(null, null, existing, eventContext, entity, keys, row, PREFIX);
 
     verifyNoInteractions(deleteAttachmentService);
     assertThat(existing.getContentId()).isNull();
@@ -301,7 +334,7 @@ class ModifyAttachmentEventFactoryTest {
     stubCreateAttachment(new AttachmentModificationResult(false, "new-cid", "Clean", null));
 
     InputStream result =
-        cut.processInlineEvent(content, null, existing, eventContext, entity, keys);
+        cut.processInlineEvent(content, null, existing, eventContext, entity, keys, row, PREFIX);
 
     verifyNoInteractions(deleteAttachmentService);
     verify(attachmentService).createAttachment(any());
@@ -314,7 +347,8 @@ class ModifyAttachmentEventFactoryTest {
     var existing = Attachments.create();
     Map<String, Object> keys = Map.of("ID", "k1");
 
-    InputStream result = cut.processInlineEvent(null, null, existing, eventContext, entity, keys);
+    InputStream result =
+        cut.processInlineEvent(null, null, existing, eventContext, entity, keys, row, PREFIX);
 
     assertThat(result).isNull();
     verifyNoInteractions(deleteAttachmentService);

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEventFactoryTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEventFactoryTest.java
@@ -213,11 +213,8 @@ class ModifyAttachmentEventFactoryTest {
     existing.put(Attachments.FILE_NAME, "avatar.png");
     Map<String, Object> keys = Map.of("ID", "k1");
 
-    when(attachmentService.createAttachment(any()))
-        .thenReturn(new AttachmentModificationResult(false, "new-cid", "Clean", Instant.now()));
-    when(listenerProvider.provideListener(any(), any())).thenReturn(mock(ChangeSetListener.class));
-    var cdsRuntime = mock(CdsRuntime.class);
-    when(eventContext.getCdsRuntime()).thenReturn(cdsRuntime);
+    stubCreateAttachment(
+        new AttachmentModificationResult(false, "new-cid", "Clean", Instant.now()));
 
     InputStream result =
         cut.processInlineEvent(content, null, existing, eventContext, entity, keys);
@@ -235,11 +232,7 @@ class ModifyAttachmentEventFactoryTest {
     var existing = Attachments.create();
     Map<String, Object> keys = Map.of("ID", "k1");
 
-    when(attachmentService.createAttachment(any()))
-        .thenReturn(new AttachmentModificationResult(true, "new-cid", "Clean", null));
-    when(listenerProvider.provideListener(any(), any())).thenReturn(mock(ChangeSetListener.class));
-    var cdsRuntime = mock(CdsRuntime.class);
-    when(eventContext.getCdsRuntime()).thenReturn(cdsRuntime);
+    stubCreateAttachment(new AttachmentModificationResult(true, "new-cid", "Clean", null));
 
     InputStream result =
         cut.processInlineEvent(content, null, existing, eventContext, entity, keys);
@@ -255,11 +248,7 @@ class ModifyAttachmentEventFactoryTest {
     existing.setContentId("old-cid");
     Map<String, Object> keys = Map.of("ID", "k1");
 
-    when(attachmentService.createAttachment(any()))
-        .thenReturn(new AttachmentModificationResult(false, "new-cid", "Clean", null));
-    when(listenerProvider.provideListener(any(), any())).thenReturn(mock(ChangeSetListener.class));
-    var cdsRuntime = mock(CdsRuntime.class);
-    when(eventContext.getCdsRuntime()).thenReturn(cdsRuntime);
+    stubCreateAttachment(new AttachmentModificationResult(false, "new-cid", "Clean", null));
 
     InputStream result =
         cut.processInlineEvent(content, null, existing, eventContext, entity, keys);
@@ -309,11 +298,7 @@ class ModifyAttachmentEventFactoryTest {
     Map<String, Object> keys = Map.of("ID", "k1");
     when(eventContext.getEvent()).thenReturn(DraftService.EVENT_DRAFT_PATCH);
 
-    when(attachmentService.createAttachment(any()))
-        .thenReturn(new AttachmentModificationResult(false, "new-cid", "Clean", null));
-    when(listenerProvider.provideListener(any(), any())).thenReturn(mock(ChangeSetListener.class));
-    var cdsRuntime = mock(CdsRuntime.class);
-    when(eventContext.getCdsRuntime()).thenReturn(cdsRuntime);
+    stubCreateAttachment(new AttachmentModificationResult(false, "new-cid", "Clean", null));
 
     InputStream result =
         cut.processInlineEvent(content, null, existing, eventContext, entity, keys);
@@ -333,5 +318,11 @@ class ModifyAttachmentEventFactoryTest {
 
     assertThat(result).isNull();
     verifyNoInteractions(deleteAttachmentService);
+  }
+
+  private void stubCreateAttachment(AttachmentModificationResult result) {
+    when(attachmentService.createAttachment(any())).thenReturn(result);
+    when(listenerProvider.provideListener(any(), any())).thenReturn(mock(ChangeSetListener.class));
+    when(eventContext.getCdsRuntime()).thenReturn(mock(CdsRuntime.class));
   }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEventFactoryTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEventFactoryTest.java
@@ -4,10 +4,27 @@
 package com.sap.cds.feature.attachments.handler.applicationservice.modifyevents;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.applicationservice.transaction.ListenerProvider;
+import com.sap.cds.feature.attachments.service.AttachmentService;
+import com.sap.cds.feature.attachments.service.model.service.AttachmentModificationResult;
+import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
+import com.sap.cds.reflect.CdsEntity;
+import com.sap.cds.services.EventContext;
+import com.sap.cds.services.changeset.ChangeSetContext;
+import com.sap.cds.services.changeset.ChangeSetListener;
+import com.sap.cds.services.draft.DraftService;
+import com.sap.cds.services.request.UserInfo;
+import com.sap.cds.services.runtime.CdsRuntime;
 import java.io.InputStream;
+import java.time.Instant;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,17 +39,38 @@ class ModifyAttachmentEventFactoryTest {
   private UpdateAttachmentEvent updateEvent;
   private MarkAsDeletedAttachmentEvent deleteContentEvent;
   private DoNothingAttachmentEvent doNothingEvent;
+  private AttachmentService attachmentService;
+  private AttachmentService deleteAttachmentService;
+  private ListenerProvider listenerProvider;
+  private EventContext eventContext;
+  private CdsEntity entity;
 
   @BeforeEach
   void setup() {
-    createEvent = mock(CreateAttachmentEvent.class);
-    updateEvent = mock(UpdateAttachmentEvent.class);
-    deleteContentEvent = mock(MarkAsDeletedAttachmentEvent.class);
-    doNothingEvent = mock(DoNothingAttachmentEvent.class);
+    attachmentService = mock(AttachmentService.class);
+    deleteAttachmentService = mock(AttachmentService.class);
+    listenerProvider = mock(ListenerProvider.class);
+    createEvent = new CreateAttachmentEvent(attachmentService, listenerProvider);
+    updateEvent =
+        new UpdateAttachmentEvent(
+            createEvent, new MarkAsDeletedAttachmentEvent(deleteAttachmentService));
+    deleteContentEvent = new MarkAsDeletedAttachmentEvent(deleteAttachmentService);
+    doNothingEvent = new DoNothingAttachmentEvent();
 
     cut =
         new ModifyAttachmentEventFactory(
             createEvent, updateEvent, deleteContentEvent, doNothingEvent);
+
+    eventContext = mock(EventContext.class);
+    entity = mock(CdsEntity.class);
+    when(entity.getQualifiedName()).thenReturn("test.Entity");
+    var changeSetContext = mock(ChangeSetContext.class);
+    when(eventContext.getChangeSetContext()).thenReturn(changeSetContext);
+    var target = mock(CdsEntity.class);
+    when(eventContext.getTarget()).thenReturn(target);
+    when(target.getQualifiedName()).thenReturn("test.Entity");
+    var userInfo = mock(UserInfo.class);
+    when(eventContext.getUserInfo()).thenReturn(userInfo);
   }
 
   @Test
@@ -152,5 +190,148 @@ class ModifyAttachmentEventFactoryTest {
     var event = cut.getEvent(mock(InputStream.class), "someValue", data);
 
     assertThat(event).isEqualTo(updateEvent);
+  }
+
+  @Test
+  void processInlineEvent_doNothing_returnsContentUnchanged() {
+    var content = mock(InputStream.class);
+    var existing = Attachments.create();
+    existing.setContentId("same-id");
+    Map<String, Object> keys = Map.of("ID", "k1");
+
+    InputStream result =
+        cut.processInlineEvent(content, "same-id", existing, eventContext, entity, keys);
+
+    assertThat(result).isSameAs(content);
+  }
+
+  @Test
+  void processInlineEvent_create_callsAttachmentService() {
+    var content = mock(InputStream.class);
+    var existing = Attachments.create();
+    existing.put(Attachments.MIME_TYPE, "image/png");
+    existing.put(Attachments.FILE_NAME, "avatar.png");
+    Map<String, Object> keys = Map.of("ID", "k1");
+
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "new-cid", "Clean", Instant.now()));
+    when(listenerProvider.provideListener(any(), any())).thenReturn(mock(ChangeSetListener.class));
+    var cdsRuntime = mock(CdsRuntime.class);
+    when(eventContext.getCdsRuntime()).thenReturn(cdsRuntime);
+
+    InputStream result =
+        cut.processInlineEvent(content, null, existing, eventContext, entity, keys);
+
+    verify(attachmentService).createAttachment(any());
+    assertThat(existing.getContentId()).isEqualTo("new-cid");
+    assertThat(existing.getStatus()).isEqualTo("Clean");
+    assertThat(existing.getScannedAt()).isNotNull();
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void processInlineEvent_create_internalStored_returnsContent() {
+    var content = mock(InputStream.class);
+    var existing = Attachments.create();
+    Map<String, Object> keys = Map.of("ID", "k1");
+
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(true, "new-cid", "Clean", null));
+    when(listenerProvider.provideListener(any(), any())).thenReturn(mock(ChangeSetListener.class));
+    var cdsRuntime = mock(CdsRuntime.class);
+    when(eventContext.getCdsRuntime()).thenReturn(cdsRuntime);
+
+    InputStream result =
+        cut.processInlineEvent(content, null, existing, eventContext, entity, keys);
+
+    assertThat(result).isSameAs(content);
+    assertThat(existing.getScannedAt()).isNull();
+  }
+
+  @Test
+  void processInlineEvent_update_deletesOldAndCreatesNew() {
+    var content = mock(InputStream.class);
+    var existing = Attachments.create();
+    existing.setContentId("old-cid");
+    Map<String, Object> keys = Map.of("ID", "k1");
+
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "new-cid", "Clean", null));
+    when(listenerProvider.provideListener(any(), any())).thenReturn(mock(ChangeSetListener.class));
+    var cdsRuntime = mock(CdsRuntime.class);
+    when(eventContext.getCdsRuntime()).thenReturn(cdsRuntime);
+
+    InputStream result =
+        cut.processInlineEvent(content, null, existing, eventContext, entity, keys);
+
+    verify(deleteAttachmentService).markAttachmentAsDeleted(any(MarkAsDeletedInput.class));
+    verify(attachmentService).createAttachment(any());
+    assertThat(existing.getContentId()).isEqualTo("new-cid");
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void processInlineEvent_delete_marksAsDeletedAndClearsFields() {
+    var existing = Attachments.create();
+    existing.setContentId("old-cid");
+    existing.setStatus("Clean");
+    existing.setScannedAt(Instant.now());
+    Map<String, Object> keys = Map.of("ID", "k1");
+
+    InputStream result = cut.processInlineEvent(null, null, existing, eventContext, entity, keys);
+
+    verify(deleteAttachmentService).markAttachmentAsDeleted(any(MarkAsDeletedInput.class));
+    assertThat(existing.getContentId()).isNull();
+    assertThat(existing.getStatus()).isNull();
+    assertThat(existing.getScannedAt()).isNull();
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void processInlineEvent_deleteWithDraftPatchEvent_skipsMarkAsDeleted() {
+    var existing = Attachments.create();
+    existing.setContentId("old-cid");
+    Map<String, Object> keys = Map.of("ID", "k1");
+    when(eventContext.getEvent()).thenReturn(DraftService.EVENT_DRAFT_PATCH);
+
+    InputStream result = cut.processInlineEvent(null, null, existing, eventContext, entity, keys);
+
+    verifyNoInteractions(deleteAttachmentService);
+    assertThat(existing.getContentId()).isNull();
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void processInlineEvent_updateWithDraftPatchEvent_skipsMarkAsDeletedButCreates() {
+    var content = mock(InputStream.class);
+    var existing = Attachments.create();
+    existing.setContentId("old-cid");
+    Map<String, Object> keys = Map.of("ID", "k1");
+    when(eventContext.getEvent()).thenReturn(DraftService.EVENT_DRAFT_PATCH);
+
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "new-cid", "Clean", null));
+    when(listenerProvider.provideListener(any(), any())).thenReturn(mock(ChangeSetListener.class));
+    var cdsRuntime = mock(CdsRuntime.class);
+    when(eventContext.getCdsRuntime()).thenReturn(cdsRuntime);
+
+    InputStream result =
+        cut.processInlineEvent(content, null, existing, eventContext, entity, keys);
+
+    verifyNoInteractions(deleteAttachmentService);
+    verify(attachmentService).createAttachment(any());
+    assertThat(existing.getContentId()).isEqualTo("new-cid");
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void processInlineEvent_deleteWithNullContentId_skipsMarkAsDeleted() {
+    var existing = Attachments.create();
+    Map<String, Object> keys = Map.of("ID", "k1");
+
+    InputStream result = cut.processInlineEvent(null, null, existing, eventContext, entity, keys);
+
+    assertThat(result).isNull();
+    verifyNoInteractions(deleteAttachmentService);
   }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/readhelper/BeforeReadItemsModifierTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/readhelper/BeforeReadItemsModifierTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
 import com.sap.cds.ql.Select;
@@ -135,6 +136,100 @@ class BeforeReadItemsModifierTest {
         Select.from(Attachment_.class).columns(Attachment_::content, Attachment_::contentId);
 
     runTestForDirectSelect(select, 1);
+  }
+
+  @Test
+  void inlineSelectExtendsWithContentIdAndStatusAndScannedAt() {
+    CqnSelect select =
+        Select.from(InlineOnlyTable_.class)
+            .columns(InlineOnlyTable_::ID, InlineOnlyTable_::avatar_content);
+
+    cut = new BeforeReadItemsModifier(List.of(BeforeReadItemsModifier.INLINE_PREFIX + "avatar"));
+    List<CqnSelectListItem> resultItems = cut.items(select.items());
+
+    long contentIdCount =
+        resultItems.stream()
+            .filter(
+                item ->
+                    item.isRef()
+                        && item.asRef().displayName().equals("avatar_" + Attachments.CONTENT_ID))
+            .count();
+    long statusCount =
+        resultItems.stream()
+            .filter(
+                item ->
+                    item.isRef()
+                        && item.asRef().displayName().equals("avatar_" + Attachments.STATUS))
+            .count();
+    long scannedAtCount =
+        resultItems.stream()
+            .filter(
+                item ->
+                    item.isRef()
+                        && item.asRef().displayName().equals("avatar_" + Attachments.SCANNED_AT))
+            .count();
+    assertThat(contentIdCount).isEqualTo(1);
+    assertThat(statusCount).isEqualTo(1);
+    assertThat(scannedAtCount).isEqualTo(1);
+  }
+
+  @Test
+  void inlineSelectDoesNotExtendIfNoContentField() {
+    CqnSelect select = Select.from(InlineOnlyTable_.class).columns(InlineOnlyTable_::ID);
+
+    cut = new BeforeReadItemsModifier(List.of(BeforeReadItemsModifier.INLINE_PREFIX + "avatar"));
+    List<CqnSelectListItem> resultItems = cut.items(select.items());
+
+    long contentIdCount =
+        resultItems.stream()
+            .filter(
+                item ->
+                    item.isRef()
+                        && item.asRef().displayName().equals("avatar_" + Attachments.CONTENT_ID))
+            .count();
+    assertThat(contentIdCount).isZero();
+  }
+
+  @Test
+  void inlineSelectDoesNotExtendIfContentIdAlreadyPresent() {
+    CqnSelect select =
+        Select.from(InlineOnlyTable_.class)
+            .columns(
+                InlineOnlyTable_::ID,
+                InlineOnlyTable_::avatar_content,
+                InlineOnlyTable_::avatar_contentId);
+
+    cut = new BeforeReadItemsModifier(List.of(BeforeReadItemsModifier.INLINE_PREFIX + "avatar"));
+    List<CqnSelectListItem> resultItems = cut.items(select.items());
+
+    long contentIdCount =
+        resultItems.stream()
+            .filter(
+                item ->
+                    item.isRef()
+                        && item.asRef().displayName().equals("avatar_" + Attachments.CONTENT_ID))
+            .count();
+    // already present, should not be duplicated
+    assertThat(contentIdCount).isEqualTo(1);
+  }
+
+  @Test
+  void inlineSelectDoesNotExtendForNonInlinePrefix() {
+    CqnSelect select =
+        Select.from(InlineOnlyTable_.class)
+            .columns(InlineOnlyTable_::ID, InlineOnlyTable_::avatar_content);
+
+    cut = new BeforeReadItemsModifier(List.of("attachments"));
+    List<CqnSelectListItem> resultItems = cut.items(select.items());
+
+    long contentIdCount =
+        resultItems.stream()
+            .filter(
+                item ->
+                    item.isRef()
+                        && item.asRef().displayName().equals("avatar_" + Attachments.CONTENT_ID))
+            .count();
+    assertThat(contentIdCount).isZero();
   }
 
   private void runTestForExpand(

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AssociationCascaderTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AssociationCascaderTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Roots_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable;
@@ -67,6 +68,15 @@ class AssociationCascaderTest {
     var result = cut.findMediaEntityNames(runtime.getCdsModel(), entity);
 
     assertThat(result).containsExactly(Attachment_.CDS_NAME);
+  }
+
+  @Test
+  void findMediaEntityNames_includesEntityWithInlineAttachments() {
+    var entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var result = cut.findMediaEntityNames(runtime.getCdsModel(), entity);
+
+    assertThat(result).containsExactly(InlineOnlyTable_.CDS_NAME);
   }
 
   @Test

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AssociationCascaderTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AssociationCascaderTest.java
@@ -40,6 +40,7 @@ class AssociationCascaderTest {
 
     assertThat(result)
         .containsExactlyInAnyOrder(
+            RootTable_.CDS_NAME,
             "unit.test.TestService.RootTable.attachments",
             Attachment_.CDS_NAME,
             "unit.test.TestService.Items.itemAttachments",
@@ -53,8 +54,10 @@ class AssociationCascaderTest {
 
     var result = cut.findMediaEntityNames(runtime.getCdsModel(), entity);
 
-    // RootTable and Items should NOT be included (they have children)
-    assertThat(result).doesNotContain(RootTable_.CDS_NAME).doesNotContain(Items_.CDS_NAME);
+    // Items should NOT be included (it is a non-leaf node without inline attachments)
+    // RootTable IS included because it has inline attachments (profilePicture)
+    assertThat(result).doesNotContain(Items_.CDS_NAME);
+    assertThat(result).contains(RootTable_.CDS_NAME);
   }
 
   @Test

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AttachmentsReaderTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AttachmentsReaderTest.java
@@ -5,16 +5,21 @@ package com.sap.cds.feature.attachments.handler.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
 import com.sap.cds.Result;
+import com.sap.cds.Row;
+import com.sap.cds.Struct;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
+import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.feature.attachments.helper.LogObserver;
 import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.Delete;
@@ -189,6 +194,57 @@ class AttachmentsReaderTest {
     assertThat(traceEvents.get(0).getFormattedMessage())
         .contains("IsActiveEntity=true")
         .contains("ID=" + dataEntry.get("ID"));
+  }
+
+  @Test
+  void readInlineAttachmentsReturnsEmptyForMediaEntity() {
+    var mediaEntity =
+        RuntimeHelper.runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+    CqnDelete statement = Delete.from(Attachment_.CDS_NAME).byId("test");
+
+    var result = cut.readInlineAttachments(mediaEntity, statement);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void readInlineAttachmentsReturnsEmptyForEntityWithoutInline() {
+    var itemsEntity = RuntimeHelper.runtime.getCdsModel().findEntity(Items_.CDS_NAME).orElseThrow();
+    CqnDelete statement = Delete.from(Items_.CDS_NAME).byId("test");
+
+    var result = cut.readInlineAttachments(itemsEntity, statement);
+
+    assertThat(result).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void readInlineAttachmentsReturnsDataForInlineEntity() {
+    var inlineEntity =
+        RuntimeHelper.runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    CqnDelete statement = Delete.from(InlineOnlyTable_.CDS_NAME).byId("test");
+
+    java.util.Map<String, Object> map = new HashMap<>();
+    map.put("ID", "test");
+    map.put("avatar_contentId", "doc-123");
+    map.put("avatar_status", "Clean");
+    map.put("avatar_scannedAt", null);
+    Row row = Struct.access(map).as(Row.class);
+    Result inlineResult = mock(Result.class);
+    doAnswer(
+            invocation -> {
+              java.util.function.Consumer<Row> consumer = invocation.getArgument(0);
+              List.of(row).forEach(consumer);
+              return null;
+            })
+        .when(inlineResult)
+        .forEach(any(java.util.function.Consumer.class));
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(inlineResult);
+
+    var result = cut.readInlineAttachments(inlineEntity, statement);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getContentId()).isEqualTo("doc-123");
   }
 
   private HashMap<String, Object> buildDefaultKeyMap() {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/InlineAttachmentHelperTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/InlineAttachmentHelperTest.java
@@ -1,0 +1,387 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.handler.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sap.cds.Result;
+import com.sap.cds.Row;
+import com.sap.cds.Struct;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
+import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
+import com.sap.cds.ql.Delete;
+import com.sap.cds.ql.cqn.CqnSelect;
+import com.sap.cds.reflect.CdsEntity;
+import com.sap.cds.services.persistence.PersistenceService;
+import com.sap.cds.services.runtime.CdsRuntime;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class InlineAttachmentHelperTest {
+
+  private static CdsRuntime runtime;
+
+  @BeforeAll
+  static void classSetup() {
+    runtime = RuntimeHelper.runtime;
+  }
+
+  @Test
+  void findInlineAttachmentPrefixes_returnsPrefix_forInlineOnlyEntity() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+
+    assertThat(result).containsExactly("avatar");
+  }
+
+  @Test
+  void findInlineAttachmentPrefixes_returnsPrefix_forRootTableWithInline() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(RootTable_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+
+    assertThat(result).containsExactly("profilePicture");
+  }
+
+  @Test
+  void findInlineAttachmentPrefixes_returnsEmpty_forMediaEntity() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void findInlineAttachmentPrefixes_returnsEmpty_forEntityWithoutInline() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Items_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineAttachmentPrefixes(entity);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void hasInlineAttachments_returnsTrue_forInlineOnlyEntity() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    assertThat(InlineAttachmentHelper.hasInlineAttachments(entity)).isTrue();
+  }
+
+  @Test
+  void hasInlineAttachments_returnsTrue_forRootTableWithInline() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(RootTable_.CDS_NAME).orElseThrow();
+
+    assertThat(InlineAttachmentHelper.hasInlineAttachments(entity)).isTrue();
+  }
+
+  @Test
+  void hasInlineAttachments_returnsFalse_forMediaEntity() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+
+    assertThat(InlineAttachmentHelper.hasInlineAttachments(entity)).isFalse();
+  }
+
+  @Test
+  void hasInlineAttachments_returnsFalse_forEntityWithoutInline() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Items_.CDS_NAME).orElseThrow();
+
+    assertThat(InlineAttachmentHelper.hasInlineAttachments(entity)).isFalse();
+  }
+
+  @Test
+  void buildInlineFieldName_combinesPrefixAndField() {
+    assertThat(InlineAttachmentHelper.buildInlineFieldName("avatar", "contentId"))
+        .isEqualTo("avatar_contentId");
+  }
+
+  @Test
+  void buildInlineFieldName_combinesLongerPrefix() {
+    assertThat(InlineAttachmentHelper.buildInlineFieldName("profilePicture", "status"))
+        .isEqualTo("profilePicture_status");
+  }
+
+  @Test
+  void extractPrefix_removesContentSuffix() {
+    assertThat(InlineAttachmentHelper.extractPrefix("avatar_content")).isEqualTo("avatar");
+  }
+
+  @Test
+  void extractPrefix_handlesLongerPrefix() {
+    assertThat(InlineAttachmentHelper.extractPrefix("profilePicture_content"))
+        .isEqualTo("profilePicture");
+  }
+
+  @Test
+  void findInlineContentElements_returnsContentFields_forInlineOnlyEntity() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineContentElements(entity);
+
+    assertThat(result).containsExactly("avatar_content");
+  }
+
+  @Test
+  void findInlineContentElements_returnsContentFields_forRootTable() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(RootTable_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineContentElements(entity);
+
+    assertThat(result).containsExactly("profilePicture_content");
+  }
+
+  @Test
+  void findInlineContentElements_returnsEmpty_forMediaEntity() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineContentElements(entity);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void findInlineContentElements_returnsEmpty_forEntityWithoutInline() {
+    CdsEntity entity = runtime.getCdsModel().findEntity(Items_.CDS_NAME).orElseThrow();
+
+    var result = InlineAttachmentHelper.findInlineContentElements(entity);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void readInlineAttachmentState_returnsEmptyForEmptyPrefixes() {
+    PersistenceService persistence = mock(PersistenceService.class);
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    var statement = Delete.from(InlineOnlyTable_.CDS_NAME);
+
+    var result =
+        InlineAttachmentHelper.readInlineAttachmentState(persistence, entity, statement, List.of());
+
+    assertThat(result).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void readInlineAttachmentState_readsAndMapsFields() {
+    PersistenceService persistence = mock(PersistenceService.class);
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    var id = UUID.randomUUID().toString();
+    var statement = Delete.from(InlineOnlyTable_.CDS_NAME).byId(id);
+
+    Row row =
+        createRow(
+            "ID",
+            id,
+            "avatar_contentId",
+            "doc-123",
+            "avatar_status",
+            "Clean",
+            "avatar_scannedAt",
+            Instant.parse("2025-01-01T00:00:00Z"));
+
+    Result result = mock(Result.class);
+    doAnswer(
+            invocation -> {
+              Consumer<Row> consumer = invocation.getArgument(0);
+              List.of(row).forEach(consumer);
+              return null;
+            })
+        .when(result)
+        .forEach(any(Consumer.class));
+    when(persistence.run(any(CqnSelect.class))).thenReturn(result);
+
+    var attachments =
+        InlineAttachmentHelper.readInlineAttachmentState(
+            persistence, entity, statement, List.of("avatar"));
+
+    assertThat(attachments).hasSize(1);
+    var att = attachments.get(0);
+    assertThat(att.getContentId()).isEqualTo("doc-123");
+    assertThat(att.getStatus()).isEqualTo("Clean");
+    assertThat(att.getScannedAt()).isEqualTo(Instant.parse("2025-01-01T00:00:00Z"));
+    assertThat(att.get("ID")).isEqualTo(id);
+
+    ArgumentCaptor<CqnSelect> selectCaptor = ArgumentCaptor.forClass(CqnSelect.class);
+    verify(persistence).run(selectCaptor.capture());
+    var select = selectCaptor.getValue();
+    assertThat(select.toString()).contains("avatar_contentId");
+    assertThat(select.toString()).contains("avatar_status");
+    assertThat(select.toString()).contains("avatar_scannedAt");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void readInlineAttachmentState_handlesNullScannedAt() {
+    PersistenceService persistence = mock(PersistenceService.class);
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    var statement = Delete.from(InlineOnlyTable_.CDS_NAME);
+
+    Row row =
+        createRow(
+            "ID",
+            "id-1",
+            "avatar_contentId",
+            "doc-456",
+            "avatar_status",
+            "Unscanned",
+            "avatar_scannedAt",
+            null);
+
+    Result result = mock(Result.class);
+    doAnswer(
+            invocation -> {
+              Consumer<Row> consumer = invocation.getArgument(0);
+              List.of(row).forEach(consumer);
+              return null;
+            })
+        .when(result)
+        .forEach(any(Consumer.class));
+    when(persistence.run(any(CqnSelect.class))).thenReturn(result);
+
+    var attachments =
+        InlineAttachmentHelper.readInlineAttachmentState(
+            persistence, entity, statement, List.of("avatar"));
+
+    assertThat(attachments).hasSize(1);
+    assertThat(attachments.get(0).getScannedAt()).isNull();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void readInlineAttachmentState_handlesNonInstantScannedAt() {
+    PersistenceService persistence = mock(PersistenceService.class);
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    var statement = Delete.from(InlineOnlyTable_.CDS_NAME);
+
+    Row row =
+        createRow(
+            "ID",
+            "id-1",
+            "avatar_contentId",
+            "doc-789",
+            "avatar_status",
+            "Clean",
+            "avatar_scannedAt",
+            "not-an-instant");
+
+    Result result = mock(Result.class);
+    doAnswer(
+            invocation -> {
+              Consumer<Row> consumer = invocation.getArgument(0);
+              List.of(row).forEach(consumer);
+              return null;
+            })
+        .when(result)
+        .forEach(any(Consumer.class));
+    when(persistence.run(any(CqnSelect.class))).thenReturn(result);
+
+    var attachments =
+        InlineAttachmentHelper.readInlineAttachmentState(
+            persistence, entity, statement, List.of("avatar"));
+
+    assertThat(attachments).hasSize(1);
+    assertThat(attachments.get(0).getScannedAt()).isNull();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void readInlineAttachmentState_multipleRows() {
+    PersistenceService persistence = mock(PersistenceService.class);
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    var statement = Delete.from(InlineOnlyTable_.CDS_NAME);
+
+    Row row1 =
+        createRow(
+            "ID",
+            "id-1",
+            "avatar_contentId",
+            "doc-1",
+            "avatar_status",
+            "Clean",
+            "avatar_scannedAt",
+            Instant.now());
+    Row row2 =
+        createRow(
+            "ID",
+            "id-2",
+            "avatar_contentId",
+            "doc-2",
+            "avatar_status",
+            "Infected",
+            "avatar_scannedAt",
+            Instant.now());
+
+    Result result = mock(Result.class);
+    doAnswer(
+            invocation -> {
+              Consumer<Row> consumer = invocation.getArgument(0);
+              List.of(row1, row2).forEach(consumer);
+              return null;
+            })
+        .when(result)
+        .forEach(any(Consumer.class));
+    when(persistence.run(any(CqnSelect.class))).thenReturn(result);
+
+    var attachments =
+        InlineAttachmentHelper.readInlineAttachmentState(
+            persistence, entity, statement, List.of("avatar"));
+
+    assertThat(attachments).hasSize(2);
+    assertThat(attachments.get(0).getContentId()).isEqualTo("doc-1");
+    assertThat(attachments.get(1).getContentId()).isEqualTo("doc-2");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void readInlineAttachmentState_withWhereClause() {
+    PersistenceService persistence = mock(PersistenceService.class);
+    CdsEntity entity = runtime.getCdsModel().findEntity(InlineOnlyTable_.CDS_NAME).orElseThrow();
+    var id = UUID.randomUUID().toString();
+    var statement = Delete.from(InlineOnlyTable_.CDS_NAME).byId(id);
+
+    Result result = mock(Result.class);
+    doAnswer(
+            invocation -> {
+              Consumer<Row> consumer = invocation.getArgument(0);
+              List.<Row>of().forEach(consumer);
+              return null;
+            })
+        .when(result)
+        .forEach(any(Consumer.class));
+    when(persistence.run(any(CqnSelect.class))).thenReturn(result);
+
+    var attachments =
+        InlineAttachmentHelper.readInlineAttachmentState(
+            persistence, entity, statement, List.of("avatar"));
+
+    assertThat(attachments).isEmpty();
+
+    ArgumentCaptor<CqnSelect> selectCaptor = ArgumentCaptor.forClass(CqnSelect.class);
+    verify(persistence).run(selectCaptor.capture());
+    var select = selectCaptor.getValue();
+    assertThat(select.toString()).contains(id);
+  }
+
+  private static Row createRow(Object... keyValues) {
+    java.util.Map<String, Object> map = new java.util.HashMap<>();
+    for (int i = 0; i < keyValues.length; i += 2) {
+      map.put((String) keyValues[i], keyValues[i + 1]);
+    }
+    return Struct.access(map).as(Row.class);
+  }
+}

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
@@ -11,16 +11,19 @@ import static org.mockito.Mockito.*;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
+import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
 import com.sap.cds.ql.Delete;
 import com.sap.cds.ql.cqn.CqnDelete;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.services.draft.DraftCancelEventContext;
 import com.sap.cds.services.draft.Drafts;
+import com.sap.cds.services.request.UserInfo;
 import com.sap.cds.services.runtime.CdsRuntime;
 import java.util.List;
 import java.util.Optional;
@@ -303,6 +306,97 @@ class DraftCancelAttachmentsHandlerTest {
 
     // Should not call deleteEvent since keys don't match
     verifyNoInteractions(deleteContentAttachmentEvent);
+  }
+
+  @Test
+  void cancelInlineAttachments_draftContentIdNotInActive_marksAsDeleted() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    CqnDelete delete = Delete.from(InlineOnlyTable_.class);
+    when(eventContext.getCqn()).thenReturn(delete);
+    when(eventContext.getModel()).thenReturn(runtime.getCdsModel());
+    when(eventContext.getEvent()).thenReturn("DRAFT_CANCEL");
+
+    var userInfo = mock(UserInfo.class);
+    when(eventContext.getUserInfo()).thenReturn(userInfo);
+
+    var draftInline = Attachments.create();
+    draftInline.setContentId("draft-inline-cid");
+    when(attachmentsReader.readInlineAttachments(any(), any()))
+        .thenReturn(List.of(draftInline))
+        .thenReturn(List.of());
+
+    cut.processBeforeDraftCancel(eventContext);
+
+    var captor = ArgumentCaptor.forClass(MarkAsDeletedInput.class);
+    verify(attachmentService).markAttachmentAsDeleted(captor.capture());
+    assertThat(captor.getValue().contentId()).isEqualTo("draft-inline-cid");
+  }
+
+  @Test
+  void cancelInlineAttachments_draftContentIdExistsInActive_notDeleted() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    CqnDelete delete = Delete.from(InlineOnlyTable_.class);
+    when(eventContext.getCqn()).thenReturn(delete);
+    when(eventContext.getModel()).thenReturn(runtime.getCdsModel());
+    when(eventContext.getEvent()).thenReturn("DRAFT_CANCEL");
+
+    var draftInline = Attachments.create();
+    draftInline.setContentId("shared-cid");
+    var activeInline = Attachments.create();
+    activeInline.setContentId("shared-cid");
+    when(attachmentsReader.readInlineAttachments(any(), any()))
+        .thenReturn(List.of(draftInline))
+        .thenReturn(List.of(activeInline));
+
+    cut.processBeforeDraftCancel(eventContext);
+
+    verify(attachmentService, never()).markAttachmentAsDeleted(any());
+  }
+
+  @Test
+  void cancelInlineAttachments_draftContentIdNull_skipped() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    CqnDelete delete = Delete.from(InlineOnlyTable_.class);
+    when(eventContext.getCqn()).thenReturn(delete);
+    when(eventContext.getModel()).thenReturn(runtime.getCdsModel());
+    when(eventContext.getEvent()).thenReturn("DRAFT_CANCEL");
+
+    var draftInline = Attachments.create();
+    // contentId is null
+    when(attachmentsReader.readInlineAttachments(any(), any()))
+        .thenReturn(List.of(draftInline))
+        .thenReturn(List.of());
+
+    cut.processBeforeDraftCancel(eventContext);
+
+    verify(attachmentService, never()).markAttachmentAsDeleted(any());
+  }
+
+  @Test
+  void cancelInlineAttachments_entityWithoutInline_skipped() {
+    getEntityAndMockContext(Attachment_.CDS_NAME);
+    CqnDelete delete = Delete.from(Attachment_.class);
+    when(eventContext.getCqn()).thenReturn(delete);
+    when(eventContext.getModel()).thenReturn(runtime.getCdsModel());
+    when(eventContext.getEvent()).thenReturn("DRAFT_CANCEL");
+
+    cut.processBeforeDraftCancel(eventContext);
+
+    verify(attachmentsReader, never()).readInlineAttachments(any(), any());
+  }
+
+  @Test
+  void deepSearch_entityWithInlineAttachments_returnsTrue() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+    CqnDelete delete = Delete.from(InlineOnlyTable_.class);
+    when(eventContext.getCqn()).thenReturn(delete);
+    when(eventContext.getModel()).thenReturn(runtime.getCdsModel());
+    when(eventContext.getEvent()).thenReturn("DRAFT_CANCEL");
+
+    // Should not skip - InlineOnlyTable has inline attachments
+    cut.processBeforeDraftCancel(eventContext);
+
+    verify(attachmentsReader, atLeastOnce()).readAttachments(any(), any(), any());
   }
 
   private Attachment buildAttachmentAndReturnByReader(

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
@@ -15,6 +15,7 @@ import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservic
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
+import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.ql.Delete;
 import com.sap.cds.ql.cqn.CqnDelete;
 import com.sap.cds.reflect.CdsEntity;
@@ -36,6 +37,7 @@ class DraftCancelAttachmentsHandlerTest {
   private DraftCancelAttachmentsHandler cut;
   private AttachmentsReader attachmentsReader;
   private MarkAsDeletedAttachmentEvent deleteContentAttachmentEvent;
+  private AttachmentService attachmentService;
   private DraftCancelEventContext eventContext;
   private ArgumentCaptor<CqnDelete> deleteArgumentCaptor;
   private ArgumentCaptor<Attachments> dataArgumentCaptor;
@@ -49,7 +51,10 @@ class DraftCancelAttachmentsHandlerTest {
   void setup() {
     attachmentsReader = mock(AttachmentsReader.class);
     deleteContentAttachmentEvent = mock(MarkAsDeletedAttachmentEvent.class);
-    cut = new DraftCancelAttachmentsHandler(attachmentsReader, deleteContentAttachmentEvent);
+    attachmentService = mock(AttachmentService.class);
+    cut =
+        new DraftCancelAttachmentsHandler(
+            attachmentsReader, deleteContentAttachmentEvent, attachmentService);
 
     eventContext = mock(DraftCancelEventContext.class);
     deleteArgumentCaptor = ArgumentCaptor.forClass(CqnDelete.class);

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandlerTest.java
@@ -190,12 +190,13 @@ class DraftPatchAttachmentsHandlerTest {
     when(persistence.run(any(CqnSelect.class))).thenReturn(result);
     when(result.listOf(Attachments.class)).thenReturn(List.of());
 
-    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(null);
 
     cut.processBeforeDraftPatch(eventContext, List.of(row));
 
-    verify(eventFactory).processInlineEvent(any(), any(), any(), eq(eventContext), any(), any());
+    verify(eventFactory)
+        .processInlineEvent(any(), any(), any(), eq(eventContext), any(), any(), any(), any());
   }
 
   @Test
@@ -208,7 +209,8 @@ class DraftPatchAttachmentsHandlerTest {
 
     cut.processBeforeDraftPatch(eventContext, List.of(attachment));
 
-    verify(eventFactory, never()).processInlineEvent(any(), any(), any(), any(), any(), any());
+    verify(eventFactory, never())
+        .processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -222,7 +224,8 @@ class DraftPatchAttachmentsHandlerTest {
 
     cut.processBeforeDraftPatch(eventContext, List.of(row));
 
-    verify(eventFactory, never()).processInlineEvent(any(), any(), any(), any(), any(), any());
+    verify(eventFactory, never())
+        .processInlineEvent(any(), any(), any(), any(), any(), any(), any(), any());
   }
 
   private RootTable buildRooWithAttachment(Attachments attachments) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandlerTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +16,8 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachmen
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Events;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Events_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable;
+import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.InlineOnlyTable_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Items;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
@@ -173,6 +176,53 @@ class DraftPatchAttachmentsHandlerTest {
 
     assertThat(beforeAnnotation.event()).isEmpty();
     assertThat(handlerOrderAnnotation.value()).isEqualTo(HandlerOrder.LATE);
+  }
+
+  @Test
+  void handleInlineAttachments_entityWithInlineContent_processesInline() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+
+    var row = InlineOnlyTable.create();
+    row.setId(UUID.randomUUID().toString());
+    row.put("avatar_content", mock(InputStream.class));
+
+    var result = mock(Result.class);
+    when(persistence.run(any(CqnSelect.class))).thenReturn(result);
+    when(result.listOf(Attachments.class)).thenReturn(List.of());
+
+    when(eventFactory.processInlineEvent(any(), any(), any(), any(), any(), any()))
+        .thenReturn(null);
+
+    cut.processBeforeDraftPatch(eventContext, List.of(row));
+
+    verify(eventFactory).processInlineEvent(any(), any(), any(), eq(eventContext), any(), any());
+  }
+
+  @Test
+  void handleInlineAttachments_entityWithoutInline_skipped() {
+    var draftAttachmentName = Attachment_.CDS_NAME + DraftUtils.DRAFT_TABLE_POSTFIX;
+    getEntityAndMockContext(draftAttachmentName);
+    var attachment = Attachments.create();
+    attachment.setContent(mock(InputStream.class));
+    when(persistence.run(any(CqnSelect.class))).thenReturn(mock(Result.class));
+
+    cut.processBeforeDraftPatch(eventContext, List.of(attachment));
+
+    verify(eventFactory, never()).processInlineEvent(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void handleInlineAttachments_rowWithoutContentField_skipped() {
+    getEntityAndMockContext(InlineOnlyTable_.CDS_NAME);
+
+    var row = InlineOnlyTable.create();
+    row.setId(UUID.randomUUID().toString());
+    row.setTitle("no inline content");
+    // avatar_content is NOT set
+
+    cut.processBeforeDraftPatch(eventContext, List.of(row));
+
+    verify(eventFactory, never()).processInlineEvent(any(), any(), any(), any(), any(), any());
   }
 
   private RootTable buildRooWithAttachment(Attachments attachments) {

--- a/cds-feature-attachments/src/test/resources/cds/db-model.cds
+++ b/cds-feature-attachments/src/test/resources/cds/db-model.cds
@@ -2,6 +2,7 @@ namespace unit.test;
 
 using {cuid} from '@sap/cds/common';
 using {sap.attachments.Attachments} from '../../../main/resources/cds/com.sap.cds/cds-feature-attachments';
+using {sap.attachments.Attachment as InlineAttachment} from '../../../main/resources/cds/com.sap.cds/cds-feature-attachments';
 using from '@sap/cds/srv/outbox';
 
 entity Attachment : Attachments {
@@ -9,9 +10,15 @@ entity Attachment : Attachments {
 
 entity Roots : cuid {
     title              : String;
+    profilePicture     : InlineAttachment;
     itemTable          : Composition of many Items
                              on itemTable.rootId = $self.ID;
     attachments        : Composition of many Attachments;
+}
+
+entity InlineOnly : cuid {
+    title  : String;
+    avatar : InlineAttachment;
 }
 
 entity Items : cuid {

--- a/cds-feature-attachments/src/test/resources/cds/service.cds
+++ b/cds-feature-attachments/src/test/resources/cds/service.cds
@@ -5,4 +5,6 @@ using unit.test as db from './db-model';
 service TestService {
     @odata.draft.enabled
     entity RootTable as projection on db.Roots;
+
+    entity InlineOnlyTable as projection on db.InlineOnly;
 }

--- a/cds-feature-attachments/src/test/resources/cds/service.cds
+++ b/cds-feature-attachments/src/test/resources/cds/service.cds
@@ -6,5 +6,6 @@ service TestService {
     @odata.draft.enabled
     entity RootTable as projection on db.Roots;
 
+    @odata.draft.enabled
     entity InlineOnlyTable as projection on db.InlineOnly;
 }

--- a/integration-tests/db/data-model.cds
+++ b/integration-tests/db/data-model.cds
@@ -2,6 +2,7 @@ namespace test.data.model;
 
 using {cuid} from '@sap/cds/common';
 using {sap.attachments.Attachments} from 'com.sap.cds/cds-feature-attachments';
+using {sap.attachments.Attachment}  from 'com.sap.cds/cds-feature-attachments';
 
 entity AttachmentEntity : Attachments {
     parentKey : UUID;
@@ -9,6 +10,7 @@ entity AttachmentEntity : Attachments {
 
 entity Roots : cuid {
     title                     : String;
+    avatar                    : Attachment;
     attachments               : Composition of many AttachmentEntity
                                     on attachments.parentKey = $self.ID;
     items                     : Composition of many Items
@@ -18,6 +20,11 @@ entity Roots : cuid {
     mimeValidatedAttachments  : Composition of many Attachments;
     contributors              : Composition of many Contributors
                                     on contributors.rootId = $self.ID;
+}
+
+entity InlineOnly : cuid {
+    title  : String;
+    avatar : Attachment;
 }
 
 entity Contributors : cuid {

--- a/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/InlineAttachmentDraftTest.java
+++ b/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/InlineAttachmentDraftTest.java
@@ -1,0 +1,331 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.integrationtests.draftservice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sap.cds.Struct;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.testdraftservice.DraftInlineOnly;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.testdraftservice.DraftInlineOnly_;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.testdraftservice.DraftRoots;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.testdraftservice.DraftRoots_;
+import com.sap.cds.feature.attachments.integrationtests.common.MockHttpRequestHelper;
+import com.sap.cds.feature.attachments.integrationtests.common.TableDataDeleter;
+import com.sap.cds.feature.attachments.integrationtests.constants.Profiles;
+import com.sap.cds.feature.attachments.integrationtests.testhandler.TestPluginAttachmentsServiceHandler;
+import com.sap.cds.feature.attachments.service.AttachmentService;
+import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
+import com.sap.cds.ql.Select;
+import com.sap.cds.ql.StructuredType;
+import com.sap.cds.services.persistence.PersistenceService;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles(Profiles.TEST_HANDLER_ENABLED)
+class InlineAttachmentDraftTest {
+
+  private static final String BASE_URL = MockHttpRequestHelper.ODATA_BASE_URL + "TestDraftService/";
+  private static final String DRAFT_INLINE_URL = BASE_URL + "DraftInlineOnly";
+
+  @Autowired private TestPluginAttachmentsServiceHandler serviceHandler;
+  @Autowired private MockHttpRequestHelper requestHelper;
+  @Autowired private PersistenceService persistenceService;
+  @Autowired private TableDataDeleter dataDeleter;
+
+  @AfterEach
+  void teardown() {
+    dataDeleter.deleteData(
+        DraftInlineOnly_.CDS_NAME,
+        DraftInlineOnly_.CDS_NAME + "_drafts",
+        DraftRoots_.CDS_NAME,
+        DraftRoots_.CDS_NAME + "_drafts",
+        "cds.outbox.Messages");
+    serviceHandler.clearEventContext();
+    serviceHandler.clearDocuments();
+    requestHelper.resetHelper();
+  }
+
+  @Test
+  void draftCreatePatchAndActivateWithInlineAttachment() throws Exception {
+    var draft = createNewDraft();
+    var draftUrl = getDraftUrl(draft.getId(), false);
+    requestHelper.executePatchWithODataResponseAndAssertStatusOk(
+        draftUrl, "{\"title\":\"draft inline\"}");
+
+    putDraftAvatarContent(draft.getId(), "draft avatar content");
+    prepareAndActivate(draftUrl);
+
+    var active = selectActiveInlineOnly(draft);
+    assertThat(active.getTitle()).isEqualTo("draft inline");
+    assertThat(active.getAvatarContentId()).isNotNull();
+
+    var createEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_CREATE_ATTACHMENT);
+    assertThat(createEvents).hasSize(1);
+    var context = (AttachmentCreateEventContext) createEvents.get(0).context();
+    assertThat(context.getData().getContent().readAllBytes())
+        .isEqualTo("draft avatar content".getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void draftCancelWithInlineAttachment() throws Exception {
+    var draft = createNewDraft();
+    var draftUrl = getDraftUrl(draft.getId(), false);
+    requestHelper.executePatchWithODataResponseAndAssertStatusOk(
+        draftUrl, "{\"title\":\"cancel me\"}");
+
+    putDraftAvatarContent(draft.getId(), "cancel this content");
+
+    awaitNumberOfExpectedEvents(1);
+    serviceHandler.clearEventContext();
+
+    cancelDraft(draftUrl);
+
+    awaitNumberOfExpectedEvents(1);
+    var deleteEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_MARK_ATTACHMENT_AS_DELETED);
+    assertThat(deleteEvents).hasSize(1);
+  }
+
+  @Test
+  void draftEditUpdateInlineAndActivate() throws Exception {
+    var draft = createNewDraft();
+    var draftUrl = getDraftUrl(draft.getId(), false);
+    requestHelper.executePatchWithODataResponseAndAssertStatusOk(
+        draftUrl, "{\"title\":\"edit test\"}");
+    putDraftAvatarContent(draft.getId(), "original content");
+    prepareAndActivate(draftUrl);
+    serviceHandler.clearEventContext();
+
+    editExistingDraft(draft.getId());
+    putDraftAvatarContent(draft.getId(), "updated content");
+    prepareAndActivate(getDraftUrl(draft.getId(), false));
+
+    awaitNumberOfExpectedEvents(2);
+    var createEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_CREATE_ATTACHMENT);
+    var deleteEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_MARK_ATTACHMENT_AS_DELETED);
+    assertThat(createEvents).hasSize(1);
+    assertThat(deleteEvents).hasSize(1);
+  }
+
+  @Test
+  void draftDeleteActiveEntityWithInlineAttachment() throws Exception {
+    var draft = createNewDraft();
+    var draftUrl = getDraftUrl(draft.getId(), false);
+    requestHelper.executePatchWithODataResponseAndAssertStatusOk(
+        draftUrl, "{\"title\":\"to delete\"}");
+    putDraftAvatarContent(draft.getId(), "delete this");
+    prepareAndActivate(draftUrl);
+    serviceHandler.clearEventContext();
+
+    var activeUrl = getDraftUrl(draft.getId(), true);
+    requestHelper.executeDeleteWithMatcher(activeUrl, status().isNoContent());
+
+    awaitNumberOfExpectedEvents(1);
+    var deleteEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_MARK_ATTACHMENT_AS_DELETED);
+    assertThat(deleteEvents).hasSize(1);
+  }
+
+  @Test
+  void readInlineAttachmentContentFromActiveDraft() throws Exception {
+    var draft = createNewDraft();
+    var draftUrl = getDraftUrl(draft.getId(), false);
+    requestHelper.executePatchWithODataResponseAndAssertStatusOk(
+        draftUrl, "{\"title\":\"read active\"}");
+    putDraftAvatarContent(draft.getId(), "readable");
+    prepareAndActivate(draftUrl);
+    serviceHandler.clearEventContext();
+
+    var contentUrl =
+        DRAFT_INLINE_URL + "(ID=" + draft.getId() + ",IsActiveEntity=true)/avatar_content";
+    Awaitility.await()
+        .atMost(60, TimeUnit.SECONDS)
+        .pollDelay(1, TimeUnit.SECONDS)
+        .pollInterval(2, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              var response = requestHelper.executeGet(contentUrl);
+              return response.getResponse().getContentAsString().equals("readable");
+            });
+    serviceHandler.clearEventContext();
+
+    var response = requestHelper.executeGet(contentUrl);
+    assertThat(response.getResponse().getContentAsString()).isEqualTo("readable");
+    var readEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_READ_ATTACHMENT);
+    assertThat(readEvents).hasSize(1);
+  }
+
+  @Test
+  void draftRootsWithBothInlineAndCompositionAttachments() throws Exception {
+    var responseRoot = createNewDraftRoot();
+    var rootUrl = getDraftRootUrl(responseRoot.getId(), false);
+    requestHelper.executePatchWithODataResponseAndAssertStatusOk(
+        rootUrl, "{\"title\":\"both kinds\"}");
+
+    putDraftRootAvatarContent(responseRoot.getId(), "draft root avatar");
+
+    var item = createDraftItem(rootUrl);
+    createDraftAttachment(item.getId(), "comp content");
+
+    prepareAndActivate(rootUrl);
+
+    var createEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_CREATE_ATTACHMENT);
+    assertThat(createEvents).hasSize(2);
+
+    var active = selectActiveDraftRoot(responseRoot);
+    assertThat(active.getAvatarContentId()).isNotNull();
+    assertThat(active.getItems().get(0).getAttachments().get(0).getContentId()).isNotNull();
+  }
+
+  private DraftInlineOnly createNewDraft() throws Exception {
+    var cdsData =
+        requestHelper.executePostWithODataResponseAndAssertStatusCreated(DRAFT_INLINE_URL, "{}");
+    return Struct.access(cdsData).as(DraftInlineOnly.class);
+  }
+
+  private void editExistingDraft(String id) throws Exception {
+    var url = getDraftUrl(id, true) + "/TestDraftService.draftEdit";
+    requestHelper.executePostWithODataResponseAndAssertStatus(
+        url, "{\"PreserveChanges\":true}", HttpStatus.OK);
+  }
+
+  private String getDraftUrl(String id, boolean isActiveEntity) {
+    return DRAFT_INLINE_URL + "(ID=" + id + ",IsActiveEntity=" + isActiveEntity + ")";
+  }
+
+  private void putDraftAvatarContent(String id, String content) throws Exception {
+    var url = DRAFT_INLINE_URL + "(ID=" + id + ",IsActiveEntity=false)/avatar_content";
+    requestHelper.setContentType("application/octet-stream");
+    requestHelper.executePutWithMatcher(
+        url, content.getBytes(StandardCharsets.UTF_8), status().isNoContent());
+    requestHelper.resetHelper();
+  }
+
+  private void prepareAndActivate(String entityUrl) throws Exception {
+    var prepareUrl = entityUrl + "/TestDraftService.draftPrepare";
+    var activateUrl = entityUrl + "/TestDraftService.draftActivate";
+    requestHelper.executePostWithMatcher(
+        prepareUrl, "{\"SideEffectsQualifier\":\"\"}", status().isOk());
+    requestHelper.executePostWithMatcher(activateUrl, "{}", status().isOk());
+  }
+
+  private void cancelDraft(String entityUrl) throws Exception {
+    requestHelper.executeDeleteWithMatcher(entityUrl, status().isNoContent());
+  }
+
+  private DraftInlineOnly selectActiveInlineOnly(DraftInlineOnly draft) {
+    var select =
+        Select.from(DraftInlineOnly_.CDS_NAME)
+            .where(e -> e.get(DraftInlineOnly.ID).eq(draft.getId()))
+            .columns(StructuredType::_all);
+    return persistenceService.run(select).single(DraftInlineOnly.class);
+  }
+
+  private DraftRoots createNewDraftRoot() throws Exception {
+    var url = BASE_URL + "DraftRoots";
+    var cdsData = requestHelper.executePostWithODataResponseAndAssertStatusCreated(url, "{}");
+    return Struct.access(cdsData).as(DraftRoots.class);
+  }
+
+  private String getDraftRootUrl(String id, boolean isActiveEntity) {
+    return BASE_URL + "DraftRoots(ID=" + id + ",IsActiveEntity=" + isActiveEntity + ")";
+  }
+
+  private void putDraftRootAvatarContent(String rootId, String content) throws Exception {
+    var url = BASE_URL + "DraftRoots(ID=" + rootId + ",IsActiveEntity=false)/avatar_content";
+    requestHelper.setContentType("application/octet-stream");
+    requestHelper.executePutWithMatcher(
+        url, content.getBytes(StandardCharsets.UTF_8), status().isNoContent());
+    requestHelper.resetHelper();
+  }
+
+  private com.sap.cds.feature.attachments.generated.integration.test.cds4j.testdraftservice.Items
+      createDraftItem(String rootUrl) throws Exception {
+    var item =
+        com.sap.cds.feature.attachments.generated.integration.test.cds4j.testdraftservice.Items
+            .create();
+    item.setTitle("draft item");
+    var itemUrl = rootUrl + "/items";
+    var cdsData =
+        requestHelper.executePostWithODataResponseAndAssertStatusCreated(itemUrl, item.toJson());
+    return Struct.access(cdsData)
+        .as(
+            com.sap.cds.feature.attachments.generated.integration.test.cds4j.testdraftservice.Items
+                .class);
+  }
+
+  private void createDraftAttachment(String itemId, String content) throws Exception {
+    var attachment =
+        com.sap.cds.feature.attachments.generated.integration.test.cds4j.sap.attachments.Attachments
+            .create();
+    attachment.setFileName("draftAttachment.txt");
+    var postUrl = BASE_URL + "Items(ID=" + itemId + ",IsActiveEntity=false)/attachments";
+    var cdsData =
+        requestHelper.executePostWithODataResponseAndAssertStatusCreated(
+            postUrl, attachment.toJson());
+    var created =
+        Struct.access(cdsData)
+            .as(
+                com.sap.cds.feature.attachments.generated.integration.test.cds4j.sap.attachments
+                    .Attachments.class);
+    var putUrl =
+        BASE_URL
+            + "Items_attachments(up__ID="
+            + itemId
+            + ",ID="
+            + created.getId()
+            + ",IsActiveEntity=false)/content";
+    requestHelper.setContentType("text/plain");
+    requestHelper.executePutWithMatcher(
+        putUrl, content.getBytes(StandardCharsets.UTF_8), status().isNoContent());
+    requestHelper.resetHelper();
+  }
+
+  private DraftRoots selectActiveDraftRoot(DraftRoots draft) {
+    var select =
+        Select.from(DraftRoots_.CDS_NAME)
+            .where(r -> r.get(DraftRoots.ID).eq(draft.getId()))
+            .columns(
+                StructuredType::_all,
+                r ->
+                    r.to(DraftRoots.ITEMS)
+                        .expand(
+                            StructuredType::_all,
+                            i ->
+                                i.to(
+                                        com.sap.cds.feature.attachments.generated.integration.test
+                                            .cds4j.testdraftservice.Items.ATTACHMENTS)
+                                    .expand(),
+                            i ->
+                                i.to(
+                                        com.sap.cds.feature.attachments.generated.integration.test
+                                            .cds4j.testdraftservice.Items.ATTACHMENT_ENTITIES)
+                                    .expand()));
+    return persistenceService.run(select).single(DraftRoots.class);
+  }
+
+  private void awaitNumberOfExpectedEvents(int expectedSize) {
+    Awaitility.await()
+        .atMost(60, TimeUnit.SECONDS)
+        .pollDelay(1, TimeUnit.SECONDS)
+        .pollInterval(2, TimeUnit.SECONDS)
+        .until(() -> serviceHandler.getEventContext().size() >= expectedSize);
+  }
+}

--- a/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/InlineAttachmentNonDraftTest.java
+++ b/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/InlineAttachmentNonDraftTest.java
@@ -1,0 +1,272 @@
+/*
+ * © 2024-2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.integrationtests.nondraftservice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.testservice.InlineOnlyTable;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.testservice.InlineOnlyTable_;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.testservice.Roots;
+import com.sap.cds.feature.attachments.generated.integration.test.cds4j.testservice.Roots_;
+import com.sap.cds.feature.attachments.integrationtests.common.MockHttpRequestHelper;
+import com.sap.cds.feature.attachments.integrationtests.common.TableDataDeleter;
+import com.sap.cds.feature.attachments.integrationtests.constants.Profiles;
+import com.sap.cds.feature.attachments.integrationtests.nondraftservice.helper.AttachmentsEntityBuilder;
+import com.sap.cds.feature.attachments.integrationtests.nondraftservice.helper.ItemEntityBuilder;
+import com.sap.cds.feature.attachments.integrationtests.nondraftservice.helper.RootEntityBuilder;
+import com.sap.cds.feature.attachments.integrationtests.testhandler.TestPluginAttachmentsServiceHandler;
+import com.sap.cds.feature.attachments.service.AttachmentService;
+import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
+import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentMarkAsDeletedEventContext;
+import com.sap.cds.ql.Select;
+import com.sap.cds.ql.StructuredType;
+import com.sap.cds.services.persistence.PersistenceService;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles(Profiles.TEST_HANDLER_ENABLED)
+class InlineAttachmentNonDraftTest {
+
+  private static final String INLINE_ONLY_URL =
+      MockHttpRequestHelper.ODATA_BASE_URL + "TestService/InlineOnlyTable";
+  private static final String ROOTS_URL =
+      MockHttpRequestHelper.ODATA_BASE_URL + "TestService/Roots";
+
+  @Autowired private TestPluginAttachmentsServiceHandler serviceHandler;
+  @Autowired private MockHttpRequestHelper requestHelper;
+  @Autowired private PersistenceService persistenceService;
+  @Autowired private TableDataDeleter dataDeleter;
+
+  @AfterEach
+  void teardown() {
+    dataDeleter.deleteData(InlineOnlyTable_.CDS_NAME, Roots_.CDS_NAME);
+    serviceHandler.clearEventContext();
+    serviceHandler.clearDocuments();
+    requestHelper.resetHelper();
+  }
+
+  @Test
+  void createEntityWithInlineAttachmentContent() throws Exception {
+    var entity = InlineOnlyTable.create();
+    entity.setTitle("inline test");
+    postInlineOnly(entity);
+
+    var created = selectSingleInlineOnly();
+    assertThat(created.getTitle()).isEqualTo("inline test");
+    assertThat(created.getAvatarContentId()).isNull();
+    assertThat(serviceHandler.getEventContext()).isEmpty();
+
+    putAvatarContent(created.getId(), "avatar content");
+    var afterPut = selectSingleInlineOnly();
+
+    assertThat(afterPut.getAvatarContentId()).isNotNull();
+    verifySingleCreateEvent("avatar content");
+  }
+
+  @Test
+  void readEntityWithInlineAttachment() throws Exception {
+    var entity = InlineOnlyTable.create();
+    entity.setTitle("read test");
+    postInlineOnly(entity);
+    var created = selectSingleInlineOnly();
+    putAvatarContent(created.getId(), "readable content");
+    serviceHandler.clearEventContext();
+
+    var url = INLINE_ONLY_URL + "(" + created.getId() + ")";
+    var response =
+        requestHelper.executeGetWithSingleODataResponseAndAssertStatus(
+            url, InlineOnlyTable.class, HttpStatus.OK);
+
+    assertThat(response.getAvatarContentId()).isNotNull();
+    assertThat(response.get("avatar_content@mediaContentType")).isNotNull();
+  }
+
+  @Test
+  void readInlineAttachmentContentViaNavigationUrl() throws Exception {
+    var entity = InlineOnlyTable.create();
+    entity.setTitle("nav read test");
+    postInlineOnly(entity);
+    var created = selectSingleInlineOnly();
+    putAvatarContent(created.getId(), "nav content");
+    serviceHandler.clearEventContext();
+
+    var url = INLINE_ONLY_URL + "(" + created.getId() + ")/avatar_content";
+    var response = requestHelper.executeGet(url);
+
+    assertThat(response.getResponse().getContentAsString()).isEqualTo("nav content");
+    var readEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_READ_ATTACHMENT);
+    assertThat(readEvents).hasSize(1);
+  }
+
+  @Test
+  void updateInlineAttachment() throws Exception {
+    var entity = InlineOnlyTable.create();
+    entity.setTitle("update test");
+    postInlineOnly(entity);
+    var created = selectSingleInlineOnly();
+    putAvatarContent(created.getId(), "original content");
+    serviceHandler.clearEventContext();
+
+    putAvatarContent(created.getId(), "updated content");
+
+    awaitNumberOfExpectedEvents(2);
+    var createEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_CREATE_ATTACHMENT);
+    var deleteEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_MARK_ATTACHMENT_AS_DELETED);
+    assertThat(createEvents).hasSize(1);
+    assertThat(deleteEvents).hasSize(1);
+
+    var createContext = (AttachmentCreateEventContext) createEvents.get(0).context();
+    assertThat(createContext.getData().getContent().readAllBytes())
+        .isEqualTo("updated content".getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void deleteEntityWithInlineAttachment() throws Exception {
+    var entity = InlineOnlyTable.create();
+    entity.setTitle("delete test");
+    postInlineOnly(entity);
+    var created = selectSingleInlineOnly();
+    putAvatarContent(created.getId(), "delete me");
+    var afterPut = selectSingleInlineOnly();
+    serviceHandler.clearEventContext();
+
+    var url = INLINE_ONLY_URL + "(" + afterPut.getId() + ")";
+    requestHelper.executeDeleteWithMatcher(url, status().isNoContent());
+
+    awaitNumberOfExpectedEvents(1);
+    var deleteEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_MARK_ATTACHMENT_AS_DELETED);
+    assertThat(deleteEvents).hasSize(1);
+    var deleteContext = (AttachmentMarkAsDeletedEventContext) deleteEvents.get(0).context();
+    assertThat(deleteContext.getContentId()).isEqualTo(afterPut.getAvatarContentId());
+  }
+
+  @Test
+  void entityWithBothInlineAndCompositionAttachments() throws Exception {
+    var root =
+        RootEntityBuilder.create()
+            .setTitle("both kinds")
+            .addAttachments(
+                AttachmentsEntityBuilder.create()
+                    .setFileName("composed.txt")
+                    .setMimeType("text/plain"))
+            .addItems(
+                ItemEntityBuilder.create()
+                    .setTitle("item1")
+                    .addAttachmentEntities(
+                        AttachmentsEntityBuilder.create()
+                            .setFileName("itemFile.txt")
+                            .setMimeType("text/plain")))
+            .build();
+    requestHelper.executePostWithMatcher(ROOTS_URL, root.toJson(), status().isCreated());
+
+    var selectedRoot = selectStoredRoot();
+    assertThat(selectedRoot.getAttachments()).hasSize(1);
+    assertThat(selectedRoot.getAvatarContentId()).isNull();
+    assertThat(serviceHandler.getEventContext()).isEmpty();
+
+    putRootAvatarContent(selectedRoot.getId(), "root avatar content");
+    verifySingleCreateEvent("root avatar content");
+    serviceHandler.clearEventContext();
+
+    putCompositionAttachmentContent(selectedRoot);
+    verifySingleCreateEvent(null);
+    serviceHandler.clearEventContext();
+
+    var url = ROOTS_URL + "(" + selectedRoot.getId() + ")";
+    requestHelper.executeDeleteWithMatcher(url, status().isNoContent());
+
+    awaitNumberOfExpectedEvents(2);
+    var deleteEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_MARK_ATTACHMENT_AS_DELETED);
+    assertThat(deleteEvents).hasSize(2);
+  }
+
+  private void postInlineOnly(InlineOnlyTable entity) throws Exception {
+    requestHelper.executePostWithMatcher(INLINE_ONLY_URL, entity.toJson(), status().isCreated());
+  }
+
+  private InlineOnlyTable selectSingleInlineOnly() {
+    var select = Select.from(InlineOnlyTable_.class).columns(StructuredType::_all);
+    return persistenceService.run(select).single(InlineOnlyTable.class);
+  }
+
+  private void putAvatarContent(String entityId, String content) throws Exception {
+    var url = INLINE_ONLY_URL + "(" + entityId + ")/avatar_content";
+    requestHelper.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+    requestHelper.executePutWithMatcher(
+        url, content.getBytes(StandardCharsets.UTF_8), status().isNoContent());
+    requestHelper.resetHelper();
+  }
+
+  private void putRootAvatarContent(String rootId, String content) throws Exception {
+    var url = ROOTS_URL + "(" + rootId + ")/avatar_content";
+    requestHelper.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+    requestHelper.executePutWithMatcher(
+        url, content.getBytes(StandardCharsets.UTF_8), status().isNoContent());
+    requestHelper.resetHelper();
+  }
+
+  private void putCompositionAttachmentContent(Roots root) throws Exception {
+    var attachment = root.getAttachments().get(0);
+    var url =
+        MockHttpRequestHelper.ODATA_BASE_URL
+            + "TestService/AttachmentEntity("
+            + attachment.getId()
+            + ")/content";
+    requestHelper.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+    requestHelper.executePutWithMatcher(
+        url, "composed content".getBytes(StandardCharsets.UTF_8), status().isNoContent());
+    requestHelper.resetHelper();
+  }
+
+  private Roots selectStoredRoot() {
+    var select =
+        Select.from(Roots_.class)
+            .columns(
+                StructuredType::_all,
+                r -> r.attachments().expand(),
+                r ->
+                    r.items()
+                        .expand(
+                            StructuredType::_all,
+                            i -> i.attachments().expand(),
+                            i -> i.attachmentEntities().expand()));
+    return persistenceService.run(select).single(Roots.class);
+  }
+
+  private void verifySingleCreateEvent(String expectedContent) throws IOException {
+    var createEvents =
+        serviceHandler.getEventContextForEvent(AttachmentService.EVENT_CREATE_ATTACHMENT);
+    assertThat(createEvents).hasSize(1);
+    if (expectedContent != null) {
+      var context = (AttachmentCreateEventContext) createEvents.get(0).context();
+      assertThat(context.getData().getContent().readAllBytes())
+          .isEqualTo(expectedContent.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  private void awaitNumberOfExpectedEvents(int expectedSize) {
+    Awaitility.await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollDelay(1, TimeUnit.SECONDS)
+        .until(() -> serviceHandler.getEventContext().size() >= expectedSize);
+  }
+}

--- a/integration-tests/generic/test-service.cds
+++ b/integration-tests/generic/test-service.cds
@@ -19,9 +19,12 @@ annotate db.Roots.mimeValidatedAttachments with {
 service TestService {
     entity Roots            as projection on db.Roots;
     entity AttachmentEntity as projection on db.AttachmentEntity;
+    entity InlineOnlyTable  as projection on db.InlineOnly;
 }
 
 service TestDraftService {
     @odata.draft.enabled
     entity DraftRoots as projection on db.Roots;
+    @odata.draft.enabled
+    entity DraftInlineOnly as projection on db.InlineOnly;
 }

--- a/samples/bookshop/app/admin-books/fiori-service.cds
+++ b/samples/bookshop/app/admin-books/fiori-service.cds
@@ -30,7 +30,23 @@ annotate AdminService.Books with @(UI: {
     {
       $Type : 'UI.ReferenceFacet',
       Label : '{i18n>Admin}',
-      Target: '@UI.FieldGroup#Admin'
+      Target: '@UI.FieldGroup#Admin' 
+    },
+    {
+      $Type : 'UI.ReferenceFacet',
+      Label : 'Profile Icon',
+      Target: '@UI.FieldGroup#ProfileIcon'
+    },
+    {
+      $Type : 'UI.ReferenceFacet',
+      Label : 'Cover Image',
+      Target: '@UI.FieldGroup#CoverImage'
+    },
+    {
+      $Type : 'UI.ReferenceFacet',
+      ID    : 'AttachmentsFacet',
+      Label : '{i18n>attachments}',
+      Target: 'attachments/@UI.LineItem'
     }
   ],
   FieldGroup #General: {Data: [
@@ -48,6 +64,18 @@ annotate AdminService.Books with @(UI: {
     {Value: createdAt},
     {Value: modifiedBy},
     {Value: modifiedAt}
+  ]},
+  FieldGroup #ProfileIcon: {Data: [
+    {Value: profileIcon_content},
+    {Value: profileIcon_fileName},
+    {Value: profileIcon_status},
+    {Value: profileIcon_note}
+  ]},
+  FieldGroup #CoverImage: {Data: [
+    {Value: coverImage_content},
+    {Value: coverImage_fileName},
+    {Value: coverImage_status},
+    {Value: coverImage_note}
   ]}
 });
 

--- a/samples/bookshop/pom.xml
+++ b/samples/bookshop/pom.xml
@@ -48,7 +48,7 @@
 			<dependency>
 				<groupId>com.sap.cds</groupId>
 				<artifactId>cds-feature-attachments</artifactId>
-				<version>1.5.0</version>
+				<version>1.6.0-SNAPSHOT</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/samples/bookshop/srv/attachments.cds
+++ b/samples/bookshop/srv/attachments.cds
@@ -1,5 +1,5 @@
 using {sap.capire.bookshop as my} from '../db/schema';
-using {sap.attachments.Attachments} from 'com.sap.cds/cds-feature-attachments';
+using {Attachments, Attachment} from 'com.sap.cds/cds-feature-attachments';
 
 // Extend Books entity to support file attachments (images, PDFs, documents)
 // Each book can have multiple attachments via composition relationship
@@ -9,6 +9,8 @@ extend my.Books with {
   sizeLimitedAttachments           : Composition of many Attachments;
   @UI.Hidden
   mediaValidatedAttachments        : Composition of many Attachments;
+  profileIcon : Attachment;
+  coverImage  : Attachment;
 }
 
 annotate my.Books.sizeLimitedAttachments with {
@@ -33,17 +35,3 @@ annotate service.Books with @(UI.Facets: [{
   Target: 'attachments/@UI.LineItem'
 }]);
 
-// Adding the UI Component (a table) to the Administrator App
-using {AdminService as adminService} from '../app/services';
-
-annotate adminService.Books with @(UI.Facets: [{
-  $Type : 'UI.ReferenceFacet',
-  ID    : 'AttachmentsFacet',
-  Label : '{i18n>attachments}',
-  Target: 'attachments/@UI.LineItem'
-}]);
-
-
-service nonDraft {
-  entity Books as projection on my.Books;
-}


### PR DESCRIPTION
# Add Inline Attachment Support

### New Feature

✨ Introduces support for **inline attachments** declared via CDS structured types (e.g., `avatar : Attachment`), alongside the existing composition-based (`Attachments`) pattern. Inline attachments are flattened by the CDS compiler into prefixed columns (e.g., `avatar_content`, `avatar_contentId`, `avatar_status`, `avatar_scannedAt`), and all Create/Read/Update/Delete and draft lifecycle handlers have been extended to handle them transparently.

### Changes

* `attachments.cds`: Introduces the new `Attachment` structured type annotated with `@_is_media_data`, enabling inline attachment declarations in CDS models.
* `attachments-annotations.cds`: Adds OData/UI annotations for the new `Attachment` type.
* `InlineAttachmentHelper.java` *(new)*: Core utility class for detecting inline attachment prefixes on entities, building flattened field names, and reading inline attachment state from the database.
* `ModifyAttachmentEventFactory.java`: Adds `processInlineEvent(...)` method to handle create, update, delete, and no-op lifecycle operations for inline attachments without requiring a CDS `Path`.
* `ModifyApplicationHandlerHelper.java`: Adds `handleInlineAttachments`, `processInlineAttachmentRow`, and `findExistingInlineAttachment` to process inline attachment rows during modify events.
* `ReadonlyDataContextEnhancer.java`: Adds `preserveInlineReadonlyFields` / `restoreInlineReadonlyFields` to backup and restore inline readonly fields (`contentId`, `status`, `scannedAt`) during draft activation.
* `CreateAttachmentsHandler.java` / `UpdateAttachmentsHandler.java`: Updated to preserve and restore inline readonly fields, and to process inline attachment content during create/update operations.
* `DeleteAttachmentsHandler.java`: Extended to read and delete inline attachments when their `contentId` is set.
* `ReadAttachmentsHandler.java`: Extended to wrap inline attachment content fields with `LazyProxyInputStream` during reads, and to inject required metadata fields into select queries.
* `BeforeReadItemsModifier.java`: Adds logic to inject `contentId`, `status`, and `scannedAt` fields for inline attachment prefixes in read queries.
* `DraftPatchAttachmentsHandler.java`: Handles inline attachment fields during draft patch events.
* `DraftCancelAttachmentsHandler.java`: Handles inline attachment cancellation by comparing draft vs. active state and marking orphaned attachments as deleted.
* `AssociationCascader.java`: Includes entities with inline attachments in the malware scan runner entity list.
* `AttachmentsReader.java`: Adds `readInlineAttachments(...)` method for querying inline attachment state.
* `ApplicationHandlerHelper.java`: Extends `containsContentField` to detect inline content fields in addition to composition-based media fields.
* `MediaTypeResolver.java`: Fixes `getElement` → `findElement` for null-safe element lookup.
* `Registration.java`: Passes `outboxedAttachmentService` to `DraftCancelAttachmentsHandler` constructor.
* `CreateAttachmentEvent.java` / `MarkAsDeletedAttachmentEvent.java`: Expose package-level accessors for the internal `AttachmentService` and `ListenerProvider` used by `processInlineEvent`.
* `db-model.cds` / `service.cds` (test): Adds `InlineOnly` entity and `profilePicture` field on `Roots` for unit test scenarios.
* `data-model.cds` / `test-service.cds` (integration): Adds `InlineOnly` entity, `avatar` inline field on `Roots`, and exposes both in `TestService` and `TestDraftService`.
* `InlineAttachmentHelperTest.java` *(new)*: Unit tests for all utility methods in `InlineAttachmentHelper`.
* `InlineAttachmentNonDraftTest.java` *(new)*: Integration tests for non-draft inline attachment lifecycle (create, read, update, delete, mixed with composition attachments).
* `InlineAttachmentDraftTest.java` *(new)*: Integration tests for draft inline attachment lifecycle (create/patch/activate, cancel, edit-update-activate, delete, mixed with composition attachments).
* Test files for `CreateAttachmentsHandler`, `UpdateAttachmentsHandler`, `DeleteAttachmentsHandler`, `ReadAttachmentsHandler`, `BeforeReadItemsModifier`, `AttachmentsReader`, `DraftCancelAttachmentsHandler`, `AssociationCascader`: Extended with new test cases covering inline attachment scenarios.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.11` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Event Trigger: `issue_comment.edited`
- Correlation ID: `c60b0a37-adaf-4b81-9243-fe9c870a33d7`
</details>
