### PR TITLE
fix: allow wget redirect for CF CLI download

### DIFF
--- a/.github/actions/cf-bind/action.yml
+++ b/.github/actions/cf-bind/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: Install CF CLI
       shell: bash
       run: |
-        wget -q --max-redirect=0 --secure-protocol=PFS "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=8.9.0&source=github-rel" -O cf-cli.tar.gz
+        wget -q "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=8.9.0&source=github-rel" -O cf-cli.tar.gz
         tar -xzf cf-cli.tar.gz
         sudo mv cf8 /usr/local/bin/cf
         cf --version

--- a/.github/actions/cf-bind/action.yml
+++ b/.github/actions/cf-bind/action.yml
@@ -26,8 +26,10 @@ runs:
   steps:
     - name: Install CF CLI
       shell: bash
+      env:
+        CF_CLI_VERSION: '8.18.3'
       run: |
-        wget -q "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=8.9.0&source=github-rel" -O cf-cli.tar.gz
+        wget -q "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}&source=github-rel" -O cf-cli.tar.gz
         tar -xzf cf-cli.tar.gz
         sudo mv cf8 /usr/local/bin/cf
         cf --version


### PR DESCRIPTION
# Fix: Allow wget Redirect for CF CLI Download

### Bug Fix

🐛 Resolved an issue where the CF CLI download was failing due to overly restrictive `wget` flags that prevented HTTP redirects.

### Changes

* `.github/actions/cf-bind/action.yml`: Removed the `--max-redirect=0` and `--secure-protocol=PFS` flags from the `wget` command used to download the CF CLI binary. The `--max-redirect=0` flag was blocking redirects required by the CloudFoundry package server, causing the download to fail.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Correlation ID: `65cb13c5-5aa2-4086-9c96-0f3e7ea570d1`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
