### PR TITLE
Add CI environment to relevant jobs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -71,6 +71,7 @@ jobs:
     name: Integration Tests (Java ${{ matrix.java-version }}, ${{ matrix.auth-method }}, ${{ matrix.hyperscaler }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: CI
     strategy:
       fail-fast: false
       matrix:
@@ -101,6 +102,7 @@ jobs:
     name: SonarQube Scan
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: CI
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
# Add CI Environment to Relevant Pipeline Jobs

### Chore

🔧 Added the `CI` environment declaration to the `integration-tests` and `sonarqube-scan` jobs in the GitHub Actions pipeline. This ensures these jobs have access to the appropriate environment-scoped secrets and protection rules configured for the `CI` environment.

### Changes

* `.github/workflows/pipeline.yml`: Added `environment: CI` to the `integration-tests` and `sonarqube-scan` job definitions.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `e68371d5-14d2-475a-ac00-fdc879fad711`
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
