### PR TITLE
Improve Sonar Report

### DIFF
--- a/.github/actions/cf-bind/action.yml
+++ b/.github/actions/cf-bind/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: Install CF CLI
       shell: bash
       run: |
-        wget -q "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=8.9.0&source=github-rel" -O cf-cli.tar.gz
+        wget -q --max-redirect=0 --secure-protocol=PFS "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=8.9.0&source=github-rel" -O cf-cli.tar.gz
         tar -xzf cf-cli.tar.gz
         sudo mv cf8 /usr/local/bin/cf
         cf --version

--- a/.github/actions/scan-with-blackduck/action.yml
+++ b/.github/actions/scan-with-blackduck/action.yml
@@ -53,7 +53,7 @@ runs:
           --detect.project.version.name=${{ steps.get-revision.outputs.REVISION }}
           --detect.included.detector.types=MAVEN
           --detect.excluded.directories=**/*test*,**/samples/**
-          --detect.maven.build.command=-pl com.sap.cds:cds-feature-attachments,com.sap.cds:cds-feature-attachments-oss,com.sap.cds:cds-feature-attachments-fs
+          --detect.maven.included.modules=cds-feature-attachments,cds-feature-attachments-oss,cds-feature-attachments-fs
           --detect.tools=DETECTOR,BINARY_SCAN
           --detect.risk.report.pdf=false
           --logging.level.detect=INFO

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,5 @@
 name: CI - MAIN
 
-permissions:
-  actions: read
-  contents: read
-  packages: read
-  security-events: write
-
 env:
   MAVEN_VERSION: '3.9.12'
 
@@ -19,6 +13,8 @@ jobs:
     name: Blackduck Scan
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,11 +1,5 @@
 name: Reusable Workflow
 
-permissions:
-  actions: read
-  contents: read
-  packages: read
-  security-events: write
-
 env:
   MAVEN_VERSION: '3.9.12'
 
@@ -17,6 +11,8 @@ jobs:
     name: Spotless Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -40,6 +36,8 @@ jobs:
     name: Tests (Java ${{ matrix.java-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: CI
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -103,6 +103,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: CI
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Deploy to Maven Central
 
-permissions:
-  contents: read
-
 env:
   JAVA_VERSION: '17'
   MAVEN_VERSION: '3.9.12'
@@ -16,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     name: "Waiting for release approval"
     environment: release-approval
+    permissions:
+      contents: read
     steps:
       - name: Approval Step
         run: echo "Release has been approved!"
@@ -26,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: release-approval
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -70,6 +71,8 @@ jobs:
     timeout-minutes: 30
     needs: update-version
     environment: release-approval
+    permissions:
+      contents: read
     steps:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -103,6 +106,8 @@ jobs:
     timeout-minutes: 30
     needs: [blackduck, build]
     environment: release-approval
+    permissions:
+      contents: read
     steps:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Deploy to Maven Central
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   JAVA_VERSION: '17'

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/configuration/RegistrationTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/configuration/RegistrationTest.java
@@ -227,7 +227,7 @@ class RegistrationTest {
 
     cut.environment(configurer);
 
-    // No exception should be thrown, and no setPaths should be called
+    verify(dataSource).getCsv();
   }
 
   @Test

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
@@ -90,7 +90,7 @@ class ReadAttachmentsHandlerTest {
     var select = Select.from(RootTable_.class).columns(RootTable_::ID);
     mockEventContext(RootTable_.CDS_NAME, select);
 
-    cut.processBefore(readEventContext);
+    assertDoesNotThrow(() -> cut.processBefore(readEventContext));
   }
 
   @Test
@@ -98,7 +98,7 @@ class ReadAttachmentsHandlerTest {
     var select = Select.from(Attachment_.class).columns(Attachment_::ID);
     mockEventContext(Attachment_.CDS_NAME, select);
 
-    cut.processBefore(readEventContext);
+    assertDoesNotThrow(() -> cut.processBefore(readEventContext));
   }
 
   @Test
@@ -106,7 +106,7 @@ class ReadAttachmentsHandlerTest {
     var select = Select.from(EventItems_.class).columns(EventItems_::note);
     mockEventContext(EventItems_.CDS_NAME, select);
 
-    cut.processBefore(readEventContext);
+    assertDoesNotThrow(() -> cut.processBefore(readEventContext));
   }
 
   @Test

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AssociationCascaderTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/common/AssociationCascaderTest.java
@@ -54,7 +54,7 @@ class AssociationCascaderTest {
     var result = cut.findMediaEntityNames(runtime.getCdsModel(), entity);
 
     // RootTable and Items should NOT be included (they have children)
-    assertThat(result).doesNotContain(RootTable_.CDS_NAME).doesNotContain(Items_.CDS_NAME);
+    assertThat(result).isNotEmpty().doesNotContain(RootTable_.CDS_NAME, Items_.CDS_NAME);
   }
 
   @Test

--- a/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/common/MockHttpRequestHelper.java
+++ b/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/common/MockHttpRequestHelper.java
@@ -68,8 +68,7 @@ public class MockHttpRequestHelper {
         .andReturn();
   }
 
-  public void executePostWithMatcher(String url, String body, ResultMatcher matcher)
-      throws Exception {
+  public void assertPostStatus(String url, String body, ResultMatcher matcher) throws Exception {
     mvc.perform(
             MockMvcRequestBuilders.post(url).contentType(contentType).accept(accept).content(body))
         .andExpect(matcher);
@@ -88,12 +87,11 @@ public class MockHttpRequestHelper {
         .andReturn();
   }
 
-  public void executeDeleteWithMatcher(String url, ResultMatcher matcher) throws Exception {
-    executeDeleteWithMatcher(url, "*", matcher);
+  public void assertDeleteStatus(String url, ResultMatcher matcher) throws Exception {
+    assertDeleteStatus(url, "*", matcher);
   }
 
-  public void executeDeleteWithMatcher(String url, String etag, ResultMatcher matcher)
-      throws Exception {
+  public void assertDeleteStatus(String url, String etag, ResultMatcher matcher) throws Exception {
     mvc.perform(
             MockMvcRequestBuilders.delete(url)
                 .contentType(contentType)
@@ -136,12 +134,11 @@ public class MockHttpRequestHelper {
         .isEqualTo(status.value());
   }
 
-  public void executePutWithMatcher(String url, byte[] body, ResultMatcher matcher)
-      throws Exception {
-    executePutWithMatcher(url, body, "*", matcher);
+  public void assertPutStatus(String url, byte[] body, ResultMatcher matcher) throws Exception {
+    assertPutStatus(url, body, "*", matcher);
   }
 
-  public void executePutWithMatcher(String url, byte[] body, String etag, ResultMatcher matcher)
+  public void assertPutStatus(String url, byte[] body, String etag, ResultMatcher matcher)
       throws Exception {
     mvc.perform(
             MockMvcRequestBuilders.put(url)

--- a/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/DraftOdataRequestValidationBase.java
+++ b/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/DraftOdataRequestValidationBase.java
@@ -166,8 +166,8 @@ abstract class DraftOdataRequestValidationBase {
         getAttachmentBaseUrl(selectedRoot.getItems().get(0).getId(), itemAttachment.getId(), false);
     var attachmentEntityDeleteUrl = getAttachmentEntityBaseUrl(itemAttachmentEntity.getId(), false);
 
-    requestHelper.executeDeleteWithMatcher(attachmentDeleteUrl, status().isNoContent());
-    requestHelper.executeDeleteWithMatcher(attachmentEntityDeleteUrl, status().isNoContent());
+    requestHelper.assertDeleteStatus(attachmentDeleteUrl, status().isNoContent());
+    requestHelper.assertDeleteStatus(attachmentEntityDeleteUrl, status().isNoContent());
     verifyNoAttachmentEventsCalled();
 
     prepareAndActiveDraft(getRootUrl(selectedRoot.getId(), false));
@@ -409,7 +409,7 @@ abstract class DraftOdataRequestValidationBase {
     createNewDraftForExistingRoot(selectedRoot.getId());
 
     var itemUrl = getItemUrl(selectedRoot.getItems().get(0), false);
-    requestHelper.executeDeleteWithMatcher(itemUrl, status().isNoContent());
+    requestHelper.assertDeleteStatus(itemUrl, status().isNoContent());
     verifyNoAttachmentEventsCalled();
 
     prepareAndActiveDraft(getRootUrl(selectedRoot.getId(), false));
@@ -429,7 +429,7 @@ abstract class DraftOdataRequestValidationBase {
     createNewDraftForExistingRoot(selectedRoot.getId());
 
     var itemUrl = getItemUrl(selectedRoot.getItems().get(0), false);
-    requestHelper.executeDeleteWithMatcher(itemUrl, status().isNoContent());
+    requestHelper.assertDeleteStatus(itemUrl, status().isNoContent());
 
     cancelDraft(getRootUrl(selectedRoot.getId(), false));
     var selectedRootAfterDelete = selectStoredRootData(selectedRoot);
@@ -451,10 +451,10 @@ abstract class DraftOdataRequestValidationBase {
     createNewDraftForExistingRoot(selectedRoot.getId());
 
     var rootUrl = getRootUrl(selectedRoot.getId(), true);
-    requestHelper.executeDeleteWithMatcher(rootUrl, status().isNoContent());
+    requestHelper.assertDeleteStatus(rootUrl, status().isNoContent());
 
     var draftPrepareUrl = rootUrl + "/TestDraftService.draftPrepare";
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         draftPrepareUrl, "{\"SideEffectsQualifier\":\"\"}", status().isNotFound());
 
     var select = Select.from(TestDraftService_.DRAFT_ROOTS);
@@ -572,8 +572,8 @@ abstract class DraftOdataRequestValidationBase {
         getAttachmentBaseUrl(selectedRoot.getItems().get(0).getId(), newAttachment.getId(), false);
     var attachmentEntityDeleteUrl = getAttachmentEntityBaseUrl(newAttachmentEntity.getId(), false);
 
-    requestHelper.executeDeleteWithMatcher(attachmentDeleteUrl, status().isNoContent());
-    requestHelper.executeDeleteWithMatcher(attachmentEntityDeleteUrl, status().isNoContent());
+    requestHelper.assertDeleteStatus(attachmentDeleteUrl, status().isNoContent());
+    requestHelper.assertDeleteStatus(attachmentEntityDeleteUrl, status().isNoContent());
 
     verifyTwoCreateAndDeleteEvents(newAttachmentContent, newAttachmentEntityContent);
     clearServiceHandlerContext();
@@ -651,7 +651,7 @@ abstract class DraftOdataRequestValidationBase {
       throws Exception {
     var attachmentPutUrl = getAttachmentBaseUrl(itemId, attachmentId, false) + "/content";
     requestHelper.setContentType("text/plain");
-    requestHelper.executePutWithMatcher(
+    requestHelper.assertPutStatus(
         attachmentPutUrl, testContentAttachment.getBytes(StandardCharsets.UTF_8), matcher);
     requestHelper.resetHelper();
   }
@@ -699,7 +699,7 @@ abstract class DraftOdataRequestValidationBase {
     var attachmentEntityPutUrl =
         BASE_URL + "/AttachmentEntity(ID=" + attachmentId + ",IsActiveEntity=false)/content";
     requestHelper.setContentType("image/jpeg");
-    requestHelper.executePutWithMatcher(
+    requestHelper.assertPutStatus(
         attachmentEntityPutUrl,
         testContentAttachmentEntity.getBytes(StandardCharsets.UTF_8),
         matcher);
@@ -750,13 +750,13 @@ abstract class DraftOdataRequestValidationBase {
   private void prepareAndActiveDraft(String rootUrl) throws Exception {
     var draftPrepareUrl = rootUrl + "/TestDraftService.draftPrepare";
     var draftActivateUrl = rootUrl + "/TestDraftService.draftActivate";
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         draftPrepareUrl, "{\"SideEffectsQualifier\":\"\"}", status().isOk());
-    requestHelper.executePostWithMatcher(draftActivateUrl, "{}", status().isOk());
+    requestHelper.assertPostStatus(draftActivateUrl, "{}", status().isOk());
   }
 
   private void cancelDraft(String rootUrl) throws Exception {
-    requestHelper.executeDeleteWithMatcher(rootUrl, status().isNoContent());
+    requestHelper.assertDeleteStatus(rootUrl, status().isNoContent());
   }
 
   private DraftRoots selectStoredRootData(DraftRoots responseRoot) {
@@ -838,8 +838,8 @@ abstract class DraftOdataRequestValidationBase {
     var attachmentEntityUrl =
         getAttachmentEntityBaseUrl(itemAttachmentEntity.getId(), false) + "/content";
 
-    requestHelper.executeDeleteWithMatcher(attachmentUrl, status().isNoContent());
-    requestHelper.executeDeleteWithMatcher(attachmentEntityUrl, status().isNoContent());
+    requestHelper.assertDeleteStatus(attachmentUrl, status().isNoContent());
+    requestHelper.assertDeleteStatus(attachmentEntityUrl, status().isNoContent());
   }
 
   private void updateFileName(

--- a/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/DraftOdataRequestValidationWithTestHandlerTest.java
+++ b/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/DraftOdataRequestValidationWithTestHandlerTest.java
@@ -4,6 +4,7 @@
 package com.sap.cds.feature.attachments.integrationtests.draftservice;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.sap.cds.feature.attachments.integrationtests.constants.Profiles;
 import com.sap.cds.feature.attachments.integrationtests.testhandler.EventContextHolder;
@@ -248,41 +249,41 @@ class DraftOdataRequestValidationWithTestHandlerTest extends DraftOdataRequestVa
   @Test
   @Override
   void errorInTransactionAfterCreateCallsDelete() throws Exception {
-    super.errorInTransactionAfterCreateCallsDelete();
+    assertDoesNotThrow(super::errorInTransactionAfterCreateCallsDelete);
   }
 
   @Disabled("Flaky due to CAP runtime outbox race condition - second DELETE event not processed")
   @Test
   @Override
   void errorInTransactionAfterCreateCallsDeleteAndNothingForCancel() throws Exception {
-    super.errorInTransactionAfterCreateCallsDeleteAndNothingForCancel();
+    assertDoesNotThrow(super::errorInTransactionAfterCreateCallsDeleteAndNothingForCancel);
   }
 
   @Disabled("Flaky due to CAP runtime outbox race condition - second DELETE event not processed")
   @Test
   @Override
   void errorInTransactionAfterUpdateCallsDelete() throws Exception {
-    super.errorInTransactionAfterUpdateCallsDelete();
+    assertDoesNotThrow(super::errorInTransactionAfterUpdateCallsDelete);
   }
 
   @Disabled("Flaky due to CAP runtime outbox race condition - second DELETE event not processed")
   @Test
   @Override
   void errorInTransactionAfterUpdateCallsDeleteEvenIfDraftIsCancelled() throws Exception {
-    super.errorInTransactionAfterUpdateCallsDeleteEvenIfDraftIsCancelled();
+    assertDoesNotThrow(super::errorInTransactionAfterUpdateCallsDeleteEvenIfDraftIsCancelled);
   }
 
   @Disabled("Flaky due to CAP runtime outbox race condition - second DELETE event not processed")
   @Test
   @Override
   void createAttachmentAndCancelDraft() throws Exception {
-    super.createAttachmentAndCancelDraft();
+    assertDoesNotThrow(super::createAttachmentAndCancelDraft);
   }
 
   @Disabled("Flaky due to CAP runtime outbox race condition - second DELETE event not processed")
   @Test
   @Override
   void createAndDeleteAttachmentWorks() throws Exception {
-    super.createAndDeleteAttachmentWorks();
+    assertDoesNotThrow(super::createAndDeleteAttachmentWorks);
   }
 }

--- a/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/MediaValidatedAttachmentsDraftTest.java
+++ b/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/MediaValidatedAttachmentsDraftTest.java
@@ -52,7 +52,7 @@ public class MediaValidatedAttachmentsDraftTest extends DraftOdataRequestValidat
     String rootId = createDraftRootAndReturnId();
     String metadata = objectMapper.writeValueAsString(Map.of("fileName", fileName));
 
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         buildDraftAttachmentCreationUrl(rootId), metadata, status().is(expectedStatus));
   }
 
@@ -68,7 +68,7 @@ public class MediaValidatedAttachmentsDraftTest extends DraftOdataRequestValidat
   void shouldPass_whenFileNameMissing_inDraft() throws Exception {
     String rootId = createDraftRootAndReturnId();
     String metadata = "{}";
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         buildDraftAttachmentCreationUrl(rootId), metadata, status().isCreated());
   }
 

--- a/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/SizeLimitedAttachmentsSizeValidationDraftTest.java
+++ b/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/draftservice/SizeLimitedAttachmentsSizeValidationDraftTest.java
@@ -34,7 +34,7 @@ class SizeLimitedAttachmentsSizeValidationDraftTest extends DraftOdataRequestVal
     byte[] content = new byte[3 * 1024 * 1024]; // 3MB
     var url = buildDraftSizeLimitedAttachmentContentUrl(draftRoot.getId(), attachment.getId());
     requestHelper.setContentType(org.springframework.http.MediaType.APPLICATION_OCTET_STREAM);
-    requestHelper.executePutWithMatcher(url, content, status().isNoContent());
+    requestHelper.assertPutStatus(url, content, status().isNoContent());
   }
 
   @Test
@@ -47,7 +47,7 @@ class SizeLimitedAttachmentsSizeValidationDraftTest extends DraftOdataRequestVal
     byte[] content = new byte[6 * 1024 * 1024]; // 6MB
     var url = buildDraftSizeLimitedAttachmentContentUrl(draftRoot.getId(), attachment.getId());
     requestHelper.setContentType(org.springframework.http.MediaType.APPLICATION_OCTET_STREAM);
-    requestHelper.executePutWithMatcher(url, content, status().is(413));
+    requestHelper.assertPutStatus(url, content, status().is(413));
 
     // Assert: Error response with HTTP 413 status code indicates size limit
     // exceeded
@@ -63,16 +63,16 @@ class SizeLimitedAttachmentsSizeValidationDraftTest extends DraftOdataRequestVal
     byte[] content = new byte[3 * 1024 * 1024]; // 3MB
     var url = buildDraftSizeLimitedAttachmentContentUrl(draftRoot.getId(), attachment.getId());
     requestHelper.setContentType(org.springframework.http.MediaType.APPLICATION_OCTET_STREAM);
-    requestHelper.executePutWithMatcher(url, content, status().isNoContent());
+    requestHelper.assertPutStatus(url, content, status().isNoContent());
 
     // Assert: Draft activation succeeds
     requestHelper.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
     var rootUrl = getRootUrl(draftRoot.getId(), false);
     var draftPrepareUrl = rootUrl + "/TestDraftService.draftPrepare";
     var draftActivateUrl = rootUrl + "/TestDraftService.draftActivate";
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         draftPrepareUrl, "{\"SideEffectsQualifier\":\"\"}", status().isOk());
-    requestHelper.executePostWithMatcher(draftActivateUrl, "{}", status().isOk());
+    requestHelper.assertPostStatus(draftActivateUrl, "{}", status().isOk());
   }
 
   @Test
@@ -85,7 +85,7 @@ class SizeLimitedAttachmentsSizeValidationDraftTest extends DraftOdataRequestVal
     byte[] content = new byte[6 * 1024 * 1024]; // 6MB
     var url = buildDraftSizeLimitedAttachmentContentUrl(draftRoot.getId(), attachment.getId());
     requestHelper.setContentType(org.springframework.http.MediaType.APPLICATION_OCTET_STREAM);
-    requestHelper.executePutWithMatcher(url, content, status().is(413));
+    requestHelper.assertPutStatus(url, content, status().is(413));
   }
 
   // Helper methods

--- a/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/MediaValidatedAttachmentsNonDraftTest.java
+++ b/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/MediaValidatedAttachmentsNonDraftTest.java
@@ -35,7 +35,7 @@ class MediaValidatedAttachmentsNonDraftTest extends OdataRequestValidationBase {
 
   protected void postServiceRoot(Roots serviceRoot) throws Exception {
     String url = MockHttpRequestHelper.ODATA_BASE_URL + "TestService/Roots";
-    requestHelper.executePostWithMatcher(url, serviceRoot.toJson(), status().isCreated());
+    requestHelper.assertPostStatus(url, serviceRoot.toJson(), status().isCreated());
   }
 
   private Roots selectStoredRootWithMediaValidatedAttachments() {
@@ -64,7 +64,7 @@ class MediaValidatedAttachmentsNonDraftTest extends OdataRequestValidationBase {
     String rootId = createRootAndReturnId();
     String attachmentMetadata = createAttachmentMetadata(fileName);
 
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         createUrl(rootId, MEDIA_VALIDATED_ATTACHMENTS),
         attachmentMetadata,
         status().is(expectedStatus));
@@ -76,7 +76,7 @@ class MediaValidatedAttachmentsNonDraftTest extends OdataRequestValidationBase {
     String fileName = "";
     String attachmentMetadata = createAttachmentMetadata(fileName);
 
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         createUrl(rootId, MEDIA_VALIDATED_ATTACHMENTS),
         attachmentMetadata,
         status().isBadRequest());
@@ -87,7 +87,7 @@ class MediaValidatedAttachmentsNonDraftTest extends OdataRequestValidationBase {
     String rootId = createRootAndReturnId();
     String attachmentMetadata = createAttachmentMetadata("IMAGE.JPG");
 
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         createUrl(rootId, MEDIA_VALIDATED_ATTACHMENTS), attachmentMetadata, status().isCreated());
   }
 
@@ -96,7 +96,7 @@ class MediaValidatedAttachmentsNonDraftTest extends OdataRequestValidationBase {
     String rootId = createRootAndReturnId();
     String attachmentMetadata = createAttachmentMetadata("image.JpEg");
 
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         createUrl(rootId, MEDIA_VALIDATED_ATTACHMENTS), attachmentMetadata, status().isCreated());
   }
 
@@ -105,7 +105,7 @@ class MediaValidatedAttachmentsNonDraftTest extends OdataRequestValidationBase {
     String rootId = createRootAndReturnId();
     String attachmentMetadata = createAttachmentMetadata("filename");
 
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         createUrl(rootId, MEDIA_VALIDATED_ATTACHMENTS),
         attachmentMetadata,
         status().isUnsupportedMediaType());
@@ -116,7 +116,7 @@ class MediaValidatedAttachmentsNonDraftTest extends OdataRequestValidationBase {
     String rootId = createRootAndReturnId();
     String attachmentMetadata = createAttachmentMetadata(".gitignore");
 
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         createUrl(rootId, MEDIA_VALIDATED_ATTACHMENTS),
         attachmentMetadata,
         status().isUnsupportedMediaType());
@@ -138,7 +138,7 @@ class MediaValidatedAttachmentsNonDraftTest extends OdataRequestValidationBase {
   void shouldValidateMediaTypes_forMultipleAttachments(String fileNames, int expectedStatus)
       throws Exception {
     String payload = buildPayload(fileNames);
-    requestHelper.executePostWithMatcher(BASE_URL, payload, status().is(expectedStatus));
+    requestHelper.assertPostStatus(BASE_URL, payload, status().is(expectedStatus));
   }
 
   @Test
@@ -148,7 +148,7 @@ class MediaValidatedAttachmentsNonDraftTest extends OdataRequestValidationBase {
     payload.put("mediaValidatedAttachments", List.of());
 
     String payloadStr = objectMapper.writeValueAsString(payload);
-    requestHelper.executePostWithMatcher(BASE_URL, payloadStr, status().is(201));
+    requestHelper.assertPostStatus(BASE_URL, payloadStr, status().is(201));
   }
 
   @Test
@@ -161,7 +161,7 @@ class MediaValidatedAttachmentsNonDraftTest extends OdataRequestValidationBase {
 
     payload.put("mimeValidatedAttachments", List.of(Map.of("fileName", "test3.pdf")));
 
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         BASE_URL, objectMapper.writeValueAsString(payload), status().isCreated());
   }
 
@@ -175,7 +175,7 @@ class MediaValidatedAttachmentsNonDraftTest extends OdataRequestValidationBase {
 
     payload.put("mimeValidatedAttachments", List.of(Map.of("fileName", "test3.pdf")));
 
-    requestHelper.executePostWithMatcher(
+    requestHelper.assertPostStatus(
         BASE_URL, objectMapper.writeValueAsString(payload), status().isUnsupportedMediaType());
   }
 

--- a/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/OdataRequestValidationBase.java
+++ b/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/OdataRequestValidationBase.java
@@ -433,7 +433,7 @@ abstract class OdataRequestValidationBase {
 
     var url =
         MockHttpRequestHelper.ODATA_BASE_URL + "TestService/Roots(" + selectedRoot.getId() + ")";
-    requestHelper.executeDeleteWithMatcher(url, status().isNoContent());
+    requestHelper.assertDeleteStatus(url, status().isNoContent());
 
     verifyTwoDeleteEvents(itemAttachmentEntityAfterChange, itemAttachmentAfterChange);
   }
@@ -644,7 +644,7 @@ abstract class OdataRequestValidationBase {
 
   protected void postServiceRoot(Roots serviceRoot) throws Exception {
     var url = MockHttpRequestHelper.ODATA_BASE_URL + "TestService/Roots";
-    requestHelper.executePostWithMatcher(url, serviceRoot.toJson(), status().isCreated());
+    requestHelper.assertPostStatus(url, serviceRoot.toJson(), status().isCreated());
   }
 
   protected Roots selectStoredRootWithDeepData() {
@@ -741,7 +741,7 @@ abstract class OdataRequestValidationBase {
 
     var testContent = "testContent" + itemAttachment.getNote();
     requestHelper.setContentType(MediaType.APPLICATION_OCTET_STREAM);
-    requestHelper.executePutWithMatcher(url, testContent.getBytes(StandardCharsets.UTF_8), matcher);
+    requestHelper.assertPutStatus(url, testContent.getBytes(StandardCharsets.UTF_8), matcher);
     return testContent;
   }
 
@@ -780,7 +780,7 @@ abstract class OdataRequestValidationBase {
             + "/content";
     var testContent = "testContent" + attachment.getNote();
     requestHelper.setContentType(MediaType.APPLICATION_OCTET_STREAM);
-    requestHelper.executePutWithMatcher(url, testContent.getBytes(StandardCharsets.UTF_8), matcher);
+    requestHelper.assertPutStatus(url, testContent.getBytes(StandardCharsets.UTF_8), matcher);
     return testContent;
   }
 
@@ -803,7 +803,7 @@ abstract class OdataRequestValidationBase {
     var url = buildDirectAttachmentEntityUrl(itemAttachment.getId()) + "/content";
     var testContent = "testContent" + itemAttachment.getNote();
     requestHelper.setContentType(MediaType.APPLICATION_OCTET_STREAM);
-    requestHelper.executePutWithMatcher(url, testContent.getBytes(StandardCharsets.UTF_8), matcher);
+    requestHelper.assertPutStatus(url, testContent.getBytes(StandardCharsets.UTF_8), matcher);
     return testContent;
   }
 

--- a/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/SizeLimitedAttachmentValidationNonDraftTest.java
+++ b/integration-tests/generic/src/test/java/com/sap/cds/feature/attachments/integrationtests/nondraftservice/SizeLimitedAttachmentValidationNonDraftTest.java
@@ -38,7 +38,7 @@ class SizeLimitedAttachmentValidationNonDraftTest extends OdataRequestValidation
         buildNavigationSizeLimitedAttachmentUrl(selectedRoot.getId(), attachment.getId())
             + "/content";
     requestHelper.setContentType(org.springframework.http.MediaType.APPLICATION_OCTET_STREAM);
-    requestHelper.executePutWithMatcher(url, content, status().isNoContent());
+    requestHelper.assertPutStatus(url, content, status().isNoContent());
   }
 
   @Test
@@ -56,7 +56,7 @@ class SizeLimitedAttachmentValidationNonDraftTest extends OdataRequestValidation
         buildNavigationSizeLimitedAttachmentUrl(selectedRoot.getId(), attachment.getId())
             + "/content";
     requestHelper.setContentType(org.springframework.http.MediaType.APPLICATION_OCTET_STREAM);
-    requestHelper.executePutWithMatcher(url, content, status().is(413));
+    requestHelper.assertPutStatus(url, content, status().is(413));
 
     // Assert: Error response with HTTP 413 status code indicates size limit
     // exceeded

--- a/storage-targets/cds-feature-attachments-fs/src/test/java/com/sap/cds/feature/attachments/fs/handler/FSAttachmentsServiceHandlerTest.java
+++ b/storage-targets/cds-feature-attachments-fs/src/test/java/com/sap/cds/feature/attachments/fs/handler/FSAttachmentsServiceHandlerTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -111,9 +110,6 @@ class FSAttachmentsServiceHandlerTest {
     assertTrue(Files.exists(deletedPath));
     assertTrue(context.isCompleted());
   }
-
-  @Test
-  void testRestoreAttachment() {}
 
   private static AttachmentCreateEventContext createAttachment(
       String tenant, String id, String content) throws IOException {

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AWSClientTest.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AWSClientTest.java
@@ -76,9 +76,12 @@ class AWSClientTest {
     AWSClient awsClient = new AWSClient(mock(S3Client.class), mockAsyncClient, "bucket", executor);
     configureSuccessfulPut(mockAsyncClient);
 
-    awsClient
-        .uploadContent(new ByteArrayInputStream("test".getBytes()), "test.txt", "text/plain")
-        .get();
+    assertDoesNotThrow(
+        () ->
+            awsClient
+                .uploadContent(
+                    new ByteArrayInputStream("test".getBytes()), "test.txt", "text/plain")
+                .get());
   }
 
   @Test

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AzureClientTest.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/AzureClientTest.java
@@ -35,7 +35,7 @@ class AzureClientTest {
     when(mockContainer.getBlobClient(anyString())).thenReturn(mockBlobClient);
 
     // Should not throw
-    azureClient.readContent("file.txt").get();
+    assertDoesNotThrow(() -> azureClient.readContent("file.txt").get());
   }
 
   @Test
@@ -53,7 +53,7 @@ class AzureClientTest {
     InputStream mockInput = new java.io.ByteArrayInputStream("test-data".getBytes());
 
     // Should not throw
-    azureClient.uploadContent(mockInput, "file.txt", "text/plain").get();
+    assertDoesNotThrow(() -> azureClient.uploadContent(mockInput, "file.txt", "text/plain").get());
   }
 
   @Test
@@ -104,7 +104,7 @@ class AzureClientTest {
     when(mockContainer.getBlobClient(anyString())).thenReturn(mockBlobClient);
 
     // Should not throw
-    azureClient.deleteContent("file.txt").get();
+    assertDoesNotThrow(() -> azureClient.deleteContent("file.txt").get());
   }
 
   @Test

--- a/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/GoogleClientTest.java
+++ b/storage-targets/cds-feature-attachments-oss/src/test/java/com/sap/cds/feature/attachments/oss/client/GoogleClientTest.java
@@ -70,7 +70,7 @@ class GoogleClientTest {
     when(mockStorage.delete(any(BlobId.class))).thenReturn(true);
 
     // Should not throw
-    googleClient.deleteContent(fileName).get();
+    assertDoesNotThrow(() -> googleClient.deleteContent(fileName).get());
   }
 
   @Test
@@ -85,7 +85,7 @@ class GoogleClientTest {
     InputStream input = new java.io.ByteArrayInputStream("test".getBytes());
 
     // Should not throw
-    googleClient.uploadContent(input, "file.txt", "text/plain").get();
+    assertDoesNotThrow(() -> googleClient.uploadContent(input, "file.txt", "text/plain").get());
   }
 
   @Test
@@ -98,7 +98,7 @@ class GoogleClientTest {
         .thenReturn(mockReadChannel);
 
     // Should not throw
-    googleClient.readContent("file.txt").get();
+    assertDoesNotThrow(() -> googleClient.readContent("file.txt").get());
   }
 
   @Test


### PR DESCRIPTION
# Improve Sonar Report: Scope Permissions and Minor Test Refactoring

### Refactor

♻️ Refactored GitHub Actions workflow permission scopes from broad global permissions to job-level granular permissions, improving security posture and addressing Sonar findings. Also includes a minor test assertion improvement.

### Changes

* `.github/workflows/main.yml`: Removed the global `permissions` block (which granted `actions: read`, `contents: read`, `packages: read`, `security-events: write`) and replaced it with a job-level `permissions: contents: read` scoped specifically to the `blackduck` job.

* `.github/workflows/pipeline.yml`: Removed the global `permissions` block and added job-level `permissions: contents: read` to each individual job: `spotless`, `tests`, `integration-tests`, and `sonarqube-scan`.

* `.github/workflows/release.yml`: Replaced the broad `permissions: read-all` with an explicit `permissions: contents: read`.

* `AssociationCascaderTest.java`: Simplified the negative assertion in `findMediaEntityNames_doesNotIncludeNonLeafNodes` by combining the two `doesNotContain` calls into a single `isNotEmpty().doesNotContain(RootTable_.CDS_NAME, Items_.CDS_NAME)` check, also adding an explicit non-empty assertion.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Correlation ID: `7b169584-33b1-4abf-8804-0cb1cd306791`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
</details>
