### PR TITLE
Improve formatting and overall presentation

### DIFF
--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
@@ -84,7 +84,7 @@ annotate sap.attachments.Attachments with
             @HTML5.CssDefaults: {width: '25%'}
         },
         {
-            Value: up_,
+            Value: up__ID,
             @UI.Hidden
         }
     ]

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
@@ -17,8 +17,12 @@ annotate MediaData with @UI.MediaResource: {Stream: content} {
     fileName  @(
         title: '{i18n>attachment_fileName}',
         UI.MultiLineText
-        );
-    status    @(title: '{i18n>attachment_status}', Common.Text : statusNav.name, Common.TextArrangement : #TextOnly);
+    );
+    status    @(
+        title                 : '{i18n>attachment_status}',
+        Common.Text           : statusNav.name,
+        Common.TextArrangement: #TextOnly
+    );
     contentId @(UI.Hidden: true);
     scannedAt @(UI.Hidden: true);
 }
@@ -29,12 +33,31 @@ annotate Attachments with @UI: {
         TypeNamePlural: '{i18n>attachments}',
     },
     LineItem  : [
-        {Value: content,   @HTML5.CssDefaults: {width: '30%'}},
-        {Value: status, Criticality: statusNav.criticality,    @HTML5.CssDefaults: {width: '10%'}},
-        {Value: createdAt, @HTML5.CssDefaults: {width: '20%'}},
-        {Value: createdBy, @HTML5.CssDefaults: {width: '15%'}},
-        {Value: note,      @HTML5.CssDefaults: {width: '25%'}},
-        {Value: up__ID, @UI.Hidden}
+        {
+            Value             : content,
+            @HTML5.CssDefaults: {width: '30%'}
+        },
+        {
+            Value             : status,
+            Criticality       : statusNav.criticality,
+            @HTML5.CssDefaults: {width: '10%'}
+        },
+        {
+            Value             : createdAt,
+            @HTML5.CssDefaults: {width: '20%'}
+        },
+        {
+            Value             : createdBy,
+            @HTML5.CssDefaults: {width: '15%'}
+        },
+        {
+            Value             : note,
+            @HTML5.CssDefaults: {width: '25%'}
+        },
+        {
+            Value: up_,
+            @UI.Hidden
+        }
     ]
 } {
     note       @(

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
@@ -5,10 +5,8 @@ using {
 
 annotate sap.attachments.MediaData with @UI.MediaResource: {Stream: content} {
     content   @(
-        title                           : '{i18n>attachment_content}',
-        Core.ContentDisposition.Type    : 'inline',
-        Core.MediaType                  : (mimeType),
-        Core.ContentDisposition.Filename: (fileName),
+        title         : '{i18n>attachment_content}',
+        Core.MediaType: mimeType,
     );
     mimeType  @(
         title: '{i18n>attachment_mimeType}',
@@ -36,6 +34,23 @@ annotate sap.attachments.MediaData with @UI.MediaResource: {Stream: content} {
     );
 }
 
+annotate sap.attachments.Attachments {
+    content    @(
+        Core.ContentDisposition: {
+            Filename: fileName,
+            Type    : 'inline',
+        },
+        Core.MediaType         : mimeType
+    );
+    mimeType   @Core.IsMediaType;
+    status     @(
+        Common.Text           : statusNav.name,
+        Common.TextArrangement: #TextOnly
+    );
+    modifiedAt @(odata.etag);
+}
+
+// Fiori Annotations
 annotate sap.attachments.Attachments with
 @Capabilities: {
     UpdateRestrictions.NonUpdateableProperties: [content],
@@ -77,15 +92,4 @@ annotate sap.attachments.Attachments with
 @Common      : {SideEffects #ContentChanged: {
     SourceProperties: [content],
     TargetProperties: ['status']
-}} {
-    content    @(
-        Core.ContentDisposition.Filename: fileName,
-        Core.MediaType                  : mimeType
-    );
-    mimeType   @Core.IsMediaType;
-    status     @(
-        Common.Text           : statusNav.name,
-        Common.TextArrangement: #TextOnly
-    );
-    modifiedAt @(odata.etag);
-}
+}}

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments-annotations.cds
@@ -3,12 +3,12 @@ using {
     sap.attachments.Attachments
 } from './attachments';
 
-annotate MediaData with @UI.MediaResource: {Stream: content} {
+annotate sap.attachments.MediaData with @UI.MediaResource: {Stream: content} {
     content   @(
         title                           : '{i18n>attachment_content}',
-        Core.MediaType                  : mimeType,
-        Core.ContentDisposition.Filename: fileName,
-        Core.ContentDisposition.Type    : 'inline'
+        Core.ContentDisposition.Type    : 'inline',
+        Core.MediaType                  : (mimeType),
+        Core.ContentDisposition.Filename: (fileName),
     );
     mimeType  @(
         title: '{i18n>attachment_mimeType}',
@@ -19,15 +19,29 @@ annotate MediaData with @UI.MediaResource: {Stream: content} {
         UI.MultiLineText
     );
     status    @(
-        title                 : '{i18n>attachment_status}',
-        Common.Text           : statusNav.name,
-        Common.TextArrangement: #TextOnly
+        title: '{i18n>attachment_status}',
+        readonly
     );
-    contentId @(UI.Hidden: true);
-    scannedAt @(UI.Hidden: true);
+    note      @(
+        title: '{i18n>attachment_note}',
+        UI.MultiLineText
+    );
+    contentId @(
+        UI.Hidden: true,
+        readonly
+    );
+    scannedAt @(
+        UI.Hidden: true,
+        readonly
+    );
 }
 
-annotate Attachments with @UI: {
+annotate sap.attachments.Attachments with
+@Capabilities: {
+    UpdateRestrictions.NonUpdateableProperties: [content],
+    SortRestrictions                          : {NonSortableProperties: [content]}
+}
+@UI          : {
     HeaderInfo: {
         TypeName      : '{i18n>attachment}',
         TypeNamePlural: '{i18n>attachments}',
@@ -59,15 +73,19 @@ annotate Attachments with @UI: {
             @UI.Hidden
         }
     ]
-} {
-    note       @(
-        title: '{i18n>attachment_note}',
-        UI.MultiLineText
+}
+@Common      : {SideEffects #ContentChanged: {
+    SourceProperties: [content],
+    TargetProperties: ['status']
+}} {
+    content    @(
+        Core.ContentDisposition.Filename: fileName,
+        Core.MediaType                  : mimeType
+    );
+    mimeType   @Core.IsMediaType;
+    status     @(
+        Common.Text           : statusNav.name,
+        Common.TextArrangement: #TextOnly
     );
     modifiedAt @(odata.etag);
 }
-
-annotate Attachments with @Common: {SideEffects #ContentChanged: {
-    SourceProperties: [content],
-    TargetProperties: ['status']
-}} {};

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
@@ -1,35 +1,41 @@
-namespace sap.attachments;
-
 using {
     cuid,
     managed,
     sap.common.CodeList
 } from '@sap/cds/common';
 
-type StatusCode : String(32) enum {
-    Unscanned;
-    Scanning;
-    Clean;
-    Infected;
-    Failed;
-}
+// The common root-level aspect used in applications like that:
+// using { Attachments } from 'com.sap.cds/cds-feature-attachments'
+aspect Attachments : sap.attachments.Attachments {}
 
-aspect MediaData @(_is_media_data) {
-    content   : LargeBinary; // stored only for db-based services
-    mimeType  : String;
-    fileName  : String(5000);
-    contentId : String     @readonly; // id of attachment in external storage, if database storage is used, same as id
-    status    : StatusCode default 'Unscanned' @readonly;
-    statusNav : Association to one ScanStates on statusNav.code = status;
-    scannedAt : Timestamp  @readonly;
-}
+context sap.attachments {
 
-entity ScanStates : CodeList {
-    key code        : StatusCode  @Common.Text: name  @Common.TextArrangement: #TextOnly;
-        name        : localized String(64);
-        criticality : Integer     @UI.Hidden;
-}
+    type StatusCode : String(32) enum {
+        Unscanned;
+        Scanning;
+        Clean;
+        Infected;
+        Failed;
+    }
 
-aspect Attachments : cuid, managed, MediaData {
-    note : String(5000);
+    entity ScanStates : CodeList {
+        key code        : StatusCode  @Common.Text: name  @Common.TextArrangement: #TextOnly;
+            name        : localized String(64);
+            criticality : Integer     @UI.Hidden;
+    }
+
+    aspect MediaData @(_is_media_data) : managed {
+        content   : LargeBinary; // stored only for db-based services
+        mimeType  : String default 'application/octet-stream';
+        fileName  : String(5000);
+        contentId : String                         @readonly; // id of attachment in external storage, if database storage is used, same as id
+        status    : StatusCode default 'Unscanned' @readonly;
+        scannedAt : Timestamp                      @readonly;
+        note      : String(5000);
+    }
+
+    aspect Attachments : cuid, MediaData {
+        statusNav : Association to one ScanStates
+                        on statusNav.code = status;
+    }
 }

--- a/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
+++ b/cds-feature-attachments/src/main/resources/cds/com.sap.cds/cds-feature-attachments/attachments.cds
@@ -26,7 +26,7 @@ context sap.attachments {
 
     aspect MediaData @(_is_media_data) : managed {
         content   : LargeBinary; // stored only for db-based services
-        mimeType  : String default 'application/octet-stream';
+        mimeType  : String;
         fileName  : String(5000);
         contentId : String                         @readonly; // id of attachment in external storage, if database storage is used, same as id
         status    : StatusCode default 'Unscanned' @readonly;

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
-- Added top-level `Attachments` aspect to allow usage without `sap.attachments` namespace (#806)
+- Added top-level `Attachments` aspect to allow usage without `sap.attachments` namespace (#806), i.e., `using {Attachments} from 'com.sap.cds/cds-feature-attachments'`.
 - Extract `fileName` and `mimeType` from HTTP headers (`Content-Disposition`, `Content-Type`, `slug`) when not provided in the request payload (#804)
 
 ## Version 1.5.0 - 2026-04-10

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,21 +6,32 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.6.0 - not yet released
+
+### Changed
+
+- Added top-level `Attachments` aspect to allow usage without `sap.attachments` namespace (#806)
+- Extract `fileName` and `mimeType` from HTTP headers (`Content-Disposition`, `Content-Type`, `slug`) when not provided in the request payload (#804)
+
 ## Version 1.5.0 - 2026-04-10
 
 ### Added
+
 - Added shared-bucket multitenancy support for OSS attachments (#767)
 - Added integration tests for multitenancy scenarios (#782)
 
 ### Fixed
+
 - Fixed rescan-on-download being triggered when no malware scanner is bound (#783)
 
 ## Version 1.4.1 - 2026-04-08
 
 ### Added
+
 - Added `ScanStates` entity with criticality for enhanced malware scan status display (#776)
 
 ### Fixed
+
 - Fixed `DRAFT_NEW` crash on non-attachment compositions (#780)
 - Fixed malware scan retriggering on draft activation without content changes (#779)
 - Fixed code smells (#775)
@@ -28,81 +39,99 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 1.4.0 - 2026-03-31
 
 ### Added
+
 - Added support to restrict allowed MIME types via `@Core.AcceptableMediaTypes` annotation (#732)
 - Added malware scan check upon attachment download (#762)
 - Added mTLS authentication support for Malware Scanning Service (#765)
 - Added `isSystemUser` to `DeletionUserInfo` (#769)
 
 ### Changed
+
 - Optimized MIME type validation to only run when `@Core.AcceptableMediaTypes` annotation exists (#761)
 
 ### Fixed
+
 - Fixed malware scan status stuck at `Scanning` after draft activation (#771)
 
 ## Version 1.3.3 - 2026-03-15
 
 ### Fixed
+
 - Fixed @Validation.Maximum error message not showing in consuming projects due to messages.properties being overwritten instead of merged. Error messages are now temporary self-contained and no longer rely on a resource bundle.
 
 ## Version 1.3.2 - 2026-03-10
 
 ### Fixed
+
 - Fixed Validation.Maximum annotation not triggering on first upload of an attachment
 
 ## Version 1.3.1 - 2026-02-06
 
 ### Changed
+
 - Changed default max file size value to only be enforced when using the malware scanner
 
 ## Version 1.3.0 - 2026-01-26
 
 ### Added
+
 - Added @Validation.Maximum Annotation for setting max file size (default: 400MB)
 
 ### Changed
+
 - Included the filestorage(fs) module in the deployment process for dev purposes
 
 ### Fixed
+
 - fix "no proper error message when exceeding char limit on note field" (also: default char limit for note is now 5000)
 
 ## Version 1.2.4 - 2025-12-17
 
 ### Fixed
+
 - DraftCancel not registering attachments as compositions
 - fix overflowing filename
 
 ## Version 1.2.3 - 2025-12-01
 
 ### Changed
+
 - Sample: Replaced cap-notebook with a bookshop sample
 
 ### Fixed
+
 - "Attempted read on closed stream" error for usage via api in oss
-- Make up__ID field invisible in UI
+- Make up\_\_ID field invisible in UI
 
 ## Version 1.2.2 - 2025-11-14
 
 ### Changed
+
 - Several version bumps
 
 ### Fixed
-- Deletion error when having "fiori": {"draft_messages": true } (#526) 
+
+- Deletion error when having "fiori": {"draft_messages": true } (#526)
 
 ## Version 1.2.1 - 2025-09-03
 
 ### Changed
+
 - Several version bumps
 - Apply GoogleJavaFormat style GOOGLE and enforce that for PRs (#551)
 
 ### Fixed
+
 - Fixed an issue where the Malware Scanning Service is not triggered after uploading an Attachment, if the target storage is other than the default DB storage. (#557)
 
 ## Version 1.2.0 - 2025-08-26
 
 ### Added
+
 - Support for Object Stores (AWS, Azure and Google) (#481)
 
 ### Changed
+
 - Rename folder 'examples' to 'storage-targets' and add section about this in the README.md (#519)
 - Use spotless plugin to ensure correct license header (#515)
 - Several version bumps

--- a/samples/bookshop/srv/attachments.cds
+++ b/samples/bookshop/srv/attachments.cds
@@ -1,5 +1,5 @@
 using {sap.capire.bookshop as my} from '../db/schema';
-using {Attachments} from 'com.sap.cds/cds-feature-attachments';
+using {sap.attachments.Attachments} from 'com.sap.cds/cds-feature-attachments';
 
 // Extend Books entity to support file attachments (images, PDFs, documents)
 // Each book can have multiple attachments via composition relationship

--- a/samples/bookshop/srv/attachments.cds
+++ b/samples/bookshop/srv/attachments.cds
@@ -1,14 +1,14 @@
 using {sap.capire.bookshop as my} from '../db/schema';
-using {sap.attachments.Attachments} from 'com.sap.cds/cds-feature-attachments';
+using {Attachments} from 'com.sap.cds/cds-feature-attachments';
 
 // Extend Books entity to support file attachments (images, PDFs, documents)
 // Each book can have multiple attachments via composition relationship
 extend my.Books with {
-  attachments                      : Composition of many Attachments;
+  attachments               : Composition of many Attachments;
   @UI.Hidden
-  sizeLimitedAttachments           : Composition of many Attachments;
+  sizeLimitedAttachments    : Composition of many Attachments;
   @UI.Hidden
-  mediaValidatedAttachments        : Composition of many Attachments;
+  mediaValidatedAttachments : Composition of many Attachments;
 }
 
 annotate my.Books.sizeLimitedAttachments with {


### PR DESCRIPTION
# Improve Formatting and Restructure CDS Attachment Definitions

### Style / Refactor

🎨 Reformatted and restructured CDS annotation and model definitions for improved readability, consistency, and correctness. Key changes include moving type/aspect definitions into a proper namespaced context, expanding compact inline declarations to multi-line format, and adding new fields.

### Changes

* `attachments.cds`: Significant restructuring — moved `StatusCode`, `ScanStates`, `MediaData`, and `Attachments` aspects into the `sap.attachments` context block. Added `managed` to `MediaData`, set a default value for `mimeType` (`'application/octet-stream'`), added a `note` field to `MediaData`, moved `statusNav` association into `Attachments`, and removed the duplicate `note` field from `Attachments`. A convenience top-level `aspect Attachments` alias is retained for backward compatibility.

* `attachments-annotations.cds`: Multiple annotation improvements:
  - Qualified references changed from short form (`MediaData`, `Attachments`) to fully qualified (`sap.attachments.MediaData`, `sap.attachments.Attachments`)
  - `@Capabilities` annotation merged into the `Attachments` annotate block
  - `status`, `contentId`, and `scannedAt` annotations expanded to multi-line with `readonly` added
  - New `note` annotation block added with `UI.MultiLineText`
  - `Common.SideEffects` block merged into the main `Attachments` annotate block
  - `LineItem` entries expanded from compact single-line to multi-line format
  - Fixed reference `up__ID` → `up_` in the hidden `LineItem` entry

* `samples/bookshop/srv/attachments.cds`: Updated import to use the short-form `Attachments` alias instead of `sap.attachments.Attachments`. Minor whitespace alignment fixes for composition fields.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.23`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.edited`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `0237327d-8cbd-40b4-b957-049b771e7258`
- File Content Strategy: Full file content
</details>
