### PR TITLE
Service Manager Life Cycle Handling For SB Multitenancy Enablement

### DIFF
--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/configuration/Registration.java
@@ -7,7 +7,9 @@ import com.sap.cds.feature.attachments.oss.client.OSClient;
 import com.sap.cds.feature.attachments.oss.client.OSClientFactory;
 import com.sap.cds.feature.attachments.oss.client.TenantOSClientProvider;
 import com.sap.cds.feature.attachments.oss.handler.OSSAttachmentsServiceHandler;
+import com.sap.cds.feature.attachments.oss.handler.ObjectStoreInstanceLifecycleHandler;
 import com.sap.cds.feature.attachments.oss.handler.TenantCleanupHandler;
+import com.sap.cds.feature.attachments.oss.servicemanager.ServiceManagerClient;
 import com.sap.cds.feature.attachments.oss.servicemanager.ServiceManagerCredentialResolver;
 import com.sap.cds.services.environment.CdsEnvironment;
 import com.sap.cds.services.runtime.CdsRuntimeConfiguration;
@@ -53,8 +55,9 @@ public class Registration implements CdsRuntimeConfiguration {
     TenantOSClientProvider tenantProvider =
         new TenantOSClientProvider(credentialResolver, executor);
 
+    ServiceManagerClient smClient = new ServiceManagerClient(credentialResolver);
     configurer.eventHandler(new OSSAttachmentsServiceHandler(tenantProvider, objectStoreKind));
-    configurer.eventHandler(new TenantCleanupHandler(tenantProvider));
+    configurer.eventHandler(new ObjectStoreInstanceLifecycleHandler(smClient, tenantProvider));
     logger.info(
         "Registered OSS Attachments Service Handler with separate-bucket multitenancy mode.");
   }

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/ObjectStoreInstanceLifecycleHandler.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/ObjectStoreInstanceLifecycleHandler.java
@@ -1,0 +1,97 @@
+/*
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.oss.handler;
+
+import static java.util.Objects.requireNonNull;
+
+import com.sap.cds.feature.attachments.oss.client.TenantOSClientProvider;
+import com.sap.cds.feature.attachments.oss.servicemanager.ServiceManagerClient;
+import com.sap.cds.services.handler.EventHandler;
+import com.sap.cds.services.handler.annotations.After;
+import com.sap.cds.services.handler.annotations.ServiceName;
+import com.sap.cds.services.mt.DeploymentService;
+import com.sap.cds.services.mt.SubscribeEventContext;
+import com.sap.cds.services.mt.UnsubscribeEventContext;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * DeploymentService handler that provisions and deprovisions per-tenant object store instances via
+ * the SAP Service Manager. Used in separate-bucket multitenancy mode.
+ *
+ * <p>On subscribe, creates an object store instance and binding for the tenant. On unsubscribe,
+ * deletes the binding and instance and evicts the cached client.
+ *
+ * <p>All operations are best-effort: errors are logged but not rethrown, so tenant
+ * subscribe/unsubscribe is not blocked by object store lifecycle failures.
+ */
+@ServiceName(DeploymentService.DEFAULT_NAME)
+public class ObjectStoreInstanceLifecycleHandler implements EventHandler {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(ObjectStoreInstanceLifecycleHandler.class);
+
+  private final ServiceManagerClient serviceManagerClient;
+  private final TenantOSClientProvider tenantOSClientProvider;
+
+  public ObjectStoreInstanceLifecycleHandler(
+      ServiceManagerClient serviceManagerClient, TenantOSClientProvider tenantOSClientProvider) {
+    this.serviceManagerClient =
+        requireNonNull(serviceManagerClient, "serviceManagerClient must not be null");
+    this.tenantOSClientProvider =
+        requireNonNull(tenantOSClientProvider, "tenantOSClientProvider must not be null");
+  }
+
+  @After(event = DeploymentService.EVENT_SUBSCRIBE)
+  void provisionObjectStore(SubscribeEventContext context) {
+    String tenantId = context.getTenant();
+    try {
+      OSSAttachmentsServiceHandler.validateTenantId(tenantId);
+
+      if (serviceManagerClient.bindingExistsForTenant(tenantId)) {
+        logger.info(
+            "Object store binding already exists for tenant {}. Skipping provisioning.", tenantId);
+        return;
+      }
+
+      String offeringId = serviceManagerClient.getOfferingId();
+      String planId = serviceManagerClient.getPlanId(offeringId);
+      String instanceId = serviceManagerClient.createInstance(tenantId, planId);
+      serviceManagerClient.createBinding(tenantId, instanceId);
+
+      logger.info("Object store instance and binding provisioned for tenant {}", tenantId);
+    } catch (Exception e) {
+      logger.error("Failed to provision object store for tenant {}", tenantId, e);
+    }
+  }
+
+  @After(event = DeploymentService.EVENT_UNSUBSCRIBE)
+  void deprovisionObjectStore(UnsubscribeEventContext context) {
+    String tenantId = context.getTenant();
+    try {
+      OSSAttachmentsServiceHandler.validateTenantId(tenantId);
+
+      tenantOSClientProvider.evict(tenantId);
+
+      Optional<String> bindingId = serviceManagerClient.findBindingIdForTenant(tenantId);
+      if (bindingId.isPresent()) {
+        serviceManagerClient.deleteBinding(bindingId.get());
+      } else {
+        logger.warn("No object store binding found for tenant {} during deprovisioning", tenantId);
+      }
+
+      Optional<String> instanceId = serviceManagerClient.findInstanceIdForTenant(tenantId);
+      if (instanceId.isPresent()) {
+        serviceManagerClient.deleteInstance(instanceId.get());
+      } else {
+        logger.warn("No object store instance found for tenant {} during deprovisioning", tenantId);
+      }
+
+      logger.info("Object store deprovisioned for tenant {}", tenantId);
+    } catch (Exception e) {
+      logger.error("Failed to deprovision object store for tenant {}", tenantId, e);
+    }
+  }
+}

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/TenantCleanupHandler.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/handler/TenantCleanupHandler.java
@@ -4,7 +4,6 @@
 package com.sap.cds.feature.attachments.oss.handler;
 
 import com.sap.cds.feature.attachments.oss.client.OSClient;
-import com.sap.cds.feature.attachments.oss.client.TenantOSClientProvider;
 import com.sap.cds.services.handler.EventHandler;
 import com.sap.cds.services.handler.annotations.After;
 import com.sap.cds.services.handler.annotations.ServiceName;
@@ -14,35 +13,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Event handler that cleans up a tenant's attachment resources when the tenant unsubscribes.
+ * Event handler that cleans up a tenant's attachment objects when the tenant unsubscribes in
+ * <b>shared</b> multitenancy mode. Deletes all objects with the tenant's prefix from the shared
+ * object store.
  *
- * <p>In <b>shared</b> multitenancy mode, deletes all objects with the tenant's prefix from the
- * shared object store.
- *
- * <p>In <b>separate</b> multitenancy mode, evicts the cached {@link OSClient} for the tenant. The
- * actual deletion of the object store instance is handled by the MTX sidecar (cap-js/attachments
- * plugin).
+ * <p>For <b>separate</b> multitenancy mode, see {@link ObjectStoreInstanceLifecycleHandler} which
+ * handles instance deprovisioning via Service Manager.
  */
 @ServiceName(DeploymentService.DEFAULT_NAME)
 public class TenantCleanupHandler implements EventHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(TenantCleanupHandler.class);
   private final OSClient osClient;
-  private final TenantOSClientProvider tenantOSClientProvider;
-  private final boolean separateMode;
 
-  /** Creates a handler for shared multitenancy mode (prefix-based cleanup). */
   public TenantCleanupHandler(OSClient osClient) {
     this.osClient = osClient;
-    this.tenantOSClientProvider = null;
-    this.separateMode = false;
-  }
-
-  /** Creates a handler for separate multitenancy mode (cache eviction only). */
-  public TenantCleanupHandler(TenantOSClientProvider tenantOSClientProvider) {
-    this.osClient = null;
-    this.tenantOSClientProvider = tenantOSClientProvider;
-    this.separateMode = true;
   }
 
   @After(event = DeploymentService.EVENT_UNSUBSCRIBE)
@@ -50,14 +35,6 @@ public class TenantCleanupHandler implements EventHandler {
     String tenantId = context.getTenant();
     OSSAttachmentsServiceHandler.validateTenantId(tenantId);
 
-    if (separateMode) {
-      cleanupSeparateMode(tenantId);
-    } else {
-      cleanupSharedMode(tenantId);
-    }
-  }
-
-  private void cleanupSharedMode(String tenantId) {
     String prefix = tenantId + "/";
     try {
       osClient.deleteContentByPrefix(prefix).get();
@@ -68,12 +45,5 @@ public class TenantCleanupHandler implements EventHandler {
     } catch (Exception e) {
       logger.error("Failed to clean up objects for tenant {}", tenantId, e);
     }
-  }
-
-  private void cleanupSeparateMode(String tenantId) {
-    tenantOSClientProvider.evict(tenantId);
-    logger.info(
-        "Evicted cached OSClient for tenant {} (instance cleanup handled by MTX sidecar)",
-        tenantId);
   }
 }

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerClient.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerClient.java
@@ -1,0 +1,367 @@
+/*
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.oss.servicemanager;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Client for SAP Service Manager REST API operations related to object store instance lifecycle.
+ * Used in separate-bucket multitenancy mode to provision and deprovision per-tenant object store
+ * instances.
+ *
+ * <p>Delegates token management and HTTP client to {@link ServiceManagerCredentialResolver}.
+ */
+public class ServiceManagerClient {
+
+  private static final Logger logger = LoggerFactory.getLogger(ServiceManagerClient.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+  private static final long POLL_INTERVAL_MS = 5000;
+  private static final long POLL_TIMEOUT_MS = 5 * 60 * 1000;
+  private static final List<String> SUPPORTED_PLANS = List.of("standard", "s3-standard");
+  private static final String LABEL_QUERY_TEMPLATE =
+      "service eq 'OBJECT_STORE' and tenant_id eq '%s'";
+
+  private final ServiceManagerCredentialResolver credentialResolver;
+
+  public ServiceManagerClient(ServiceManagerCredentialResolver credentialResolver) {
+    this.credentialResolver =
+        requireNonNull(credentialResolver, "credentialResolver must not be null");
+  }
+
+  /**
+   * Checks whether a service binding already exists for the given tenant.
+   *
+   * @param tenantId the tenant ID
+   * @return true if at least one binding exists
+   */
+  public boolean bindingExistsForTenant(String tenantId) {
+    List<Map<String, Object>> items = queryByLabel("/v1/service_bindings", tenantId);
+    return !items.isEmpty();
+  }
+
+  /**
+   * Retrieves the service offering ID for the "objectstore" service.
+   *
+   * @return the offering ID
+   * @throws ServiceManagerException if not found
+   */
+  public String getOfferingId() {
+    String url =
+        credentialResolver.getSmUrl()
+            + "/v1/service_offerings?fieldQuery="
+            + URLEncoder.encode("name eq 'objectstore'", StandardCharsets.UTF_8);
+
+    Map<String, Object> result = executeGet(url);
+    List<Map<String, Object>> items = getItems(result);
+
+    if (items.isEmpty()) {
+      throw new ServiceManagerException(
+          "Object store service offering not found in Service Manager");
+    }
+    return (String) items.get(0).get("id");
+  }
+
+  /**
+   * Retrieves a supported service plan ID for the given offering.
+   *
+   * @param offeringId the service offering ID
+   * @return the plan ID
+   * @throws ServiceManagerException if no supported plan is found
+   */
+  public String getPlanId(String offeringId) {
+    for (String planName : SUPPORTED_PLANS) {
+      String fieldQuery =
+          "service_offering_id eq '%s' and catalog_name eq '%s'".formatted(offeringId, planName);
+      String url =
+          credentialResolver.getSmUrl()
+              + "/v1/service_plans?fieldQuery="
+              + URLEncoder.encode(fieldQuery, StandardCharsets.UTF_8);
+
+      Map<String, Object> result = executeGet(url);
+      List<Map<String, Object>> items = getItems(result);
+
+      if (!items.isEmpty()) {
+        String planId = (String) items.get(0).get("id");
+        logger.debug("Using object store plan '{}' with ID {}", planName, planId);
+        return planId;
+      }
+    }
+    throw new ServiceManagerException(
+        "No supported object store service plan found in Service Manager. Tried: "
+            + SUPPORTED_PLANS);
+  }
+
+  /**
+   * Creates an object store instance for the given tenant and polls until provisioning completes.
+   *
+   * @param tenantId the tenant ID
+   * @param planId the service plan ID
+   * @return the instance ID
+   * @throws ServiceManagerException if creation fails or times out
+   */
+  @SuppressWarnings("unchecked")
+  public String createInstance(String tenantId, String planId) {
+    String instanceName = "object-store-" + tenantId + "-" + UUID.randomUUID();
+    Map<String, Object> body =
+        Map.of(
+            "name",
+            instanceName,
+            "service_plan_id",
+            planId,
+            "parameters",
+            Map.of(),
+            "labels",
+            Map.of("tenant_id", List.of(tenantId), "service", List.of("OBJECT_STORE")));
+
+    logger.info("Creating object store instance '{}' for tenant {}", instanceName, tenantId);
+
+    String url = credentialResolver.getSmUrl() + "/v1/service_instances";
+    Map<String, Object> response = executePost(url, body);
+
+    String instanceId = (String) response.get("id");
+    if (instanceId == null) {
+      throw new ServiceManagerException(
+          "Service Manager did not return an instance ID for tenant " + tenantId);
+    }
+
+    pollUntilDone(instanceId, tenantId);
+    return instanceId;
+  }
+
+  /**
+   * Creates a service binding for the given tenant's object store instance.
+   *
+   * @param tenantId the tenant ID
+   * @param instanceId the instance ID to bind
+   * @return the binding ID
+   */
+  public String createBinding(String tenantId, String instanceId) {
+    String bindingName = "object-store-" + tenantId + "-" + UUID.randomUUID();
+    Map<String, Object> body =
+        Map.of(
+            "name",
+            bindingName,
+            "service_instance_id",
+            instanceId,
+            "parameters",
+            Map.of(),
+            "labels",
+            Map.of("tenant_id", List.of(tenantId), "service", List.of("OBJECT_STORE")));
+
+    logger.info("Creating binding '{}' for tenant {}", bindingName, tenantId);
+
+    String url = credentialResolver.getSmUrl() + "/v1/service_bindings";
+    Map<String, Object> response = executePost(url, body);
+
+    String bindingId = (String) response.get("id");
+    if (bindingId == null) {
+      throw new ServiceManagerException(
+          "Service Manager did not return a binding ID for tenant " + tenantId);
+    }
+    return bindingId;
+  }
+
+  /**
+   * Finds the binding ID for the given tenant, if one exists.
+   *
+   * @param tenantId the tenant ID
+   * @return the binding ID, or empty if none found
+   */
+  public Optional<String> findBindingIdForTenant(String tenantId) {
+    List<Map<String, Object>> items = queryByLabel("/v1/service_bindings", tenantId);
+    if (items.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable((String) items.get(0).get("id"));
+  }
+
+  /**
+   * Deletes the service binding with the given ID.
+   *
+   * @param bindingId the binding ID to delete
+   */
+  public void deleteBinding(String bindingId) {
+    String url = credentialResolver.getSmUrl() + "/v1/service_bindings/" + bindingId;
+    executeDelete(url);
+    logger.info("Deleted service binding {}", bindingId);
+  }
+
+  /**
+   * Finds the instance ID for the given tenant, if one exists.
+   *
+   * @param tenantId the tenant ID
+   * @return the instance ID, or empty if none found
+   */
+  public Optional<String> findInstanceIdForTenant(String tenantId) {
+    List<Map<String, Object>> items = queryByLabel("/v1/service_instances", tenantId);
+    if (items.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable((String) items.get(0).get("id"));
+  }
+
+  /**
+   * Deletes the service instance with the given ID.
+   *
+   * @param instanceId the instance ID to delete
+   */
+  public void deleteInstance(String instanceId) {
+    String url = credentialResolver.getSmUrl() + "/v1/service_instances/" + instanceId;
+    executeDelete(url);
+    logger.info("Deleted service instance {}", instanceId);
+  }
+
+  private void pollUntilDone(String instanceId, String tenantId) {
+    String url =
+        credentialResolver.getSmUrl() + "/v1/service_instances/" + instanceId + "/last_operation";
+    long startTime = System.currentTimeMillis();
+    int iteration = 1;
+
+    while (true) {
+      long waitTime = POLL_INTERVAL_MS * iteration;
+      try {
+        Thread.sleep(waitTime);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new ServiceManagerException(
+            "Interrupted while waiting for object store instance for tenant " + tenantId, e);
+      }
+
+      Map<String, Object> operation = executeGet(url);
+      String state = (String) operation.get("state");
+
+      if ("succeeded".equals(state)) {
+        logger.info("Object store instance provisioned for tenant {}", tenantId);
+        return;
+      }
+
+      if ("failed".equals(state)) {
+        String description = (String) operation.get("description");
+        throw new ServiceManagerException(
+            "Object store instance provisioning failed for tenant %s: %s"
+                .formatted(tenantId, description));
+      }
+
+      if (System.currentTimeMillis() - startTime > POLL_TIMEOUT_MS) {
+        throw new ServiceManagerException(
+            "Timed out waiting for object store instance provisioning for tenant " + tenantId);
+      }
+
+      iteration++;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Map<String, Object>> queryByLabel(String path, String tenantId) {
+    String labelQuery = LABEL_QUERY_TEMPLATE.formatted(tenantId);
+    String url =
+        credentialResolver.getSmUrl()
+            + path
+            + "?labelQuery="
+            + URLEncoder.encode(labelQuery, StandardCharsets.UTF_8);
+
+    Map<String, Object> result = executeGet(url);
+    return getItems(result);
+  }
+
+  private Map<String, Object> executeGet(String url) {
+    String token = credentialResolver.getAccessToken();
+    HttpGet request = new HttpGet(url);
+    request.setHeader("Accept", "application/json");
+    request.setHeader("Authorization", "Bearer " + token);
+
+    try (CloseableHttpResponse response = credentialResolver.getHttpClient().execute(request)) {
+      int statusCode = response.getStatusLine().getStatusCode();
+      String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+      if (statusCode < 200 || statusCode >= 300) {
+        throw new ServiceManagerException(
+            "Service Manager GET %s returned status %d: %s".formatted(url, statusCode, body));
+      }
+      return MAPPER.readValue(body, MAP_TYPE);
+    } catch (ServiceManagerException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ServiceManagerException("Service Manager GET request failed: " + url, e);
+    }
+  }
+
+  private Map<String, Object> executePost(String url, Map<String, Object> requestBody) {
+    String token = credentialResolver.getAccessToken();
+    HttpPost request = new HttpPost(url);
+    request.setHeader("Accept", "application/json");
+    request.setHeader("Content-Type", "application/json");
+    request.setHeader("Authorization", "Bearer " + token);
+
+    try {
+      String jsonBody = MAPPER.writeValueAsString(requestBody);
+      request.setEntity(new StringEntity(jsonBody, StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      throw new ServiceManagerException("Failed to serialize request body", e);
+    }
+
+    try (CloseableHttpResponse response = credentialResolver.getHttpClient().execute(request)) {
+      int statusCode = response.getStatusLine().getStatusCode();
+      String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+      if (statusCode < 200 || statusCode >= 300) {
+        throw new ServiceManagerException(
+            "Service Manager POST %s returned status %d: %s".formatted(url, statusCode, body));
+      }
+      return MAPPER.readValue(body, MAP_TYPE);
+    } catch (ServiceManagerException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ServiceManagerException("Service Manager POST request failed: " + url, e);
+    }
+  }
+
+  private void executeDelete(String url) {
+    String token = credentialResolver.getAccessToken();
+    HttpDelete request = new HttpDelete(url);
+    request.setHeader("Accept", "application/json");
+    request.setHeader("Authorization", "Bearer " + token);
+
+    try (CloseableHttpResponse response = credentialResolver.getHttpClient().execute(request)) {
+      int statusCode = response.getStatusLine().getStatusCode();
+
+      if (statusCode < 200 || statusCode >= 300) {
+        String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+        throw new ServiceManagerException(
+            "Service Manager DELETE %s returned status %d: %s".formatted(url, statusCode, body));
+      }
+    } catch (ServiceManagerException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ServiceManagerException("Service Manager DELETE request failed: " + url, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> getItems(Map<String, Object> response) {
+    Object items = response.get("items");
+    if (items instanceof List<?> list) {
+      return (List<Map<String, Object>>) list;
+    }
+    return List.of();
+  }
+}

--- a/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerCredentialResolver.java
+++ b/storage-targets/cds-feature-attachments-oss/src/main/java/com/sap/cds/feature/attachments/oss/servicemanager/ServiceManagerCredentialResolver.java
@@ -41,11 +41,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Resolves per-tenant object store credentials from the SAP Service Manager. Used in
- * separate-bucket multitenancy mode where each tenant has a dedicated object store instance
- * provisioned by the MTX sidecar (cap-js/attachments plugin).
+ * separate-bucket multitenancy mode where each tenant has a dedicated object store instance.
  *
- * <p>This client only reads tenant bindings; instance lifecycle (subscribe/unsubscribe) is handled
- * by the cap-js sidecar.
+ * <p>Provides token management and HTTP client infrastructure that {@link ServiceManagerClient}
+ * reuses for instance lifecycle operations.
  */
 public class ServiceManagerCredentialResolver {
 
@@ -156,7 +155,7 @@ public class ServiceManagerCredentialResolver {
     }
   }
 
-  private synchronized String getAccessToken() {
+  synchronized String getAccessToken() {
     if (cachedToken != null && Instant.now().isBefore(tokenExpiry)) {
       return cachedToken;
     }
@@ -224,6 +223,14 @@ public class ServiceManagerCredentialResolver {
     } catch (Exception e) {
       throw new ServiceManagerException("Failed to fetch Service Manager access token", e);
     }
+  }
+
+  String getSmUrl() {
+    return smUrl;
+  }
+
+  CloseableHttpClient getHttpClient() {
+    return httpClient;
   }
 
   private CloseableHttpClient buildHttpClient() {


### PR DESCRIPTION
# Service Manager Life Cycle Handling For Object Store Multitenancy

### New Feature

✨ Introduces full Service Manager-based lifecycle handling for per-tenant object store instances in separate-bucket multitenancy mode. Previously, instance provisioning/deprovisioning was delegated to the MTX sidecar (cap-js/attachments plugin). Now, the Java layer directly manages creating and deleting object store instances and bindings via the SAP Service Manager REST API.

### Changes

* `Registration.java`: Replaced the registration of `TenantCleanupHandler` (cache-eviction only) with the new `ObjectStoreInstanceLifecycleHandler` in separate-bucket multitenancy mode. Also adds instantiation of `ServiceManagerClient` and passes it to the lifecycle handler.

* `ObjectStoreInstanceLifecycleHandler.java` *(new)*: A new `DeploymentService` event handler that handles object store provisioning and deprovisioning per tenant. On subscribe, it checks for an existing binding, resolves the offering and plan IDs, creates an instance, and creates a binding. On unsubscribe, it evicts the cached client, deletes the binding, and deletes the instance. All operations are best-effort—errors are logged but don't block tenant lifecycle events.

* `ServiceManagerClient.java` *(new)*: A new REST client for the SAP Service Manager API. Supports the full instance lifecycle: querying offerings and plans, creating/deleting instances (with polling until provisioning completes), and creating/deleting/finding bindings. Uses label-based queries (`tenant_id` + `service eq 'OBJECT_STORE'`) for tenant isolation. Delegates authentication and HTTP infrastructure to `ServiceManagerCredentialResolver`.

* `TenantCleanupHandler.java`: Simplified to only support shared multitenancy mode (prefix-based object deletion on unsubscribe). Removed the separate-mode constructor, fields, and `cleanupSeparateMode` logic. Updated Javadoc to reference `ObjectStoreInstanceLifecycleHandler` for separate mode.

* `ServiceManagerCredentialResolver.java`: Changed visibility of `getAccessToken()`, `getSmUrl()`, and `getHttpClient()` from `private`/none to package-accessible so they can be reused by `ServiceManagerClient`. Updated Javadoc to reflect that instance lifecycle is now handled locally rather than by the cap-js sidecar.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.27`

- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `f6bc1db0-eb49-4e17-96ac-b6ede4fe4696`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
</details>
