### PR TITLE
Extract fileName and mimeType from HTTP headers

### DIFF
--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEvent.java
@@ -35,7 +35,7 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
 
   private static final Logger logger = LoggerFactory.getLogger(CreateAttachmentEvent.class);
   private static final Pattern RFC5987_FILENAME_PATTERN =
-      Pattern.compile("filename\\*=UTF-8''(.+)", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("filename\\*=UTF-8''([^;]+)", Pattern.CASE_INSENSITIVE);
   private static final Pattern PLAIN_FILENAME_PATTERN =
       Pattern.compile("filename=\"?([^\";]+)\"?", Pattern.CASE_INSENSITIVE);
 
@@ -66,7 +66,7 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
       fileNameOptional.ifPresent(fn -> values.put(MediaData.FILE_NAME, fn));
     }
     if (mimeTypeOptional.isEmpty()
-        || "application/octet-stream".equals(mimeTypeOptional.orElse(null))) {
+        || "application/octet-stream".equalsIgnoreCase(mimeTypeOptional.get())) {
       Optional<String> headerMimeType = extractMimeTypeFromHeader(eventContext);
       if (headerMimeType.isPresent()) {
         mimeTypeOptional = headerMimeType;

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEvent.java
@@ -17,8 +17,12 @@ import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.services.EventContext;
 import com.sap.cds.services.changeset.ChangeSetListener;
 import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +34,10 @@ import org.slf4j.LoggerFactory;
 public class CreateAttachmentEvent implements ModifyAttachmentEvent {
 
   private static final Logger logger = LoggerFactory.getLogger(CreateAttachmentEvent.class);
+  private static final Pattern RFC5987_FILENAME_PATTERN =
+      Pattern.compile("filename\\*=UTF-8''(.+)", Pattern.CASE_INSENSITIVE);
+  private static final Pattern PLAIN_FILENAME_PATTERN =
+      Pattern.compile("filename=\"?([^\";]+)\"?", Pattern.CASE_INSENSITIVE);
 
   private final AttachmentService attachmentService;
   private final ListenerProvider listenerProvider;
@@ -51,6 +59,20 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
     Map<String, Object> keys = ApplicationHandlerHelper.removeDraftKey(path.target().keys());
     Optional<String> mimeTypeOptional = getFieldValue(MediaData.MIME_TYPE, values, attachment);
     Optional<String> fileNameOptional = getFieldValue(MediaData.FILE_NAME, values, attachment);
+
+    // Fall back to HTTP headers when values are not set in payload
+    if (fileNameOptional.isEmpty()) {
+      fileNameOptional = extractFileNameFromHeader(eventContext);
+      fileNameOptional.ifPresent(fn -> values.put(MediaData.FILE_NAME, fn));
+    }
+    if (mimeTypeOptional.isEmpty()
+        || "application/octet-stream".equals(mimeTypeOptional.orElse(null))) {
+      Optional<String> headerMimeType = extractMimeTypeFromHeader(eventContext);
+      if (headerMimeType.isPresent()) {
+        mimeTypeOptional = headerMimeType;
+        values.put(MediaData.MIME_TYPE, mimeTypeOptional.get());
+      }
+    }
 
     CreateAttachmentInput createEventInput =
         new CreateAttachmentInput(
@@ -77,5 +99,44 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
     Object annotationValue = values.get(fieldName);
     Object value = nonNull(annotationValue) ? annotationValue : attachment.get(fieldName);
     return Optional.ofNullable((String) value);
+  }
+
+  /**
+   * Extracts the filename from the Content-Disposition header or falls back to the slug header.
+   * Supports RFC 5987 encoded filenames (filename*=UTF-8''...) and plain filenames.
+   */
+  private static Optional<String> extractFileNameFromHeader(EventContext eventContext) {
+    String header = eventContext.getParameterInfo().getHeader("Content-Disposition");
+    if (header != null) {
+      // Try RFC 5987 encoded filename first (filename*=UTF-8''...)
+      Matcher utf8Matcher = RFC5987_FILENAME_PATTERN.matcher(header);
+      if (utf8Matcher.find()) {
+        return Optional.of(URLDecoder.decode(utf8Matcher.group(1), StandardCharsets.UTF_8));
+      }
+      // Fall back to plain filename=
+      Matcher plainMatcher = PLAIN_FILENAME_PATTERN.matcher(header);
+      if (plainMatcher.find()) {
+        return Optional.of(plainMatcher.group(1).trim());
+      }
+    }
+    // Fiori Elements may use the slug header instead
+    String slug = eventContext.getParameterInfo().getHeader("slug");
+    return Optional.ofNullable(slug);
+  }
+
+  /**
+   * Extracts the MIME type from the Content-Type header, stripping charset and other parameters.
+   * Returns empty if the Content-Type is null, empty, or application/octet-stream.
+   */
+  private static Optional<String> extractMimeTypeFromHeader(EventContext eventContext) {
+    String contentType = eventContext.getParameterInfo().getHeader("Content-Type");
+    if (contentType == null) {
+      return Optional.empty();
+    }
+    String mimeType = contentType.split(";")[0].trim();
+    if (mimeType.isEmpty() || "application/octet-stream".equalsIgnoreCase(mimeType)) {
+      return Optional.empty();
+    }
+    return Optional.of(mimeType);
   }
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEvent.java
@@ -37,7 +37,7 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
   private static final Pattern RFC5987_FILENAME_PATTERN =
       Pattern.compile("filename\\*=UTF-8''([^;]+)", Pattern.CASE_INSENSITIVE);
   private static final Pattern PLAIN_FILENAME_PATTERN =
-      Pattern.compile("filename=\"?([^\";]+)\"?", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("(?<!\\*)filename=\"?([^\";]+)\"?", Pattern.CASE_INSENSITIVE);
 
   private final AttachmentService attachmentService;
   private final ListenerProvider listenerProvider;
@@ -61,16 +61,14 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
     Optional<String> fileNameOptional = getFieldValue(MediaData.FILE_NAME, values, attachment);
 
     // Fall back to HTTP headers when values are not set in payload
-    if (fileNameOptional.isEmpty()) {
-      fileNameOptional = extractFileNameFromHeader(eventContext);
-      fileNameOptional.ifPresent(fn -> values.put(MediaData.FILE_NAME, fn));
-    }
-    if (mimeTypeOptional.isEmpty()
-        || "application/octet-stream".equalsIgnoreCase(mimeTypeOptional.get())) {
-      Optional<String> headerMimeType = extractMimeTypeFromHeader(eventContext);
-      if (headerMimeType.isPresent()) {
-        mimeTypeOptional = headerMimeType;
-        values.put(MediaData.MIME_TYPE, mimeTypeOptional.get());
+    if (eventContext.getParameterInfo() != null) {
+      if (fileNameOptional.isEmpty()) {
+        fileNameOptional = extractFileNameFromHeader(eventContext);
+        fileNameOptional.ifPresent(fn -> values.put(MediaData.FILE_NAME, fn));
+      }
+      if (mimeTypeOptional.isEmpty()) {
+        mimeTypeOptional = extractMimeTypeFromHeader(eventContext);
+        mimeTypeOptional.ifPresent(mt -> values.put(MediaData.MIME_TYPE, mt));
       }
     }
 
@@ -121,12 +119,15 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
     }
     // Fiori Elements may use the slug header instead
     String slug = eventContext.getParameterInfo().getHeader("slug");
-    return Optional.ofNullable(slug);
+    if (slug != null) {
+      return Optional.of(URLDecoder.decode(slug, StandardCharsets.UTF_8));
+    }
+    return Optional.empty();
   }
 
   /**
    * Extracts the MIME type from the Content-Type header, stripping charset and other parameters.
-   * Returns empty if the Content-Type is null, empty, or application/octet-stream.
+   * Returns empty if the Content-Type is null or empty.
    */
   private static Optional<String> extractMimeTypeFromHeader(EventContext eventContext) {
     String contentType = eventContext.getParameterInfo().getHeader("Content-Type");
@@ -134,7 +135,7 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
       return Optional.empty();
     }
     String mimeType = contentType.split(";")[0].trim();
-    if (mimeType.isEmpty() || "application/octet-stream".equalsIgnoreCase(mimeType)) {
+    if (mimeType.isEmpty()) {
       return Optional.empty();
     }
     return Optional.of(mimeType);

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
@@ -16,7 +16,7 @@ type StatusCode : String(32) enum {
 
 aspect MediaData @(_is_media_data) {
     content   : LargeBinary; // stored only for db-based services
-    mimeType  : String;
+    mimeType  : String default 'application/octet-stream';
     fileName  : String(5000);
     contentId : String     @readonly; // id of attachment in external storage, if database storage is used, same as id
     status    : StatusCode default 'Unscanned' @readonly;

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
@@ -16,7 +16,7 @@ type StatusCode : String(32) enum {
 
 aspect MediaData @(_is_media_data) {
     content   : LargeBinary; // stored only for db-based services
-    mimeType  : String default 'application/octet-stream';
+    mimeType  : String;
     fileName  : String(5000);
     contentId : String     @readonly; // id of attachment in external storage, if database storage is used, same as id
     status    : StatusCode default 'Unscanned' @readonly;

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEventTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEventTest.java
@@ -21,6 +21,7 @@ import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.services.EventContext;
 import com.sap.cds.services.changeset.ChangeSetContext;
 import com.sap.cds.services.changeset.ChangeSetListener;
+import com.sap.cds.services.request.ParameterInfo;
 import com.sap.cds.services.runtime.CdsRuntime;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -48,6 +49,7 @@ class CreateAttachmentEventTest {
   private ArgumentCaptor<CreateAttachmentInput> contextArgumentCaptor;
   private EventContext eventContext;
   private ChangeSetContext changeSetContext;
+  private ParameterInfo parameterInfo;
 
   @BeforeEach
   void setup() {
@@ -61,7 +63,9 @@ class CreateAttachmentEventTest {
     entity = mock(CdsEntity.class);
     eventContext = mock(EventContext.class);
     changeSetContext = mock(ChangeSetContext.class);
+    parameterInfo = mock(ParameterInfo.class);
     when(eventContext.getChangeSetContext()).thenReturn(changeSetContext);
+    when(eventContext.getParameterInfo()).thenReturn(parameterInfo);
     when(target.entity()).thenReturn(entity);
     when(path.target()).thenReturn(target);
   }
@@ -178,5 +182,193 @@ class CreateAttachmentEventTest {
 
     cut.processEvent(path, attachment.getContent(), Attachments.create(), eventContext);
     return attachment;
+  }
+
+  @Test
+  void fileNameExtractedFromRfc5987ContentDispositionHeader() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    when(parameterInfo.getHeader("Content-Disposition"))
+        .thenReturn("attachment; filename*=UTF-8''my%20file%20name.pdf");
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().fileName()).isEqualTo("my file name.pdf");
+    assertThat(attachment.getFileName()).isEqualTo("my file name.pdf");
+  }
+
+  @Test
+  void fileNameExtractedFromPlainContentDispositionHeader() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    when(parameterInfo.getHeader("Content-Disposition"))
+        .thenReturn("attachment; filename=\"report.pdf\"");
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().fileName()).isEqualTo("report.pdf");
+  }
+
+  @Test
+  void fileNameExtractedFromPlainContentDispositionHeaderWithoutQuotes() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    when(parameterInfo.getHeader("Content-Disposition"))
+        .thenReturn("attachment; filename=report.pdf");
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().fileName()).isEqualTo("report.pdf");
+  }
+
+  @Test
+  void fileNameExtractedFromSlugHeaderAsFallback() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    when(parameterInfo.getHeader("Content-Disposition")).thenReturn(null);
+    when(parameterInfo.getHeader("slug")).thenReturn("document.docx");
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().fileName()).isEqualTo("document.docx");
+  }
+
+  @Test
+  void fileNameFromPayloadTakesPrecedenceOverHeader() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    attachment.setFileName("payload-name.pdf");
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    when(parameterInfo.getHeader("Content-Disposition"))
+        .thenReturn("attachment; filename=\"header-name.pdf\"");
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().fileName()).isEqualTo("payload-name.pdf");
+  }
+
+  @Test
+  void mimeTypeExtractedFromContentTypeHeader() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    when(parameterInfo.getHeader("Content-Type")).thenReturn("image/jpeg; charset=utf-8");
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().mimeType()).isEqualTo("image/jpeg");
+    assertThat(attachment.getMimeType()).isEqualTo("image/jpeg");
+  }
+
+  @Test
+  void mimeTypeOctetStreamOverriddenByContentTypeHeader() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    attachment.setMimeType("application/octet-stream");
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    when(parameterInfo.getHeader("Content-Type")).thenReturn("application/pdf");
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().mimeType()).isEqualTo("application/pdf");
+  }
+
+  @Test
+  void mimeTypeFromPayloadTakesPrecedenceOverHeader() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    attachment.setMimeType("text/plain");
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    when(parameterInfo.getHeader("Content-Type")).thenReturn("application/pdf");
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().mimeType()).isEqualTo("text/plain");
+  }
+
+  @Test
+  void mimeTypeOctetStreamFromHeaderNotUsed() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    when(parameterInfo.getHeader("Content-Type")).thenReturn("application/octet-stream");
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().mimeType()).isNull();
+  }
+
+  @Test
+  void fileNameNotExtractedFromInvalidContentDispositionHeader() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    // Header exists but has no valid filename pattern
+    when(parameterInfo.getHeader("Content-Disposition")).thenReturn("inline");
+    when(parameterInfo.getHeader("slug")).thenReturn(null);
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().fileName()).isNull();
+  }
+
+  @Test
+  void mimeTypeExtractedWhenEmpty() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    when(parameterInfo.getHeader("Content-Type")).thenReturn("text/csv");
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().mimeType()).isEqualTo("text/csv");
   }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEventTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEventTest.java
@@ -203,6 +203,25 @@ class CreateAttachmentEventTest {
   }
 
   @Test
+  void fileNameExtractedFromRfc5987HeaderWithTrailingParameters() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    // Header with trailing parameters after the filename - should stop at semicolon
+    when(parameterInfo.getHeader("Content-Disposition"))
+        .thenReturn("attachment; filename*=UTF-8''my%20file.pdf; size=1234");
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().fileName()).isEqualTo("my file.pdf");
+    assertThat(attachment.getFileName()).isEqualTo("my file.pdf");
+  }
+
+  @Test
   void fileNameExtractedFromPlainContentDispositionHeader() {
     var attachment = Attachments.create();
     attachment.setId(UUID.randomUUID().toString());
@@ -293,6 +312,24 @@ class CreateAttachmentEventTest {
     var attachment = Attachments.create();
     attachment.setId(UUID.randomUUID().toString());
     attachment.setMimeType("application/octet-stream");
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    when(parameterInfo.getHeader("Content-Type")).thenReturn("application/pdf");
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().mimeType()).isEqualTo("application/pdf");
+  }
+
+  @Test
+  void mimeTypeOctetStreamMixedCaseOverriddenByContentTypeHeader() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    // Client sends MIME type in mixed case - should still be treated as octet-stream
+    attachment.setMimeType("Application/Octet-Stream");
     when(target.values()).thenReturn(attachment);
     when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
     when(attachmentService.createAttachment(any()))

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEventTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEventTest.java
@@ -185,7 +185,7 @@ class CreateAttachmentEventTest {
   }
 
   @Test
-  void fileNameExtractedFromRfc5987ContentDispositionHeader() {
+  void fileNameFromRfc5987Header() {
     var attachment = Attachments.create();
     attachment.setId(UUID.randomUUID().toString());
     when(target.values()).thenReturn(attachment);
@@ -203,7 +203,7 @@ class CreateAttachmentEventTest {
   }
 
   @Test
-  void fileNameExtractedFromRfc5987HeaderWithTrailingParameters() {
+  void fileNameFromRfc5987HeaderWithTrailingParams() {
     var attachment = Attachments.create();
     attachment.setId(UUID.randomUUID().toString());
     when(target.values()).thenReturn(attachment);
@@ -222,7 +222,7 @@ class CreateAttachmentEventTest {
   }
 
   @Test
-  void fileNameExtractedFromPlainContentDispositionHeader() {
+  void fileNameFromPlainHeader() {
     var attachment = Attachments.create();
     attachment.setId(UUID.randomUUID().toString());
     when(target.values()).thenReturn(attachment);
@@ -239,7 +239,7 @@ class CreateAttachmentEventTest {
   }
 
   @Test
-  void fileNameExtractedFromPlainContentDispositionHeaderWithoutQuotes() {
+  void fileNameFromPlainHeaderWithoutQuotes() {
     var attachment = Attachments.create();
     attachment.setId(UUID.randomUUID().toString());
     when(target.values()).thenReturn(attachment);
@@ -256,7 +256,7 @@ class CreateAttachmentEventTest {
   }
 
   @Test
-  void fileNameExtractedFromSlugHeaderAsFallback() {
+  void fileNameFromSlugHeader() {
     var attachment = Attachments.create();
     attachment.setId(UUID.randomUUID().toString());
     when(target.values()).thenReturn(attachment);
@@ -273,7 +273,7 @@ class CreateAttachmentEventTest {
   }
 
   @Test
-  void fileNameFromPayloadTakesPrecedenceOverHeader() {
+  void fileNamePayloadPrecedesHeader() {
     var attachment = Attachments.create();
     attachment.setId(UUID.randomUUID().toString());
     attachment.setFileName("payload-name.pdf");
@@ -291,7 +291,7 @@ class CreateAttachmentEventTest {
   }
 
   @Test
-  void mimeTypeExtractedFromContentTypeHeader() {
+  void mimeTypeFromContentTypeHeader() {
     var attachment = Attachments.create();
     attachment.setId(UUID.randomUUID().toString());
     when(target.values()).thenReturn(attachment);
@@ -308,42 +308,7 @@ class CreateAttachmentEventTest {
   }
 
   @Test
-  void mimeTypeOctetStreamOverriddenByContentTypeHeader() {
-    var attachment = Attachments.create();
-    attachment.setId(UUID.randomUUID().toString());
-    attachment.setMimeType("application/octet-stream");
-    when(target.values()).thenReturn(attachment);
-    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
-    when(attachmentService.createAttachment(any()))
-        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
-    when(parameterInfo.getHeader("Content-Type")).thenReturn("application/pdf");
-
-    cut.processEvent(path, null, Attachments.create(), eventContext);
-
-    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
-    assertThat(contextArgumentCaptor.getValue().mimeType()).isEqualTo("application/pdf");
-  }
-
-  @Test
-  void mimeTypeOctetStreamMixedCaseOverriddenByContentTypeHeader() {
-    var attachment = Attachments.create();
-    attachment.setId(UUID.randomUUID().toString());
-    // Client sends MIME type in mixed case - should still be treated as octet-stream
-    attachment.setMimeType("Application/Octet-Stream");
-    when(target.values()).thenReturn(attachment);
-    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
-    when(attachmentService.createAttachment(any()))
-        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
-    when(parameterInfo.getHeader("Content-Type")).thenReturn("application/pdf");
-
-    cut.processEvent(path, null, Attachments.create(), eventContext);
-
-    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
-    assertThat(contextArgumentCaptor.getValue().mimeType()).isEqualTo("application/pdf");
-  }
-
-  @Test
-  void mimeTypeFromPayloadTakesPrecedenceOverHeader() {
+  void mimeTypePayloadPrecedesHeader() {
     var attachment = Attachments.create();
     attachment.setId(UUID.randomUUID().toString());
     attachment.setMimeType("text/plain");
@@ -360,23 +325,7 @@ class CreateAttachmentEventTest {
   }
 
   @Test
-  void mimeTypeOctetStreamFromHeaderNotUsed() {
-    var attachment = Attachments.create();
-    attachment.setId(UUID.randomUUID().toString());
-    when(target.values()).thenReturn(attachment);
-    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
-    when(attachmentService.createAttachment(any()))
-        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
-    when(parameterInfo.getHeader("Content-Type")).thenReturn("application/octet-stream");
-
-    cut.processEvent(path, null, Attachments.create(), eventContext);
-
-    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
-    assertThat(contextArgumentCaptor.getValue().mimeType()).isNull();
-  }
-
-  @Test
-  void fileNameNotExtractedFromInvalidContentDispositionHeader() {
+  void fileNameIgnoredForInvalidHeader() {
     var attachment = Attachments.create();
     attachment.setId(UUID.randomUUID().toString());
     when(target.values()).thenReturn(attachment);
@@ -394,7 +343,7 @@ class CreateAttachmentEventTest {
   }
 
   @Test
-  void mimeTypeExtractedWhenEmpty() {
+  void mimeTypeFromHeaderWhenEmpty() {
     var attachment = Attachments.create();
     attachment.setId(UUID.randomUUID().toString());
     when(target.values()).thenReturn(attachment);
@@ -407,5 +356,22 @@ class CreateAttachmentEventTest {
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     assertThat(contextArgumentCaptor.getValue().mimeType()).isEqualTo("text/csv");
+  }
+
+  @Test
+  void headersSkippedWhenParameterInfoIsNull() {
+    var attachment = Attachments.create();
+    attachment.setId(UUID.randomUUID().toString());
+    when(target.values()).thenReturn(attachment);
+    when(target.keys()).thenReturn(Map.of("ID", attachment.getId()));
+    when(attachmentService.createAttachment(any()))
+        .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
+    when(eventContext.getParameterInfo()).thenReturn(null);
+
+    cut.processEvent(path, null, Attachments.create(), eventContext);
+
+    verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
+    assertThat(contextArgumentCaptor.getValue().fileName()).isNull();
+    assertThat(contextArgumentCaptor.getValue().mimeType()).isNull();
   }
 }


### PR DESCRIPTION
# Extract `fileName` and `mimeType` from HTTP Headers When Creating Attachments

### New Feature

✨ When creating attachments, metadata (`fileName` and `mimeType`) is now automatically extracted from HTTP request headers as a fallback when not provided in the payload. This improves compatibility with Fiori Elements and standard HTTP clients.

**Header extraction logic:**
- `fileName` from `Content-Disposition` header — supports RFC 5987 encoded format (`filename*=UTF-8''...`) and plain format (`filename="..."`)
- `fileName` from `slug` header as a Fiori Elements compatibility fallback
- `mimeType` from `Content-Type` header (stripping charset/parameters)
- Payload values always take precedence over header-derived values

### Changes

* `CreateAttachmentEvent.java`: Added two private helper methods (`extractFileNameFromHeader`, `extractMimeTypeFromHeader`) that read from `EventContext` headers. Fallback logic is applied before creating the `CreateAttachmentInput` if `fileName` or `mimeType` is missing. Added regex patterns (`RFC5987_FILENAME_PATTERN`, `PLAIN_FILENAME_PATTERN`) for `Content-Disposition` parsing. Imports for `URLDecoder`, `StandardCharsets`, `Matcher`, and `Pattern` were added accordingly.

* `CreateAttachmentEventTest.java`: Added comprehensive test coverage for all new header extraction scenarios:
  - RFC 5987 encoded filenames (with and without trailing parameters)
  - Plain `Content-Disposition` filenames (quoted and unquoted)
  - `slug` header fallback
  - Payload precedence over headers (for both `fileName` and `mimeType`)
  - `Content-Type` header MIME type extraction (with charset stripping)
  - Invalid/missing header handling
  - Graceful skip when `ParameterInfo` is `null`

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.21` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Event Trigger: `pull_request.edited`
- Correlation ID: `1d08e4fa-5a03-4dbb-93bc-226d68d44a67`
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
