### PR TITLE
Remove CI environment and use only release environment

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -69,7 +69,6 @@ jobs:
     name: Integration Tests (Java ${{ matrix.java-version }}, ${{ matrix.auth-method }}, ${{ matrix.hyperscaler }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: CI
     permissions:
       contents: read
     strategy:
@@ -102,7 +101,6 @@ jobs:
     name: SonarQube Scan
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: CI
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
     name: Blackduck Scan
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: release
     permissions:
       contents: read
     steps:
@@ -70,7 +69,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: update-version
-    environment: release
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
# Remove CI and Redundant Release Environment References from Workflows

### Chore

🔧 Removed unnecessary `environment` declarations from GitHub Actions workflow files to simplify the CI/CD pipeline configuration.

### Changes

* `.github/workflows/pipeline.yml`: Removed `environment: CI` from both the `integration-tests` and `sonarqube-scan` jobs, eliminating the dependency on the CI environment for these steps.
* `.github/workflows/release.yml`: Removed `environment: release` from both the `blackduck` and `build` jobs, as these jobs already inherit context through the release approval gate (`requires-approval` job with `environment: release-approval`).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- File Content Strategy: Full file content
- Correlation ID: `7a19a55f-3d0b-4e45-a78b-5e5f9e96e7e5`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
