### PR TITLE
bugfix: malformed workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,4 +29,9 @@ jobs:
 
   build-and-test:
     uses: cap-java/cds-feature-attachments/.github/workflows/pipeline.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+      packages: read
     secrets: inherit


### PR DESCRIPTION
# Fix: Add Missing Permissions to `build-and-test` Job in Workflow

### Bug Fix

🐛 Fixed a malformed GitHub Actions workflow by adding the missing `permissions` block to the `build-and-test` job.

### Changes

* `.github/workflows/main.yml`: Added the required `permissions` block to the `build-and-test` job, granting `contents: read`, `security-events: write`, `actions: read`, and `packages: read` permissions. Previously, these permissions were only defined for another job, leaving `build-and-test` without the necessary access rights.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Correlation ID: `f0dbc15d-2ed3-4df7-9c52-6037d1807baf`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
