### PR TITLE
Add support for separate bucket MT

### DIFF
--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/client/TenantOSClientProvider.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/client/TenantOSClientProvider.java
@@ -1,0 +1,77 @@
+/*
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.oss.client;
+
+import static java.util.Objects.requireNonNull;
+
+import com.sap.cds.feature.attachments.oss.servicemanager.ServiceManagerCredentialResolver;
+import com.sap.cloud.environment.servicebinding.api.DefaultServiceBindingBuilder;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Thread-safe provider that resolves and caches per-tenant {@link OSClient} instances for
+ * separate-bucket multitenancy mode. On cache miss, fetches the tenant's object store credentials
+ * from the Service Manager and creates an {@link OSClient} via {@link OSClientFactory}.
+ */
+public class TenantOSClientProvider {
+
+  private static final Logger logger = LoggerFactory.getLogger(TenantOSClientProvider.class);
+
+  private final ServiceManagerCredentialResolver credentialResolver;
+  private final ExecutorService executor;
+  private final ConcurrentHashMap<String, OSClient> clientCache = new ConcurrentHashMap<>();
+
+  /**
+   * Creates a new provider.
+   *
+   * @param credentialResolver the resolver for fetching per-tenant credentials from Service Manager
+   * @param executor the executor for async storage operations
+   */
+  public TenantOSClientProvider(
+      ServiceManagerCredentialResolver credentialResolver, ExecutorService executor) {
+    this.credentialResolver =
+        requireNonNull(credentialResolver, "credentialResolver must not be null");
+    this.executor = requireNonNull(executor, "executor must not be null");
+  }
+
+  /**
+   * Returns the {@link OSClient} for the given tenant, creating and caching it if necessary.
+   *
+   * @param tenantId the tenant ID
+   * @return the tenant's OSClient
+   */
+  public OSClient getClientForTenant(String tenantId) {
+    requireNonNull(tenantId, "tenantId must not be null");
+    return clientCache.computeIfAbsent(tenantId, this::createClientForTenant);
+  }
+
+  /**
+   * Removes the cached {@link OSClient} for the given tenant. Called during tenant unsubscribe to
+   * ensure stale clients are not reused.
+   *
+   * @param tenantId the tenant ID to evict
+   */
+  public void evict(String tenantId) {
+    clientCache.remove(tenantId);
+    logger.info("Evicted cached OSClient for tenant {}", tenantId);
+  }
+
+  private OSClient createClientForTenant(String tenantId) {
+    logger.info("Creating OSClient for tenant {}", tenantId);
+
+    Map<String, Object> credentials = credentialResolver.getCredentialsForTenant(tenantId);
+    ServiceBinding binding =
+        new DefaultServiceBindingBuilder()
+            .withCredentials(credentials)
+            .withServiceName("objectstore")
+            .build();
+
+    return OSClientFactory.create(binding, executor);
+  }
+}

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
@@ -5,8 +5,10 @@ package com.sap.cds.feature.attachments.oss.configuration;
 
 import com.sap.cds.feature.attachments.oss.client.OSClient;
 import com.sap.cds.feature.attachments.oss.client.OSClientFactory;
+import com.sap.cds.feature.attachments.oss.client.TenantOSClientProvider;
 import com.sap.cds.feature.attachments.oss.handler.OSSAttachmentsServiceHandler;
 import com.sap.cds.feature.attachments.oss.handler.TenantCleanupHandler;
+import com.sap.cds.feature.attachments.oss.servicemanager.ServiceManagerCredentialResolver;
 import com.sap.cds.services.environment.CdsEnvironment;
 import com.sap.cds.services.runtime.CdsRuntimeConfiguration;
 import com.sap.cds.services.runtime.CdsRuntimeConfigurer;
@@ -25,37 +27,46 @@ public class Registration implements CdsRuntimeConfiguration {
   @Override
   public void eventHandlers(CdsRuntimeConfigurer configurer) {
     CdsEnvironment env = configurer.getCdsRuntime().getEnvironment();
+    boolean multitenancyEnabled = isMultitenancyEnabled(env);
+    String objectStoreKind = getObjectStoreKind(env);
+
+    if (multitenancyEnabled && "separate".equals(objectStoreKind)) {
+      registerSeparateMode(configurer, env, objectStoreKind);
+    } else {
+      registerSharedOrSingleTenantMode(configurer, env, multitenancyEnabled, objectStoreKind);
+    }
+  }
+
+  private void registerSeparateMode(
+      CdsRuntimeConfigurer configurer, CdsEnvironment env, String objectStoreKind) {
+    Optional<ServiceBinding> smBindingOpt = getSMBinding(env);
+    if (smBindingOpt.isEmpty()) {
+      logger.warn(
+          "No service binding to Service Manager found. Separate-bucket multitenancy for"
+              + " attachments requires a 'service-manager' service binding.");
+      return;
+    }
+
+    ExecutorService executor = createExecutor(env);
+    ServiceManagerCredentialResolver credentialResolver =
+        new ServiceManagerCredentialResolver(smBindingOpt.get());
+    TenantOSClientProvider tenantProvider =
+        new TenantOSClientProvider(credentialResolver, executor);
+
+    configurer.eventHandler(new OSSAttachmentsServiceHandler(tenantProvider, objectStoreKind));
+    configurer.eventHandler(new TenantCleanupHandler(tenantProvider));
+    logger.info(
+        "Registered OSS Attachments Service Handler with separate-bucket multitenancy mode.");
+  }
+
+  private void registerSharedOrSingleTenantMode(
+      CdsRuntimeConfigurer configurer,
+      CdsEnvironment env,
+      boolean multitenancyEnabled,
+      String objectStoreKind) {
     Optional<ServiceBinding> bindingOpt = getOSBinding(env);
     if (bindingOpt.isPresent()) {
-      boolean multitenancyEnabled = isMultitenancyEnabled(env);
-      String objectStoreKind = getObjectStoreKind(env);
-
-      // Fixed thread pool for background I/O operations (upload, download, delete).
-      // Default 16 is tuned for I/O-bound cloud storage calls, not CPU-bound work.
-      int threadPoolSize =
-          env.getProperty("cds.attachments.objectStore.threadPoolSize", Integer.class, 16);
-      ExecutorService executor =
-          Executors.newFixedThreadPool(
-              threadPoolSize,
-              r -> {
-                Thread t = new Thread(r, "attachment-oss-tasks");
-                t.setDaemon(true);
-                return t;
-              });
-      Runtime.getRuntime()
-          .addShutdownHook(
-              new Thread(
-                  () -> {
-                    executor.shutdown();
-                    try {
-                      if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
-                        executor.shutdownNow();
-                      }
-                    } catch (InterruptedException e) {
-                      executor.shutdownNow();
-                      Thread.currentThread().interrupt();
-                    }
-                  }));
+      ExecutorService executor = createExecutor(env);
       OSClient osClient = OSClientFactory.create(bindingOpt.get(), executor);
       OSSAttachmentsServiceHandler handler =
           new OSSAttachmentsServiceHandler(osClient, multitenancyEnabled, objectStoreKind);
@@ -64,14 +75,44 @@ public class Registration implements CdsRuntimeConfiguration {
       if (multitenancyEnabled && "shared".equals(objectStoreKind)) {
         configurer.eventHandler(new TenantCleanupHandler(osClient));
         logger.info(
-            "Registered OSS Attachments Service Handler with shared multitenancy mode and tenant cleanup.");
+            "Registered OSS Attachments Service Handler with shared multitenancy mode and tenant"
+                + " cleanup.");
       } else {
         logger.info("Registered OSS Attachments Service Handler.");
       }
     } else {
       logger.warn(
-          "No service binding to Object Store Service found, hence the OSS Attachments Service Handler is not connected!");
+          "No service binding to Object Store Service found, hence the OSS Attachments Service"
+              + " Handler is not connected!");
     }
+  }
+
+  private ExecutorService createExecutor(CdsEnvironment env) {
+    int threadPoolSize =
+        env.getProperty("cds.attachments.objectStore.threadPoolSize", Integer.class, 16);
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            threadPoolSize,
+            r -> {
+              Thread t = new Thread(r, "attachment-oss-tasks");
+              t.setDaemon(true);
+              return t;
+            });
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  executor.shutdown();
+                  try {
+                    if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                      executor.shutdownNow();
+                    }
+                  } catch (InterruptedException e) {
+                    executor.shutdownNow();
+                    Thread.currentThread().interrupt();
+                  }
+                }));
+    return executor;
   }
 
   /**
@@ -86,6 +127,13 @@ public class Registration implements CdsRuntimeConfiguration {
     return environment
         .getServiceBindings()
         .filter(b -> b.getServiceName().map(name -> name.equals("objectstore")).orElse(false))
+        .findFirst();
+  }
+
+  private static Optional<ServiceBinding> getSMBinding(CdsEnvironment environment) {
+    return environment
+        .getServiceBindings()
+        .filter(b -> b.getServiceName().map(name -> name.equals("service-manager")).orElse(false))
         .findFirst();
   }
 

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
@@ -7,7 +7,9 @@ import com.sap.cds.feature.attachments.oss.client.OSClient;
 import com.sap.cds.feature.attachments.oss.client.OSClientFactory;
 import com.sap.cds.feature.attachments.oss.client.TenantOSClientProvider;
 import com.sap.cds.feature.attachments.oss.handler.OSSAttachmentsServiceHandler;
+import com.sap.cds.feature.attachments.oss.handler.ObjectStoreInstanceLifecycleHandler;
 import com.sap.cds.feature.attachments.oss.handler.TenantCleanupHandler;
+import com.sap.cds.feature.attachments.oss.servicemanager.ServiceManagerClient;
 import com.sap.cds.feature.attachments.oss.servicemanager.ServiceManagerCredentialResolver;
 import com.sap.cds.services.environment.CdsEnvironment;
 import com.sap.cds.services.runtime.CdsRuntimeConfiguration;
@@ -53,8 +55,9 @@ public class Registration implements CdsRuntimeConfiguration {
     TenantOSClientProvider tenantProvider =
         new TenantOSClientProvider(credentialResolver, executor);
 
+    ServiceManagerClient smClient = new ServiceManagerClient(credentialResolver);
     configurer.eventHandler(new OSSAttachmentsServiceHandler(tenantProvider, objectStoreKind));
-    configurer.eventHandler(new TenantCleanupHandler(tenantProvider));
+    configurer.eventHandler(new ObjectStoreInstanceLifecycleHandler(smClient, tenantProvider));
     logger.info(
         "Registered OSS Attachments Service Handler with separate-bucket multitenancy mode.");
   }

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/OSSAttachmentsServiceHandler.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/OSSAttachmentsServiceHandler.java
@@ -7,6 +7,7 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachmen
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.StatusCode;
 import com.sap.cds.feature.attachments.oss.client.OSClient;
+import com.sap.cds.feature.attachments.oss.client.TenantOSClientProvider;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentMarkAsDeletedEventContext;
@@ -32,11 +33,13 @@ public class OSSAttachmentsServiceHandler implements EventHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(OSSAttachmentsServiceHandler.class);
   private final OSClient osClient;
+  private final TenantOSClientProvider tenantOSClientProvider;
   private final boolean multitenancyEnabled;
   private final String objectStoreKind;
 
   /**
-   * Creates a new OSSAttachmentsServiceHandler with the given {@link OSClient}.
+   * Creates a new OSSAttachmentsServiceHandler with a fixed {@link OSClient}. Used for
+   * single-tenant and shared multitenancy modes where all tenants share one object store.
    *
    * <p>Use {@link com.sap.cds.feature.attachments.oss.client.OSClientFactory#create
    * OSClientFactory.create()} to obtain an {@link OSClient} from a service binding.
@@ -48,7 +51,24 @@ public class OSSAttachmentsServiceHandler implements EventHandler {
   public OSSAttachmentsServiceHandler(
       OSClient osClient, boolean multitenancyEnabled, String objectStoreKind) {
     this.osClient = osClient;
+    this.tenantOSClientProvider = null;
     this.multitenancyEnabled = multitenancyEnabled;
+    this.objectStoreKind = objectStoreKind;
+  }
+
+  /**
+   * Creates a new OSSAttachmentsServiceHandler for separate-bucket multitenancy mode. Each tenant
+   * gets a dedicated object store instance resolved at runtime via the {@link
+   * TenantOSClientProvider}.
+   *
+   * @param tenantOSClientProvider the provider for per-tenant OSClient instances
+   * @param objectStoreKind the object store kind (must be "separate")
+   */
+  public OSSAttachmentsServiceHandler(
+      TenantOSClientProvider tenantOSClientProvider, String objectStoreKind) {
+    this.osClient = null;
+    this.tenantOSClientProvider = tenantOSClientProvider;
+    this.multitenancyEnabled = true;
     this.objectStoreKind = objectStoreKind;
   }
 
@@ -64,7 +84,7 @@ public class OSSAttachmentsServiceHandler implements EventHandler {
     String objectKey = buildObjectKey(context, contentId);
 
     try {
-      osClient.uploadContent(data.getContent(), objectKey, data.getMimeType()).get();
+      resolveClient(context).uploadContent(data.getContent(), objectKey, data.getMimeType()).get();
       logger.info("Uploaded file {}", fileName);
       context.getData().setStatus(StatusCode.SCANNING);
       context.setIsInternalStored(false);
@@ -88,7 +108,7 @@ public class OSSAttachmentsServiceHandler implements EventHandler {
 
     try {
       String objectKey = buildObjectKey(context, context.getContentId());
-      osClient.deleteContent(objectKey).get();
+      resolveClient(context).deleteContent(objectKey).get();
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
       throw new ServiceException(
@@ -118,7 +138,7 @@ public class OSSAttachmentsServiceHandler implements EventHandler {
         context.getContentId());
     try {
       String objectKey = buildObjectKey(context, context.getContentId());
-      Future<InputStream> future = osClient.readContent(objectKey);
+      Future<InputStream> future = resolveClient(context).readContent(objectKey);
       InputStream inputStream = future.get(); // Wait for the content to be read
       if (inputStream != null) {
         context.getData().setContent(inputStream);
@@ -137,6 +157,19 @@ public class OSSAttachmentsServiceHandler implements EventHandler {
     } finally {
       context.setCompleted();
     }
+  }
+
+  /**
+   * Resolves the appropriate {@link OSClient} for the current request. In separate multitenancy
+   * mode, each tenant has a dedicated object store instance resolved via the {@link
+   * TenantOSClientProvider}. In shared or single-tenant mode, the fixed client is returned.
+   */
+  private OSClient resolveClient(EventContext context) {
+    if (tenantOSClientProvider != null && "separate".equals(objectStoreKind)) {
+      String tenant = getTenant(context);
+      return tenantOSClientProvider.getClientForTenant(tenant);
+    }
+    return osClient;
   }
 
   /**

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/ObjectStoreInstanceLifecycleHandler.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/ObjectStoreInstanceLifecycleHandler.java
@@ -1,0 +1,97 @@
+/*
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.oss.handler;
+
+import static java.util.Objects.requireNonNull;
+
+import com.sap.cds.feature.attachments.oss.client.TenantOSClientProvider;
+import com.sap.cds.feature.attachments.oss.servicemanager.ServiceManagerClient;
+import com.sap.cds.services.handler.EventHandler;
+import com.sap.cds.services.handler.annotations.After;
+import com.sap.cds.services.handler.annotations.ServiceName;
+import com.sap.cds.services.mt.DeploymentService;
+import com.sap.cds.services.mt.SubscribeEventContext;
+import com.sap.cds.services.mt.UnsubscribeEventContext;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * DeploymentService handler that provisions and deprovisions per-tenant object store instances via
+ * the SAP Service Manager. Used in separate-bucket multitenancy mode.
+ *
+ * <p>On subscribe, creates an object store instance and binding for the tenant. On unsubscribe,
+ * deletes the binding and instance and evicts the cached client.
+ *
+ * <p>All operations are best-effort: errors are logged but not rethrown, so tenant
+ * subscribe/unsubscribe is not blocked by object store lifecycle failures.
+ */
+@ServiceName(DeploymentService.DEFAULT_NAME)
+public class ObjectStoreInstanceLifecycleHandler implements EventHandler {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(ObjectStoreInstanceLifecycleHandler.class);
+
+  private final ServiceManagerClient serviceManagerClient;
+  private final TenantOSClientProvider tenantOSClientProvider;
+
+  public ObjectStoreInstanceLifecycleHandler(
+      ServiceManagerClient serviceManagerClient, TenantOSClientProvider tenantOSClientProvider) {
+    this.serviceManagerClient =
+        requireNonNull(serviceManagerClient, "serviceManagerClient must not be null");
+    this.tenantOSClientProvider =
+        requireNonNull(tenantOSClientProvider, "tenantOSClientProvider must not be null");
+  }
+
+  @After(event = DeploymentService.EVENT_SUBSCRIBE)
+  void provisionObjectStore(SubscribeEventContext context) {
+    String tenantId = context.getTenant();
+    try {
+      OSSAttachmentsServiceHandler.validateTenantId(tenantId);
+
+      if (serviceManagerClient.bindingExistsForTenant(tenantId)) {
+        logger.info(
+            "Object store binding already exists for tenant {}. Skipping provisioning.", tenantId);
+        return;
+      }
+
+      String offeringId = serviceManagerClient.getOfferingId();
+      String planId = serviceManagerClient.getPlanId(offeringId);
+      String instanceId = serviceManagerClient.createInstance(tenantId, planId);
+      serviceManagerClient.createBinding(tenantId, instanceId);
+
+      logger.info("Object store instance and binding provisioned for tenant {}", tenantId);
+    } catch (Exception e) {
+      logger.error("Failed to provision object store for tenant {}", tenantId, e);
+    }
+  }
+
+  @After(event = DeploymentService.EVENT_UNSUBSCRIBE)
+  void deprovisionObjectStore(UnsubscribeEventContext context) {
+    String tenantId = context.getTenant();
+    try {
+      OSSAttachmentsServiceHandler.validateTenantId(tenantId);
+
+      tenantOSClientProvider.evict(tenantId);
+
+      Optional<String> bindingId = serviceManagerClient.findBindingIdForTenant(tenantId);
+      if (bindingId.isPresent()) {
+        serviceManagerClient.deleteBinding(bindingId.get());
+      } else {
+        logger.warn("No object store binding found for tenant {} during deprovisioning", tenantId);
+      }
+
+      Optional<String> instanceId = serviceManagerClient.findInstanceIdForTenant(tenantId);
+      if (instanceId.isPresent()) {
+        serviceManagerClient.deleteInstance(instanceId.get());
+      } else {
+        logger.warn("No object store instance found for tenant {} during deprovisioning", tenantId);
+      }
+
+      logger.info("Object store deprovisioned for tenant {}", tenantId);
+    } catch (Exception e) {
+      logger.error("Failed to deprovision object store for tenant {}", tenantId, e);
+    }
+  }
+}

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/TenantCleanupHandler.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/TenantCleanupHandler.java
@@ -4,6 +4,7 @@
 package com.sap.cds.feature.attachments.oss.handler;
 
 import com.sap.cds.feature.attachments.oss.client.OSClient;
+import com.sap.cds.feature.attachments.oss.client.TenantOSClientProvider;
 import com.sap.cds.services.handler.EventHandler;
 import com.sap.cds.services.handler.annotations.After;
 import com.sap.cds.services.handler.annotations.ServiceName;
@@ -13,23 +14,50 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Event handler that cleans up a tenant's attachment data from the shared object store when the
- * tenant unsubscribes. Registered only in shared multitenancy mode.
+ * Event handler that cleans up a tenant's attachment resources when the tenant unsubscribes.
+ *
+ * <p>In <b>shared</b> multitenancy mode, deletes all objects with the tenant's prefix from the
+ * shared object store.
+ *
+ * <p>In <b>separate</b> multitenancy mode, evicts the cached {@link OSClient} for the tenant. The
+ * actual deletion of the object store instance is handled by the MTX sidecar (cap-js/attachments
+ * plugin).
  */
 @ServiceName(DeploymentService.DEFAULT_NAME)
 public class TenantCleanupHandler implements EventHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(TenantCleanupHandler.class);
   private final OSClient osClient;
+  private final TenantOSClientProvider tenantOSClientProvider;
+  private final boolean separateMode;
 
+  /** Creates a handler for shared multitenancy mode (prefix-based cleanup). */
   public TenantCleanupHandler(OSClient osClient) {
     this.osClient = osClient;
+    this.tenantOSClientProvider = null;
+    this.separateMode = false;
+  }
+
+  /** Creates a handler for separate multitenancy mode (cache eviction only). */
+  public TenantCleanupHandler(TenantOSClientProvider tenantOSClientProvider) {
+    this.osClient = null;
+    this.tenantOSClientProvider = tenantOSClientProvider;
+    this.separateMode = true;
   }
 
   @After(event = DeploymentService.EVENT_UNSUBSCRIBE)
   void cleanupTenantData(UnsubscribeEventContext context) {
     String tenantId = context.getTenant();
     OSSAttachmentsServiceHandler.validateTenantId(tenantId);
+
+    if (separateMode) {
+      cleanupSeparateMode(tenantId);
+    } else {
+      cleanupSharedMode(tenantId);
+    }
+  }
+
+  private void cleanupSharedMode(String tenantId) {
     String prefix = tenantId + "/";
     try {
       osClient.deleteContentByPrefix(prefix).get();
@@ -40,5 +68,12 @@ public class TenantCleanupHandler implements EventHandler {
     } catch (Exception e) {
       logger.error("Failed to clean up objects for tenant {}", tenantId, e);
     }
+  }
+
+  private void cleanupSeparateMode(String tenantId) {
+    tenantOSClientProvider.evict(tenantId);
+    logger.info(
+        "Evicted cached OSClient for tenant {} (instance cleanup handled by MTX sidecar)",
+        tenantId);
   }
 }

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/TenantCleanupHandler.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/TenantCleanupHandler.java
@@ -4,7 +4,6 @@
 package com.sap.cds.feature.attachments.oss.handler;
 
 import com.sap.cds.feature.attachments.oss.client.OSClient;
-import com.sap.cds.feature.attachments.oss.client.TenantOSClientProvider;
 import com.sap.cds.services.handler.EventHandler;
 import com.sap.cds.services.handler.annotations.After;
 import com.sap.cds.services.handler.annotations.ServiceName;
@@ -14,35 +13,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Event handler that cleans up a tenant's attachment resources when the tenant unsubscribes.
+ * Event handler that cleans up a tenant's attachment objects when the tenant unsubscribes in
+ * <b>shared</b> multitenancy mode. Deletes all objects with the tenant's prefix from the shared
+ * object store.
  *
- * <p>In <b>shared</b> multitenancy mode, deletes all objects with the tenant's prefix from the
- * shared object store.
- *
- * <p>In <b>separate</b> multitenancy mode, evicts the cached {@link OSClient} for the tenant. The
- * actual deletion of the object store instance is handled by the MTX sidecar (cap-js/attachments
- * plugin).
+ * <p>For <b>separate</b> multitenancy mode, see {@link ObjectStoreInstanceLifecycleHandler} which
+ * handles instance deprovisioning via Service Manager.
  */
 @ServiceName(DeploymentService.DEFAULT_NAME)
 public class TenantCleanupHandler implements EventHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(TenantCleanupHandler.class);
   private final OSClient osClient;
-  private final TenantOSClientProvider tenantOSClientProvider;
-  private final boolean separateMode;
 
-  /** Creates a handler for shared multitenancy mode (prefix-based cleanup). */
   public TenantCleanupHandler(OSClient osClient) {
     this.osClient = osClient;
-    this.tenantOSClientProvider = null;
-    this.separateMode = false;
-  }
-
-  /** Creates a handler for separate multitenancy mode (cache eviction only). */
-  public TenantCleanupHandler(TenantOSClientProvider tenantOSClientProvider) {
-    this.osClient = null;
-    this.tenantOSClientProvider = tenantOSClientProvider;
-    this.separateMode = true;
   }
 
   @After(event = DeploymentService.EVENT_UNSUBSCRIBE)
@@ -50,14 +35,6 @@ public class TenantCleanupHandler implements EventHandler {
     String tenantId = context.getTenant();
     OSSAttachmentsServiceHandler.validateTenantId(tenantId);
 
-    if (separateMode) {
-      cleanupSeparateMode(tenantId);
-    } else {
-      cleanupSharedMode(tenantId);
-    }
-  }
-
-  private void cleanupSharedMode(String tenantId) {
     String prefix = tenantId + "/";
     try {
       osClient.deleteContentByPrefix(prefix).get();
@@ -68,12 +45,5 @@ public class TenantCleanupHandler implements EventHandler {
     } catch (Exception e) {
       logger.error("Failed to clean up objects for tenant {}", tenantId, e);
     }
-  }
-
-  private void cleanupSeparateMode(String tenantId) {
-    tenantOSClientProvider.evict(tenantId);
-    logger.info(
-        "Evicted cached OSClient for tenant {} (instance cleanup handled by MTX sidecar)",
-        tenantId);
   }
 }

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerClient.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerClient.java
@@ -1,0 +1,367 @@
+/*
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.oss.servicemanager;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Client for SAP Service Manager REST API operations related to object store instance lifecycle.
+ * Used in separate-bucket multitenancy mode to provision and deprovision per-tenant object store
+ * instances.
+ *
+ * <p>Delegates token management and HTTP client to {@link ServiceManagerCredentialResolver}.
+ */
+public class ServiceManagerClient {
+
+  private static final Logger logger = LoggerFactory.getLogger(ServiceManagerClient.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+  private static final long POLL_INTERVAL_MS = 5000;
+  private static final long POLL_TIMEOUT_MS = 5 * 60 * 1000;
+  private static final List<String> SUPPORTED_PLANS = List.of("standard", "s3-standard");
+  private static final String LABEL_QUERY_TEMPLATE =
+      "service eq 'OBJECT_STORE' and tenant_id eq '%s'";
+
+  private final ServiceManagerCredentialResolver credentialResolver;
+
+  public ServiceManagerClient(ServiceManagerCredentialResolver credentialResolver) {
+    this.credentialResolver =
+        requireNonNull(credentialResolver, "credentialResolver must not be null");
+  }
+
+  /**
+   * Checks whether a service binding already exists for the given tenant.
+   *
+   * @param tenantId the tenant ID
+   * @return true if at least one binding exists
+   */
+  public boolean bindingExistsForTenant(String tenantId) {
+    List<Map<String, Object>> items = queryByLabel("/v1/service_bindings", tenantId);
+    return !items.isEmpty();
+  }
+
+  /**
+   * Retrieves the service offering ID for the "objectstore" service.
+   *
+   * @return the offering ID
+   * @throws ServiceManagerException if not found
+   */
+  public String getOfferingId() {
+    String url =
+        credentialResolver.getSmUrl()
+            + "/v1/service_offerings?fieldQuery="
+            + URLEncoder.encode("name eq 'objectstore'", StandardCharsets.UTF_8);
+
+    Map<String, Object> result = executeGet(url);
+    List<Map<String, Object>> items = getItems(result);
+
+    if (items.isEmpty()) {
+      throw new ServiceManagerException(
+          "Object store service offering not found in Service Manager");
+    }
+    return (String) items.get(0).get("id");
+  }
+
+  /**
+   * Retrieves a supported service plan ID for the given offering.
+   *
+   * @param offeringId the service offering ID
+   * @return the plan ID
+   * @throws ServiceManagerException if no supported plan is found
+   */
+  public String getPlanId(String offeringId) {
+    for (String planName : SUPPORTED_PLANS) {
+      String fieldQuery =
+          "service_offering_id eq '%s' and catalog_name eq '%s'".formatted(offeringId, planName);
+      String url =
+          credentialResolver.getSmUrl()
+              + "/v1/service_plans?fieldQuery="
+              + URLEncoder.encode(fieldQuery, StandardCharsets.UTF_8);
+
+      Map<String, Object> result = executeGet(url);
+      List<Map<String, Object>> items = getItems(result);
+
+      if (!items.isEmpty()) {
+        String planId = (String) items.get(0).get("id");
+        logger.debug("Using object store plan '{}' with ID {}", planName, planId);
+        return planId;
+      }
+    }
+    throw new ServiceManagerException(
+        "No supported object store service plan found in Service Manager. Tried: "
+            + SUPPORTED_PLANS);
+  }
+
+  /**
+   * Creates an object store instance for the given tenant and polls until provisioning completes.
+   *
+   * @param tenantId the tenant ID
+   * @param planId the service plan ID
+   * @return the instance ID
+   * @throws ServiceManagerException if creation fails or times out
+   */
+  @SuppressWarnings("unchecked")
+  public String createInstance(String tenantId, String planId) {
+    String instanceName = "object-store-" + tenantId + "-" + UUID.randomUUID();
+    Map<String, Object> body =
+        Map.of(
+            "name",
+            instanceName,
+            "service_plan_id",
+            planId,
+            "parameters",
+            Map.of(),
+            "labels",
+            Map.of("tenant_id", List.of(tenantId), "service", List.of("OBJECT_STORE")));
+
+    logger.info("Creating object store instance '{}' for tenant {}", instanceName, tenantId);
+
+    String url = credentialResolver.getSmUrl() + "/v1/service_instances";
+    Map<String, Object> response = executePost(url, body);
+
+    String instanceId = (String) response.get("id");
+    if (instanceId == null) {
+      throw new ServiceManagerException(
+          "Service Manager did not return an instance ID for tenant " + tenantId);
+    }
+
+    pollUntilDone(instanceId, tenantId);
+    return instanceId;
+  }
+
+  /**
+   * Creates a service binding for the given tenant's object store instance.
+   *
+   * @param tenantId the tenant ID
+   * @param instanceId the instance ID to bind
+   * @return the binding ID
+   */
+  public String createBinding(String tenantId, String instanceId) {
+    String bindingName = "object-store-" + tenantId + "-" + UUID.randomUUID();
+    Map<String, Object> body =
+        Map.of(
+            "name",
+            bindingName,
+            "service_instance_id",
+            instanceId,
+            "parameters",
+            Map.of(),
+            "labels",
+            Map.of("tenant_id", List.of(tenantId), "service", List.of("OBJECT_STORE")));
+
+    logger.info("Creating binding '{}' for tenant {}", bindingName, tenantId);
+
+    String url = credentialResolver.getSmUrl() + "/v1/service_bindings";
+    Map<String, Object> response = executePost(url, body);
+
+    String bindingId = (String) response.get("id");
+    if (bindingId == null) {
+      throw new ServiceManagerException(
+          "Service Manager did not return a binding ID for tenant " + tenantId);
+    }
+    return bindingId;
+  }
+
+  /**
+   * Finds the binding ID for the given tenant, if one exists.
+   *
+   * @param tenantId the tenant ID
+   * @return the binding ID, or empty if none found
+   */
+  public Optional<String> findBindingIdForTenant(String tenantId) {
+    List<Map<String, Object>> items = queryByLabel("/v1/service_bindings", tenantId);
+    if (items.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable((String) items.get(0).get("id"));
+  }
+
+  /**
+   * Deletes the service binding with the given ID.
+   *
+   * @param bindingId the binding ID to delete
+   */
+  public void deleteBinding(String bindingId) {
+    String url = credentialResolver.getSmUrl() + "/v1/service_bindings/" + bindingId;
+    executeDelete(url);
+    logger.info("Deleted service binding {}", bindingId);
+  }
+
+  /**
+   * Finds the instance ID for the given tenant, if one exists.
+   *
+   * @param tenantId the tenant ID
+   * @return the instance ID, or empty if none found
+   */
+  public Optional<String> findInstanceIdForTenant(String tenantId) {
+    List<Map<String, Object>> items = queryByLabel("/v1/service_instances", tenantId);
+    if (items.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable((String) items.get(0).get("id"));
+  }
+
+  /**
+   * Deletes the service instance with the given ID.
+   *
+   * @param instanceId the instance ID to delete
+   */
+  public void deleteInstance(String instanceId) {
+    String url = credentialResolver.getSmUrl() + "/v1/service_instances/" + instanceId;
+    executeDelete(url);
+    logger.info("Deleted service instance {}", instanceId);
+  }
+
+  private void pollUntilDone(String instanceId, String tenantId) {
+    String url =
+        credentialResolver.getSmUrl() + "/v1/service_instances/" + instanceId + "/last_operation";
+    long startTime = System.currentTimeMillis();
+    int iteration = 1;
+
+    while (true) {
+      long waitTime = POLL_INTERVAL_MS * iteration;
+      try {
+        Thread.sleep(waitTime);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new ServiceManagerException(
+            "Interrupted while waiting for object store instance for tenant " + tenantId, e);
+      }
+
+      Map<String, Object> operation = executeGet(url);
+      String state = (String) operation.get("state");
+
+      if ("succeeded".equals(state)) {
+        logger.info("Object store instance provisioned for tenant {}", tenantId);
+        return;
+      }
+
+      if ("failed".equals(state)) {
+        String description = (String) operation.get("description");
+        throw new ServiceManagerException(
+            "Object store instance provisioning failed for tenant %s: %s"
+                .formatted(tenantId, description));
+      }
+
+      if (System.currentTimeMillis() - startTime > POLL_TIMEOUT_MS) {
+        throw new ServiceManagerException(
+            "Timed out waiting for object store instance provisioning for tenant " + tenantId);
+      }
+
+      iteration++;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Map<String, Object>> queryByLabel(String path, String tenantId) {
+    String labelQuery = LABEL_QUERY_TEMPLATE.formatted(tenantId);
+    String url =
+        credentialResolver.getSmUrl()
+            + path
+            + "?labelQuery="
+            + URLEncoder.encode(labelQuery, StandardCharsets.UTF_8);
+
+    Map<String, Object> result = executeGet(url);
+    return getItems(result);
+  }
+
+  private Map<String, Object> executeGet(String url) {
+    String token = credentialResolver.getAccessToken();
+    HttpGet request = new HttpGet(url);
+    request.setHeader("Accept", "application/json");
+    request.setHeader("Authorization", "Bearer " + token);
+
+    try (CloseableHttpResponse response = credentialResolver.getHttpClient().execute(request)) {
+      int statusCode = response.getStatusLine().getStatusCode();
+      String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+      if (statusCode < 200 || statusCode >= 300) {
+        throw new ServiceManagerException(
+            "Service Manager GET %s returned status %d: %s".formatted(url, statusCode, body));
+      }
+      return MAPPER.readValue(body, MAP_TYPE);
+    } catch (ServiceManagerException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ServiceManagerException("Service Manager GET request failed: " + url, e);
+    }
+  }
+
+  private Map<String, Object> executePost(String url, Map<String, Object> requestBody) {
+    String token = credentialResolver.getAccessToken();
+    HttpPost request = new HttpPost(url);
+    request.setHeader("Accept", "application/json");
+    request.setHeader("Content-Type", "application/json");
+    request.setHeader("Authorization", "Bearer " + token);
+
+    try {
+      String jsonBody = MAPPER.writeValueAsString(requestBody);
+      request.setEntity(new StringEntity(jsonBody, StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      throw new ServiceManagerException("Failed to serialize request body", e);
+    }
+
+    try (CloseableHttpResponse response = credentialResolver.getHttpClient().execute(request)) {
+      int statusCode = response.getStatusLine().getStatusCode();
+      String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+      if (statusCode < 200 || statusCode >= 300) {
+        throw new ServiceManagerException(
+            "Service Manager POST %s returned status %d: %s".formatted(url, statusCode, body));
+      }
+      return MAPPER.readValue(body, MAP_TYPE);
+    } catch (ServiceManagerException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ServiceManagerException("Service Manager POST request failed: " + url, e);
+    }
+  }
+
+  private void executeDelete(String url) {
+    String token = credentialResolver.getAccessToken();
+    HttpDelete request = new HttpDelete(url);
+    request.setHeader("Accept", "application/json");
+    request.setHeader("Authorization", "Bearer " + token);
+
+    try (CloseableHttpResponse response = credentialResolver.getHttpClient().execute(request)) {
+      int statusCode = response.getStatusLine().getStatusCode();
+
+      if (statusCode < 200 || statusCode >= 300) {
+        String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+        throw new ServiceManagerException(
+            "Service Manager DELETE %s returned status %d: %s".formatted(url, statusCode, body));
+      }
+    } catch (ServiceManagerException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ServiceManagerException("Service Manager DELETE request failed: " + url, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> getItems(Map<String, Object> response) {
+    Object items = response.get("items");
+    if (items instanceof List<?> list) {
+      return (List<Map<String, Object>>) list;
+    }
+    return List.of();
+  }
+}

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerClient.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerClient.java
@@ -34,8 +34,6 @@ public class ServiceManagerClient {
   private static final Logger logger = LoggerFactory.getLogger(ServiceManagerClient.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
-  private static final long POLL_INTERVAL_MS = 5000;
-  private static final long POLL_TIMEOUT_MS = 5 * 60 * 1000;
   private static final List<String> SUPPORTED_PLANS = List.of("standard", "s3-standard");
   private static final String LABEL_QUERY_TEMPLATE =
       "service eq 'OBJECT_STORE' and tenant_id eq '%s'";
@@ -111,14 +109,13 @@ public class ServiceManagerClient {
   }
 
   /**
-   * Creates an object store instance for the given tenant and polls until provisioning completes.
+   * Creates an object store instance for the given tenant synchronously.
    *
    * @param tenantId the tenant ID
    * @param planId the service plan ID
    * @return the instance ID
-   * @throws ServiceManagerException if creation fails or times out
+   * @throws ServiceManagerException if creation fails
    */
-  @SuppressWarnings("unchecked")
   public String createInstance(String tenantId, String planId) {
     String instanceName = "object-store-" + tenantId + "-" + UUID.randomUUID();
     Map<String, Object> body =
@@ -134,16 +131,19 @@ public class ServiceManagerClient {
 
     logger.info("Creating object store instance '{}' for tenant {}", instanceName, tenantId);
 
-    String url = credentialResolver.getSmUrl() + "/v1/service_instances";
+    String url = credentialResolver.getSmUrl() + "/v1/service_instances?async=false";
     Map<String, Object> response = executePost(url, body);
+
+    logger.debug("Service Manager create instance response: {}", response);
 
     String instanceId = (String) response.get("id");
     if (instanceId == null) {
       throw new ServiceManagerException(
-          "Service Manager did not return an instance ID for tenant " + tenantId);
+          "Service Manager did not return an instance ID for tenant %s. Response: %s"
+              .formatted(tenantId, response));
     }
 
-    pollUntilDone(instanceId, tenantId);
+    logger.info("Object store instance provisioned for tenant {}", tenantId);
     return instanceId;
   }
 
@@ -169,7 +169,7 @@ public class ServiceManagerClient {
 
     logger.info("Creating binding '{}' for tenant {}", bindingName, tenantId);
 
-    String url = credentialResolver.getSmUrl() + "/v1/service_bindings";
+    String url = credentialResolver.getSmUrl() + "/v1/service_bindings?async=false";
     Map<String, Object> response = executePost(url, body);
 
     String bindingId = (String) response.get("id");
@@ -230,46 +230,6 @@ public class ServiceManagerClient {
     logger.info("Deleted service instance {}", instanceId);
   }
 
-  private void pollUntilDone(String instanceId, String tenantId) {
-    String url =
-        credentialResolver.getSmUrl() + "/v1/service_instances/" + instanceId + "/last_operation";
-    long startTime = System.currentTimeMillis();
-    int iteration = 1;
-
-    while (true) {
-      long waitTime = POLL_INTERVAL_MS * iteration;
-      try {
-        Thread.sleep(waitTime);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new ServiceManagerException(
-            "Interrupted while waiting for object store instance for tenant " + tenantId, e);
-      }
-
-      Map<String, Object> operation = executeGet(url);
-      String state = (String) operation.get("state");
-
-      if ("succeeded".equals(state)) {
-        logger.info("Object store instance provisioned for tenant {}", tenantId);
-        return;
-      }
-
-      if ("failed".equals(state)) {
-        String description = (String) operation.get("description");
-        throw new ServiceManagerException(
-            "Object store instance provisioning failed for tenant %s: %s"
-                .formatted(tenantId, description));
-      }
-
-      if (System.currentTimeMillis() - startTime > POLL_TIMEOUT_MS) {
-        throw new ServiceManagerException(
-            "Timed out waiting for object store instance provisioning for tenant " + tenantId);
-      }
-
-      iteration++;
-    }
-  }
-
   @SuppressWarnings("unchecked")
   private List<Map<String, Object>> queryByLabel(String path, String tenantId) {
     String labelQuery = LABEL_QUERY_TEMPLATE.formatted(tenantId);
@@ -327,7 +287,10 @@ public class ServiceManagerClient {
         throw new ServiceManagerException(
             "Service Manager POST %s returned status %d: %s".formatted(url, statusCode, body));
       }
-      return MAPPER.readValue(body, MAP_TYPE);
+
+      return (body != null && !body.isBlank())
+          ? MAPPER.readValue(body, MAP_TYPE)
+          : Map.of();
     } catch (ServiceManagerException e) {
       throw e;
     } catch (Exception e) {

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerCredentialResolver.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerCredentialResolver.java
@@ -1,0 +1,289 @@
+/*
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.oss.servicemanager;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves per-tenant object store credentials from the SAP Service Manager. Used in
+ * separate-bucket multitenancy mode where each tenant has a dedicated object store instance
+ * provisioned by the MTX sidecar (cap-js/attachments plugin).
+ *
+ * <p>This client only reads tenant bindings; instance lifecycle (subscribe/unsubscribe) is handled
+ * by the cap-js sidecar.
+ */
+public class ServiceManagerCredentialResolver {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(ServiceManagerCredentialResolver.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+  private static final long TOKEN_EXPIRY_BUFFER_SECONDS = 300;
+
+  private final String smUrl;
+  private final String tokenUrl;
+  private final String clientId;
+  private final String clientSecret;
+  private final String certificate;
+  private final String key;
+  private final CloseableHttpClient httpClient;
+
+  private volatile String cachedToken;
+  private volatile Instant tokenExpiry = Instant.EPOCH;
+
+  /**
+   * Creates a new resolver from a {@code service-manager} service binding.
+   *
+   * @param smBinding the service binding for the Service Manager service
+   */
+  public ServiceManagerCredentialResolver(ServiceBinding smBinding) {
+    requireNonNull(smBinding, "smBinding must not be null");
+    Map<String, Object> creds = smBinding.getCredentials();
+
+    this.smUrl = requireString(creds, "sm_url");
+    this.clientId = requireString(creds, "clientid");
+    this.clientSecret = (String) creds.get("clientsecret");
+    this.certificate = (String) creds.get("certificate");
+    this.key = (String) creds.get("key");
+
+    String certUrl = (String) creds.get("certurl");
+    this.tokenUrl =
+        (certUrl != null && certificate != null && key != null)
+            ? certUrl
+            : requireString(creds, "url");
+
+    if (clientSecret == null && (certificate == null || key == null)) {
+      throw new ServiceManagerException(
+          "Service Manager binding must provide either clientsecret or certificate+key for"
+              + " authentication");
+    }
+
+    this.httpClient = buildHttpClient();
+  }
+
+  /**
+   * Fetches the object store credentials for the given tenant from Service Manager.
+   *
+   * @param tenantId the tenant ID to fetch credentials for
+   * @return the credentials map from the tenant's service binding
+   * @throws ServiceManagerException if no binding is found or the SM API call fails
+   */
+  @SuppressWarnings("unchecked")
+  public Map<String, Object> getCredentialsForTenant(String tenantId) {
+    requireNonNull(tenantId, "tenantId must not be null");
+    String token = getAccessToken();
+
+    String labelQuery = "service eq 'OBJECT_STORE' and tenant_id eq '" + tenantId + "'";
+    String encodedQuery = URLEncoder.encode(labelQuery, StandardCharsets.UTF_8);
+    String url = smUrl + "/v1/service_bindings?labelQuery=" + encodedQuery;
+
+    logger.debug("Fetching object store binding for tenant {} from Service Manager", tenantId);
+
+    HttpGet request = new HttpGet(url);
+    request.setHeader("Accept", "application/json");
+    request.setHeader("Authorization", "Bearer " + token);
+
+    try (CloseableHttpResponse response = httpClient.execute(request)) {
+      int statusCode = response.getStatusLine().getStatusCode();
+      String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+      if (statusCode != 200) {
+        throw new ServiceManagerException(
+            "Service Manager returned status %d when fetching binding for tenant %s: %s"
+                .formatted(statusCode, tenantId, body));
+      }
+
+      Map<String, Object> result = MAPPER.readValue(body, MAP_TYPE);
+      List<Map<String, Object>> items = (List<Map<String, Object>>) result.get("items");
+
+      if (items == null || items.isEmpty()) {
+        throw new ServiceManagerException(
+            "No object store service binding found for tenant %s. ".formatted(tenantId)
+                + "Ensure the tenant is subscribed and the MTX sidecar has provisioned an object"
+                + " store instance.");
+      }
+
+      Map<String, Object> binding = items.get(0);
+      Map<String, Object> credentials = (Map<String, Object>) binding.get("credentials");
+
+      if (credentials == null) {
+        throw new ServiceManagerException(
+            "Object store binding for tenant %s has no credentials".formatted(tenantId));
+      }
+
+      logger.info("Retrieved object store credentials for tenant {}", tenantId);
+      return credentials;
+    } catch (ServiceManagerException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ServiceManagerException(
+          "Failed to fetch object store credentials for tenant %s".formatted(tenantId), e);
+    }
+  }
+
+  private synchronized String getAccessToken() {
+    if (cachedToken != null && Instant.now().isBefore(tokenExpiry)) {
+      return cachedToken;
+    }
+    return fetchAccessToken();
+  }
+
+  private String fetchAccessToken() {
+    boolean useMtls = certificate != null && key != null && clientSecret == null;
+    String tokenEndpoint = tokenUrl + "/oauth/token";
+
+    logger.debug(
+        "Fetching Service Manager access token using {}", useMtls ? "mTLS" : "client credentials");
+
+    HttpPost request = new HttpPost(tokenEndpoint);
+    request.setHeader("Accept", "application/json");
+    request.setHeader("Content-Type", "application/x-www-form-urlencoded");
+
+    String formBody;
+    if (useMtls) {
+      formBody =
+          "grant_type=client_credentials&response_type=token&client_id="
+              + URLEncoder.encode(clientId, StandardCharsets.UTF_8);
+    } else {
+      formBody =
+          "grant_type=client_credentials&client_id="
+              + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
+              + "&client_secret="
+              + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8);
+    }
+
+    try {
+      request.setEntity(new StringEntity(formBody, StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      throw new ServiceManagerException("Failed to build token request", e);
+    }
+
+    try (CloseableHttpResponse response = httpClient.execute(request)) {
+      int statusCode = response.getStatusLine().getStatusCode();
+      String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+      if (statusCode != 200) {
+        throw new ServiceManagerException(
+            "Token endpoint returned status %d: %s".formatted(statusCode, body));
+      }
+
+      Map<String, Object> tokenResponse = MAPPER.readValue(body, MAP_TYPE);
+      String accessToken = (String) tokenResponse.get("access_token");
+      if (accessToken == null) {
+        throw new ServiceManagerException("Token response missing access_token");
+      }
+
+      Object expiresIn = tokenResponse.get("expires_in");
+      long ttlSeconds =
+          expiresIn instanceof Number
+              ? ((Number) expiresIn).longValue() - TOKEN_EXPIRY_BUFFER_SECONDS
+              : 3300;
+
+      cachedToken = accessToken;
+      tokenExpiry = Instant.now().plusSeconds(Math.max(ttlSeconds, 60));
+
+      logger.debug("Service Manager access token acquired, expires in {} seconds", ttlSeconds);
+      return accessToken;
+    } catch (ServiceManagerException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ServiceManagerException("Failed to fetch Service Manager access token", e);
+    }
+  }
+
+  private CloseableHttpClient buildHttpClient() {
+    boolean useMtls = certificate != null && key != null;
+    if (useMtls) {
+      try {
+        SSLContext sslContext = createSSLContext(certificate, key);
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext);
+        return HttpClients.custom().setSSLSocketFactory(sslSocketFactory).build();
+      } catch (GeneralSecurityException | IOException e) {
+        throw new ServiceManagerException(
+            "Failed to create mTLS HTTP client for Service Manager", e);
+      }
+    }
+    return HttpClients.createDefault();
+  }
+
+  private static SSLContext createSSLContext(String certificatePem, String privateKeyPem)
+      throws GeneralSecurityException, IOException {
+    CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+    Collection<? extends Certificate> certChain =
+        certFactory.generateCertificates(
+            new ByteArrayInputStream(certificatePem.getBytes(StandardCharsets.UTF_8)));
+
+    PrivateKey privateKey = parsePrivateKey(privateKeyPem);
+
+    KeyStore keyStore = KeyStore.getInstance("PKCS12");
+    keyStore.load(null, null);
+    keyStore.setKeyEntry("client", privateKey, new char[0], certChain.toArray(new Certificate[0]));
+
+    KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+    kmf.init(keyStore, new char[0]);
+
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(kmf.getKeyManagers(), null, null);
+    return sslContext;
+  }
+
+  private static PrivateKey parsePrivateKey(String pem) throws IOException {
+    try (PEMParser parser = new PEMParser(new StringReader(pem))) {
+      Object parsed = parser.readObject();
+      if (parsed == null) {
+        throw new IOException("PEM stream contained no recognizable key block.");
+      }
+      JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+      if (parsed instanceof PEMKeyPair keyPair) {
+        return converter.getPrivateKey(keyPair.getPrivateKeyInfo());
+      } else if (parsed instanceof PrivateKeyInfo keyInfo) {
+        return converter.getPrivateKey(keyInfo);
+      }
+      throw new IOException("Unsupported PEM key format. Expected PKCS#1 or PKCS#8 private key.");
+    }
+  }
+
+  private static String requireString(Map<String, Object> map, String key) {
+    Object value = map.get(key);
+    if (!(value instanceof String str) || str.isEmpty()) {
+      throw new ServiceManagerException(
+          "Service Manager binding is missing required credential: " + key);
+    }
+    return str;
+  }
+}

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerCredentialResolver.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerCredentialResolver.java
@@ -41,11 +41,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Resolves per-tenant object store credentials from the SAP Service Manager. Used in
- * separate-bucket multitenancy mode where each tenant has a dedicated object store instance
- * provisioned by the MTX sidecar (cap-js/attachments plugin).
+ * separate-bucket multitenancy mode where each tenant has a dedicated object store instance.
  *
- * <p>This client only reads tenant bindings; instance lifecycle (subscribe/unsubscribe) is handled
- * by the cap-js sidecar.
+ * <p>Provides token management and HTTP client infrastructure that {@link ServiceManagerClient}
+ * reuses for instance lifecycle operations.
  */
 public class ServiceManagerCredentialResolver {
 
@@ -156,7 +155,7 @@ public class ServiceManagerCredentialResolver {
     }
   }
 
-  private synchronized String getAccessToken() {
+  synchronized String getAccessToken() {
     if (cachedToken != null && Instant.now().isBefore(tokenExpiry)) {
       return cachedToken;
     }
@@ -224,6 +223,14 @@ public class ServiceManagerCredentialResolver {
     } catch (Exception e) {
       throw new ServiceManagerException("Failed to fetch Service Manager access token", e);
     }
+  }
+
+  String getSmUrl() {
+    return smUrl;
+  }
+
+  CloseableHttpClient getHttpClient() {
+    return httpClient;
   }
 
   private CloseableHttpClient buildHttpClient() {

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerException.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerException.java
@@ -1,0 +1,16 @@
+/*
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.oss.servicemanager;
+
+public class ServiceManagerException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
+  public ServiceManagerException(String message) {
+    super(message);
+  }
+
+  public ServiceManagerException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
# Add Support for Separate-Bucket Multitenancy Mode

### New Feature

✨ Introduces **separate-bucket multitenancy** support for the OSS attachments feature. In this mode, each tenant gets a dedicated object store instance provisioned by the MTX sidecar, with per-tenant credentials resolved dynamically from the SAP Service Manager at runtime.

Previously, only single-tenant and shared-bucket multitenancy modes were supported. This change adds a third mode (`objectStoreKind = "separate"`) where each tenant's attachments are isolated in their own object store bucket.

### Changes

* `TenantOSClientProvider.java` *(new)*: Thread-safe provider that resolves and caches per-tenant `OSClient` instances. On cache miss, fetches credentials from the Service Manager and creates a new `OSClient` via `OSClientFactory`. Supports eviction of stale clients on tenant unsubscribe.

* `ServiceManagerCredentialResolver.java` *(new)*: Fetches per-tenant object store credentials from the SAP Service Manager API. Supports both client-secret and mTLS (certificate+key) authentication, with token caching and a 5-minute expiry buffer.

* `ServiceManagerException.java` *(new)*: Unchecked exception type for Service Manager API errors.

* `Registration.java`: Updated registration logic to detect the `separate` object store kind and, when enabled, wire up `TenantOSClientProvider` and the Service Manager credential resolver instead of a shared `OSClient`. Executor creation extracted into a reusable `createExecutor()` helper. A new `getSMBinding()` helper looks up the `service-manager` service binding.

* `OSSAttachmentsServiceHandler.java`: Added a new constructor for separate-bucket mode accepting a `TenantOSClientProvider`. Introduced a `resolveClient(EventContext)` method that dynamically selects the correct `OSClient` per tenant in separate mode, or falls back to the fixed shared client.

* `TenantCleanupHandler.java`: Extended to handle both multitenancy modes. In **shared** mode, deletes all tenant-prefixed objects. In **separate** mode, evicts the cached `OSClient` (actual instance cleanup is delegated to the MTX sidecar).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.23`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Correlation ID: `7c476004-39b1-4615-937a-c064b9e1fdc2`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
