### PR TITLE
Remove re-implementations of AssociationCascader

### DIFF
--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -147,8 +147,8 @@ public class Registration implements CdsRuntimeConfiguration {
         new MarkAsDeletedAttachmentEvent(outboxedAttachmentService);
     ModifyAttachmentEventFactory eventFactory =
         buildAttachmentEventFactory(attachmentService, deleteEvent, outboxedAttachmentService);
-    AttachmentsReader attachmentsReader =
-        new AttachmentsReader(new AssociationCascader(), persistenceService);
+    AssociationCascader cascader = new AssociationCascader();
+    AttachmentsReader attachmentsReader = new AttachmentsReader(cascader, persistenceService);
     ThreadLocalDataStorage storage = new ThreadLocalDataStorage();
 
     // register event handlers for application service, if at least one application service is
@@ -182,7 +182,8 @@ public class Registration implements CdsRuntimeConfiguration {
     if (hasDraftServices) {
       configurer.eventHandler(
           new DraftPatchAttachmentsHandler(persistenceService, eventFactory, defaultMaxSize));
-      configurer.eventHandler(new DraftCancelAttachmentsHandler(attachmentsReader, deleteEvent));
+      configurer.eventHandler(
+          new DraftCancelAttachmentsHandler(cascader, attachmentsReader, deleteEvent));
       configurer.eventHandler(new DraftActiveAttachmentsHandler(storage));
     } else {
       logger.debug("No draft service is available. Draft event handlers will not be registered.");

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -170,6 +170,7 @@ public class Registration implements CdsRuntimeConfiguration {
               new AttachmentStatusValidator(),
               scanRunner,
               persistenceService,
+              cascader,
               scanClient != null));
     } else {
       logger.debug(

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -182,8 +182,7 @@ public class Registration implements CdsRuntimeConfiguration {
     if (hasDraftServices) {
       configurer.eventHandler(
           new DraftPatchAttachmentsHandler(persistenceService, eventFactory, defaultMaxSize));
-      configurer.eventHandler(
-          new DraftCancelAttachmentsHandler(cascader, attachmentsReader, deleteEvent));
+      configurer.eventHandler(new DraftCancelAttachmentsHandler(attachmentsReader, deleteEvent));
       configurer.eventHandler(new DraftActiveAttachmentsHandler(storage));
     } else {
       logger.debug("No draft service is available. Draft event handlers will not be registered.");

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
@@ -15,6 +15,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.Att
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.BeforeReadItemsModifier;
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.LazyProxyInputStream;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AssociationCascader;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.AsyncMalwareScanExecutor;
 import com.sap.cds.ql.CQL;
@@ -22,13 +23,10 @@ import com.sap.cds.ql.Update;
 import com.sap.cds.ql.cqn.CqnSelect;
 import com.sap.cds.ql.cqn.CqnUpdate;
 import com.sap.cds.ql.cqn.Path;
-import com.sap.cds.reflect.CdsAssociationType;
-import com.sap.cds.reflect.CdsElementDefinition;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.services.cds.ApplicationService;
 import com.sap.cds.services.cds.CdsReadEventContext;
-import com.sap.cds.services.draft.Drafts;
 import com.sap.cds.services.handler.EventHandler;
 import com.sap.cds.services.handler.annotations.After;
 import com.sap.cds.services.handler.annotations.Before;
@@ -38,13 +36,10 @@ import com.sap.cds.services.persistence.PersistenceService;
 import java.io.InputStream;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,6 +72,7 @@ public class ReadAttachmentsHandler implements EventHandler {
   private final AttachmentStatusValidator statusValidator;
   private final AsyncMalwareScanExecutor scanExecutor;
   private final PersistenceService persistenceService;
+  private final AssociationCascader cascader;
   private final boolean scannerAvailable;
 
   public ReadAttachmentsHandler(
@@ -84,6 +80,7 @@ public class ReadAttachmentsHandler implements EventHandler {
       AttachmentStatusValidator statusValidator,
       AsyncMalwareScanExecutor scanExecutor,
       PersistenceService persistenceService,
+      AssociationCascader cascader,
       boolean scannerAvailable) {
     this.attachmentService =
         requireNonNull(attachmentService, "attachmentService must not be null");
@@ -91,6 +88,7 @@ public class ReadAttachmentsHandler implements EventHandler {
     this.scanExecutor = requireNonNull(scanExecutor, "scanExecutor must not be null");
     this.persistenceService =
         requireNonNull(persistenceService, "persistenceService must not be null");
+    this.cascader = requireNonNull(cascader, "cascader must not be null");
     this.scannerAvailable = scannerAvailable;
   }
 
@@ -100,8 +98,7 @@ public class ReadAttachmentsHandler implements EventHandler {
     logger.debug("Processing before {} for entity {}.", context.getEvent(), context.getTarget());
 
     CdsModel cdsModel = context.getModel();
-    List<String> fieldNames =
-        getAttachmentAssociations(cdsModel, context.getTarget(), "", new ArrayList<>());
+    List<String> fieldNames = cascader.findMediaAssociationNames(cdsModel, context.getTarget());
     if (!fieldNames.isEmpty()) {
       CqnSelect resultCqn = CQL.copy(context.getCqn(), new BeforeReadItemsModifier(fieldNames));
       context.setCqn(resultCqn);
@@ -135,39 +132,6 @@ public class ReadAttachmentsHandler implements EventHandler {
           .addConverter(ApplicationHandlerHelper.MEDIA_CONTENT_FILTER, converter)
           .process(data, context.getTarget());
     }
-  }
-
-  private List<String> getAttachmentAssociations(
-      CdsModel model, CdsEntity entity, String associationName, List<String> processedEntities) {
-    List<String> associationNames = new ArrayList<>();
-    if (ApplicationHandlerHelper.isMediaEntity(entity)) {
-      associationNames.add(associationName);
-    }
-
-    Map<String, CdsEntity> annotatedEntities =
-        entity
-            .associations()
-            .collect(
-                Collectors.toMap(
-                    CdsElementDefinition::getName,
-                    element -> element.getType().as(CdsAssociationType.class).getTarget()));
-
-    if (annotatedEntities.isEmpty()) {
-      return associationNames;
-    }
-
-    for (Entry<String, CdsEntity> associatedElement : annotatedEntities.entrySet()) {
-      if (!associationNames.contains(associatedElement.getKey())
-          && !processedEntities.contains(associatedElement.getKey())
-          && !Drafts.SIBLING_ENTITY.equals(associatedElement.getKey())) {
-        processedEntities.add(associatedElement.getKey());
-        List<String> result =
-            getAttachmentAssociations(
-                model, associatedElement.getValue(), associatedElement.getKey(), processedEntities);
-        associationNames.addAll(result);
-      }
-    }
-    return associationNames;
   }
 
   private void verifyStatus(Path path, Attachments attachment) {

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AssociationCascader.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AssociationCascader.java
@@ -27,14 +27,24 @@ public class AssociationCascader {
   public List<String> findMediaEntityNames(CdsModel model, CdsEntity entity) {
     NodeTree tree = findEntityPath(model, entity);
     List<String> result = new ArrayList<>();
-    collect(model, tree, result);
+    collectEntityNames(model, tree, result);
     return result;
   }
 
-  private void collect(CdsModel model, NodeTree node, List<String> result) {
+  public List<String> findMediaAssociationNames(CdsModel model, CdsEntity entity) {
+    List<String> result = new ArrayList<>();
+    if (ApplicationHandlerHelper.isMediaEntity(entity)) {
+      result.add("");
+    }
+    NodeTree tree = findEntityPath(model, entity);
+    collectAssociationNames(model, tree, result);
+    return result;
+  }
+
+  private void collectEntityNames(CdsModel model, NodeTree node, List<String> result) {
     if (!node.getChildren().isEmpty()) {
       for (NodeTree child : node.getChildren()) {
-        collect(model, child, result);
+        collectEntityNames(model, child, result);
       }
     } else {
       String entityName = node.getIdentifier().fullEntityName();
@@ -42,6 +52,19 @@ public class AssociationCascader {
           .findEntity(entityName)
           .filter(ApplicationHandlerHelper::isMediaEntity)
           .ifPresent(e -> result.add(entityName));
+    }
+  }
+
+  private void collectAssociationNames(CdsModel model, NodeTree node, List<String> result) {
+    for (NodeTree child : node.getChildren()) {
+      if (child.getChildren().isEmpty()) {
+        model
+            .findEntity(child.getIdentifier().fullEntityName())
+            .filter(ApplicationHandlerHelper::isMediaEntity)
+            .ifPresent(e -> result.add(child.getIdentifier().associationName()));
+      } else {
+        collectAssociationNames(model, child, result);
+      }
     }
   }
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AttachmentsReader.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AttachmentsReader.java
@@ -46,6 +46,11 @@ public class AttachmentsReader {
     NodeTree nodePath = cascader.findEntityPath(model, entity);
     List<Expand<?>> expandList = buildExpandList(nodePath);
 
+    if (expandList.isEmpty() && !ApplicationHandlerHelper.isMediaEntity(entity)) {
+      logResultData(entity, List.of());
+      return List.of();
+    }
+
     Select<?> select =
         !expandList.isEmpty()
             ? Select.from(statement.ref()).columns(expandList)

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
@@ -12,10 +12,10 @@ import com.sap.cds.CdsDataProcessor.Validator;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AssociationCascader;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.cqn.CqnDelete;
-import com.sap.cds.reflect.CdsAssociationType;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.reflect.CdsStructuredType;
 import com.sap.cds.services.draft.DraftCancelEventContext;
@@ -25,7 +25,6 @@ import com.sap.cds.services.handler.EventHandler;
 import com.sap.cds.services.handler.annotations.Before;
 import com.sap.cds.services.handler.annotations.HandlerOrder;
 import com.sap.cds.services.handler.annotations.ServiceName;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,11 +46,15 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
           ApplicationHandlerHelper.isMediaEntity(path.target().type())
               && element.getName().equals(Attachments.CONTENT_ID);
 
+  private final AssociationCascader cascader;
   private final AttachmentsReader attachmentsReader;
   private final MarkAsDeletedAttachmentEvent deleteEvent;
 
   public DraftCancelAttachmentsHandler(
-      AttachmentsReader attachmentsReader, MarkAsDeletedAttachmentEvent deleteEvent) {
+      AssociationCascader cascader,
+      AttachmentsReader attachmentsReader,
+      MarkAsDeletedAttachmentEvent deleteEvent) {
+    this.cascader = requireNonNull(cascader, "cascader must not be null");
     this.attachmentsReader =
         requireNonNull(attachmentsReader, "attachmentsReader must not be null");
     this.deleteEvent = requireNonNull(deleteEvent, "deleteEvent must not be null");
@@ -62,7 +65,7 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
   void processBeforeDraftCancel(DraftCancelEventContext context) {
     CdsEntity entity = context.getTarget();
 
-    if (deepSearchForAttachments(entity)) {
+    if (!cascader.findMediaEntityNames(context.getModel(), entity).isEmpty()) {
       logger.debug(
           "Processing before {} event for entity {}", context.getEvent(), context.getTarget());
 
@@ -105,28 +108,6 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
             }
           });
     };
-  }
-
-  private boolean deepSearchForAttachments(CdsEntity entity) {
-    return deepSearchForAttachmentsRecursive(entity, new HashSet<>());
-  }
-
-  private boolean deepSearchForAttachmentsRecursive(CdsEntity entity, HashSet<String> visited) {
-
-    if (visited.contains(entity.getQualifiedName())) {
-      return false;
-    }
-    visited.add(entity.getQualifiedName());
-
-    if (ApplicationHandlerHelper.isMediaEntity(entity)) {
-      return true;
-    }
-
-    return entity
-        .compositions()
-        .map(element -> element.getType().as(CdsAssociationType.class))
-        .anyMatch(
-            association -> deepSearchForAttachmentsRecursive(association.getTarget(), visited));
   }
 
   private List<Attachments> readAttachments(

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
@@ -60,7 +60,6 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
   void processBeforeDraftCancel(DraftCancelEventContext context) {
     CdsEntity entity = context.getTarget();
 
-    CdsEntity activeEntity = DraftUtils.getActiveEntity(entity);
     CdsEntity draftEntity = DraftUtils.getDraftEntity(entity);
 
     List<Attachments> draftAttachments = readAttachments(context, draftEntity, false);
@@ -76,6 +75,7 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
     logger.debug(
         "Processing before {} event for entity {}", context.getEvent(), context.getTarget());
 
+    CdsEntity activeEntity = DraftUtils.getActiveEntity(entity);
     List<Attachments> activeCondensedAttachments =
         getCondensedActiveAttachments(context, activeEntity);
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
@@ -12,7 +12,6 @@ import com.sap.cds.CdsDataProcessor.Validator;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
-import com.sap.cds.feature.attachments.handler.common.AssociationCascader;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.cqn.CqnDelete;
@@ -46,15 +45,11 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
           ApplicationHandlerHelper.isMediaEntity(path.target().type())
               && element.getName().equals(Attachments.CONTENT_ID);
 
-  private final AssociationCascader cascader;
   private final AttachmentsReader attachmentsReader;
   private final MarkAsDeletedAttachmentEvent deleteEvent;
 
   public DraftCancelAttachmentsHandler(
-      AssociationCascader cascader,
-      AttachmentsReader attachmentsReader,
-      MarkAsDeletedAttachmentEvent deleteEvent) {
-    this.cascader = requireNonNull(cascader, "cascader must not be null");
+      AttachmentsReader attachmentsReader, MarkAsDeletedAttachmentEvent deleteEvent) {
     this.attachmentsReader =
         requireNonNull(attachmentsReader, "attachmentsReader must not be null");
     this.deleteEvent = requireNonNull(deleteEvent, "deleteEvent must not be null");
@@ -65,27 +60,29 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
   void processBeforeDraftCancel(DraftCancelEventContext context) {
     CdsEntity entity = context.getTarget();
 
-    if (!cascader.findMediaEntityNames(context.getModel(), entity).isEmpty()) {
-      logger.debug(
-          "Processing before {} event for entity {}", context.getEvent(), context.getTarget());
+    CdsEntity activeEntity = DraftUtils.getActiveEntity(entity);
+    CdsEntity draftEntity = DraftUtils.getDraftEntity(entity);
 
-      CdsEntity activeEntity = DraftUtils.getActiveEntity(context.getTarget());
-      CdsEntity draftEntity = DraftUtils.getDraftEntity(context.getTarget());
+    List<Attachments> draftAttachments = readAttachments(context, draftEntity, false);
 
-      List<Attachments> draftAttachments = readAttachments(context, draftEntity, false);
-      List<Attachments> activeCondensedAttachments =
-          getCondensedActiveAttachments(context, activeEntity);
-
-      Validator validator = buildDeleteContentValidator(context, activeCondensedAttachments);
-      CdsDataProcessor.create()
-          .addValidator(contentIdFilter, validator)
-          .process(draftAttachments, context.getTarget());
-    } else {
+    if (draftAttachments.isEmpty()) {
       logger.debug(
           "Skipping processing before {} event for entity {}",
           context.getEvent(),
           context.getTarget());
+      return;
     }
+
+    logger.debug(
+        "Processing before {} event for entity {}", context.getEvent(), context.getTarget());
+
+    List<Attachments> activeCondensedAttachments =
+        getCondensedActiveAttachments(context, activeEntity);
+
+    Validator validator = buildDeleteContentValidator(context, activeCondensedAttachments);
+    CdsDataProcessor.create()
+        .addValidator(contentIdFilter, validator)
+        .process(draftAttachments, context.getTarget());
   }
 
   private Validator buildDeleteContentValidator(

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
@@ -25,6 +25,7 @@ import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservic
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.AttachmentStatusException;
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.AttachmentStatusValidator;
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.LazyProxyInputStream;
+import com.sap.cds.feature.attachments.handler.common.AssociationCascader;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.AsyncMalwareScanExecutor;
@@ -78,6 +79,7 @@ class ReadAttachmentsHandlerTest {
             attachmentStatusValidator,
             asyncMalwareScanExecutor,
             persistenceService,
+            new AssociationCascader(),
             true);
 
     readEventContext = mock(CdsReadEventContext.class);
@@ -396,6 +398,7 @@ class ReadAttachmentsHandlerTest {
             attachmentStatusValidator,
             asyncMalwareScanExecutor,
             persistenceService,
+            new AssociationCascader(),
             false);
     mockEventContext(Attachment_.CDS_NAME, mock(CqnSelect.class));
     var attachment = Attachments.create();
@@ -419,6 +422,7 @@ class ReadAttachmentsHandlerTest {
             attachmentStatusValidator,
             asyncMalwareScanExecutor,
             persistenceService,
+            new AssociationCascader(),
             false);
     mockEventContext(Attachment_.CDS_NAME, mock(CqnSelect.class));
     var attachment = Attachments.create();
@@ -442,6 +446,7 @@ class ReadAttachmentsHandlerTest {
             attachmentStatusValidator,
             asyncMalwareScanExecutor,
             persistenceService,
+            new AssociationCascader(),
             false);
     mockEventContext(Attachment_.CDS_NAME, mock(CqnSelect.class));
     var attachment = Attachments.create();

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AssociationCascaderTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AssociationCascaderTest.java
@@ -128,6 +128,30 @@ class AssociationCascaderTest {
         "unit.test.Items.itemAttachments");
   }
 
+  @Test
+  void findMediaAssociationNames_returnsAssociationNames_forRoot() {
+    var entity = runtime.getCdsModel().findEntity(RootTable_.CDS_NAME).orElseThrow();
+
+    var result = cut.findMediaAssociationNames(runtime.getCdsModel(), entity);
+
+    assertThat(result)
+        .containsExactlyInAnyOrder(
+            RootTable.ATTACHMENTS,
+            Items.ATTACHMENTS,
+            "itemAttachments",
+            "sizeLimitedAttachments",
+            "defaultSizeLimitedAttachments");
+  }
+
+  @Test
+  void findMediaAssociationNames_returnsEmptyString_whenEntityIsMediaEntity() {
+    var entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME).orElseThrow();
+
+    var result = cut.findMediaAssociationNames(runtime.getCdsModel(), entity);
+
+    assertThat(result).containsExactly("");
+  }
+
   private void verifyItemAttachments(
       NodeTree itemNode, String attachmentNodeName, String itemAttachmentNodeName) {
     var attachmentNode = itemNode.getChildren().get(0);

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AttachmentsReaderTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AttachmentsReaderTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
@@ -52,6 +53,7 @@ class AttachmentsReaderTest {
     cut = new AttachmentsReader(cascader, persistenceService);
 
     entity = mock(CdsEntity.class);
+    when(entity.getAnnotationValue("_is_media_data", false)).thenReturn(false);
     model = mock(CdsModel.class);
     selectArgumentCaptor = ArgumentCaptor.forClass(CqnSelect.class);
     result = mock(Result.class);
@@ -165,6 +167,19 @@ class AttachmentsReaderTest {
   }
 
   @Test
+  void returnsEmptyListWhenNoMediaEntityPaths() {
+    var emptyTree = new NodeTree(new AssociationIdentifier("", RootTable_.CDS_NAME));
+    when(cascader.findEntityPath(model, entity)).thenReturn(emptyTree);
+    when(entity.getQualifiedName()).thenReturn(RootTable_.CDS_NAME);
+    CqnDelete delete = Delete.from(RootTable_.CDS_NAME);
+
+    var resultData = cut.readAttachments(model, entity, delete);
+
+    assertThat(resultData).isEmpty();
+    verifyNoInteractions(persistenceService);
+  }
+
+  @Test
   void dataAreLogged() {
     mockPathListAndEntity(Attachment_.CDS_NAME);
     var keys = buildDefaultKeyMap();
@@ -213,6 +228,8 @@ class AttachmentsReaderTest {
     pathList.forEach(nodeTree::addPath);
     when(cascader.findEntityPath(model, entity)).thenReturn(nodeTree);
     when(entity.getQualifiedName()).thenReturn(entityName);
+    boolean isMediaEntity = Attachment_.CDS_NAME.equals(entityName);
+    when(entity.getAnnotationValue("_is_media_data", false)).thenReturn(isMediaEntity);
   }
 
   private String getExpectedSelectStatementWithWhereAndFilter(String id) {

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
@@ -13,6 +13,7 @@ import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservic
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
+import com.sap.cds.feature.attachments.handler.common.AssociationCascader;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.ql.Delete;
@@ -49,7 +50,9 @@ class DraftCancelAttachmentsHandlerTest {
   void setup() {
     attachmentsReader = mock(AttachmentsReader.class);
     deleteContentAttachmentEvent = mock(MarkAsDeletedAttachmentEvent.class);
-    cut = new DraftCancelAttachmentsHandler(attachmentsReader, deleteContentAttachmentEvent);
+    cut =
+        new DraftCancelAttachmentsHandler(
+            new AssociationCascader(), attachmentsReader, deleteContentAttachmentEvent);
 
     eventContext = mock(DraftCancelEventContext.class);
     deleteArgumentCaptor = ArgumentCaptor.forClass(CqnDelete.class);
@@ -68,7 +71,7 @@ class DraftCancelAttachmentsHandlerTest {
     when(mockEntity.elements()).thenReturn(java.util.stream.Stream.empty());
 
     com.sap.cds.reflect.CdsModel mockModel = mock(com.sap.cds.reflect.CdsModel.class);
-    when(mockModel.getEntity("TestService.RegularEntity")).thenReturn(mockEntity);
+    when(mockModel.findEntity("TestService.RegularEntity")).thenReturn(Optional.of(mockEntity));
 
     when(eventContext.getTarget()).thenReturn(mockEntity);
     when(eventContext.getModel()).thenReturn(mockModel);
@@ -90,6 +93,7 @@ class DraftCancelAttachmentsHandlerTest {
     when(mockEntity.getQualifiedName()).thenReturn("TestService.RegularEntity");
     when(mockEntity.getAnnotationValue("_is_media_data", false)).thenReturn(false);
     when(mockEntity.compositions()).thenReturn(java.util.stream.Stream.empty());
+    when(mockEntity.elements()).thenReturn(java.util.stream.Stream.empty());
 
     when(eventContext.getTarget()).thenReturn(mockEntity);
     when(eventContext.getCqn()).thenReturn(Delete.from("RegularEntity"));

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
@@ -77,23 +77,6 @@ class DraftCancelAttachmentsHandlerTest {
   }
 
   @Test
-  void entityWithoutAttachmentsIsSkipped() {
-    CdsEntity mockEntity = mock(CdsEntity.class);
-    when(mockEntity.getQualifiedName()).thenReturn("TestService.RegularEntity");
-    CdsEntity siblingEntity = mock(CdsEntity.class);
-    when(mockEntity.getTargetOf(Drafts.SIBLING_ENTITY)).thenReturn(siblingEntity);
-
-    when(eventContext.getTarget()).thenReturn(mockEntity);
-    when(eventContext.getCqn()).thenReturn(Delete.from("RegularEntity"));
-    when(eventContext.getModel()).thenReturn(runtime.getCdsModel());
-    when(attachmentsReader.readAttachments(any(), any(), any())).thenReturn(List.of());
-
-    cut.processBeforeDraftCancel(eventContext);
-
-    verifyNoInteractions(deleteContentAttachmentEvent);
-  }
-
-  @Test
   void nothingSelectedNothingToDo() {
     getEntityAndMockContext(RootTable_.CDS_NAME);
     CqnDelete delete = Delete.from(RootTable_.class);

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
@@ -13,7 +13,6 @@ import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservic
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
-import com.sap.cds.feature.attachments.handler.common.AssociationCascader;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.ql.Delete;
@@ -49,10 +48,10 @@ class DraftCancelAttachmentsHandlerTest {
   @BeforeEach
   void setup() {
     attachmentsReader = mock(AttachmentsReader.class);
+    when(attachmentsReader.readAttachments(any(), any(), any()))
+        .thenReturn(List.of(Attachments.create()));
     deleteContentAttachmentEvent = mock(MarkAsDeletedAttachmentEvent.class);
-    cut =
-        new DraftCancelAttachmentsHandler(
-            new AssociationCascader(), attachmentsReader, deleteContentAttachmentEvent);
+    cut = new DraftCancelAttachmentsHandler(attachmentsReader, deleteContentAttachmentEvent);
 
     eventContext = mock(DraftCancelEventContext.class);
     deleteArgumentCaptor = ArgumentCaptor.forClass(CqnDelete.class);
@@ -61,47 +60,37 @@ class DraftCancelAttachmentsHandlerTest {
 
   @Test
   void entityHasNoAttachmentsAndIsNotAttachmentEntityNothingHappens() {
-    // Test the case where isAttachmentEntity and hasAttachmentAssociations both
-    // return false
     CdsEntity mockEntity = mock(CdsEntity.class);
-    // Entity has no elements with name "attachment"
-    when(mockEntity.getQualifiedName())
-        .thenReturn("TestService.RegularEntity"); // No "Attachment" in name
-    when(mockEntity.getAnnotationValue("_is_media_data", false)).thenReturn(false);
-    when(mockEntity.elements()).thenReturn(java.util.stream.Stream.empty());
-
-    com.sap.cds.reflect.CdsModel mockModel = mock(com.sap.cds.reflect.CdsModel.class);
-    when(mockModel.findEntity("TestService.RegularEntity")).thenReturn(Optional.of(mockEntity));
+    when(mockEntity.getQualifiedName()).thenReturn("TestService.RegularEntity");
+    CdsEntity siblingEntity = mock(CdsEntity.class);
+    when(mockEntity.getTargetOf(Drafts.SIBLING_ENTITY)).thenReturn(siblingEntity);
 
     when(eventContext.getTarget()).thenReturn(mockEntity);
-    when(eventContext.getModel()).thenReturn(mockModel);
-
-    CqnDelete mockDelete = mock(CqnDelete.class);
-    when(mockDelete.where()).thenReturn(Optional.empty());
-    when(eventContext.getCqn()).thenReturn(mockDelete);
+    when(eventContext.getModel()).thenReturn(runtime.getCdsModel());
+    when(eventContext.getCqn()).thenReturn(Delete.from("RegularEntity"));
     when(eventContext.getEvent()).thenReturn("DRAFT_CANCEL");
+    when(attachmentsReader.readAttachments(any(), any(), any())).thenReturn(List.of());
 
     cut.processBeforeDraftCancel(eventContext);
 
-    verifyNoInteractions(attachmentsReader);
+    verifyNoInteractions(deleteContentAttachmentEvent);
   }
 
   @Test
   void entityWithoutAttachmentsIsSkipped() {
-    // Test that entities without attachments are properly skipped
     CdsEntity mockEntity = mock(CdsEntity.class);
     when(mockEntity.getQualifiedName()).thenReturn("TestService.RegularEntity");
-    when(mockEntity.getAnnotationValue("_is_media_data", false)).thenReturn(false);
-    when(mockEntity.compositions()).thenReturn(java.util.stream.Stream.empty());
-    when(mockEntity.elements()).thenReturn(java.util.stream.Stream.empty());
+    CdsEntity siblingEntity = mock(CdsEntity.class);
+    when(mockEntity.getTargetOf(Drafts.SIBLING_ENTITY)).thenReturn(siblingEntity);
 
     when(eventContext.getTarget()).thenReturn(mockEntity);
     when(eventContext.getCqn()).thenReturn(Delete.from("RegularEntity"));
     when(eventContext.getModel()).thenReturn(runtime.getCdsModel());
+    when(attachmentsReader.readAttachments(any(), any(), any())).thenReturn(List.of());
 
     cut.processBeforeDraftCancel(eventContext);
 
-    verifyNoInteractions(attachmentsReader, deleteContentAttachmentEvent);
+    verifyNoInteractions(deleteContentAttachmentEvent);
   }
 
   @Test
@@ -254,18 +243,14 @@ class DraftCancelAttachmentsHandlerTest {
 
   @Test
   void circularReferenceInCompositionsHandled() {
-    // Test that circular references in entity compositions are handled correctly
     getEntityAndMockContext(RootTable_.CDS_NAME);
     CqnDelete delete = Delete.from(RootTable_.class);
     when(eventContext.getCqn()).thenReturn(delete);
     when(eventContext.getModel()).thenReturn(runtime.getCdsModel());
     when(eventContext.getEvent()).thenReturn("DRAFT_CANCEL");
 
-    // The deepSearchForAttachmentsRecursive should handle circular references via
-    // the visited set
     cut.processBeforeDraftCancel(eventContext);
 
-    // Should complete without stack overflow or infinite loop
     verify(attachmentsReader, atLeastOnce()).readAttachments(any(), any(), any());
   }
 


### PR DESCRIPTION
- Replace the custom recursive association traversal in ReadAttachmentsHandler with the shared AssociationCascader. The handler had its own getAttachmentAssociations method that walked all associations to find media entities, this duplicated logic already present in AssociationCascader, which correctly restricts traversal to compositions only.
- Added findMediaAssociationNames to AssociationCascader that collects leaf association names from the existing NodeTree, reusing findEntityPath. Injected the cascader into ReadAttachmentsHandler and removed the 30-line private method along with its unused imports.
- This also fixes cycle detection: the old code tracked visited nodes by association name (fragile), while AssociationCascader tracks by qualified entity name.