### PR TITLE
bugfix: broken release pipeline

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -24,6 +24,10 @@ runs:
       with:
         maven-version: ${{ inputs.maven-version }}
 
+    - name: Install @sap/cds-dk
+      run: npm i -g @sap/cds-dk@9.9.1
+      shell: bash
+
     - name: Maven Build
       run: mvn clean install -DskipTests -B -ntp
       shell: bash

--- a/.github/actions/scan-with-blackduck/action.yml
+++ b/.github/actions/scan-with-blackduck/action.yml
@@ -15,6 +15,9 @@ inputs:
   maven-version:
     description: The Maven version the build shall run with.
     required: true
+  version:
+    description: The project version to report to Black Duck (e.g. release tag).
+    required: true
   scan_mode:
     description: The scan mode to use (FULL or RAPID)
     default: 'FULL'
@@ -35,12 +38,6 @@ runs:
       with:
         maven-version: ${{ inputs.maven-version }}
 
-    - name: Get Revision
-      id: get-revision
-      run: |
-        echo "REVISION=$(mvn help:evaluate -Dexpression=revision -q -DforceStdout)" >> $GITHUB_OUTPUT
-      shell: bash
-
     - name: BlackDuck Security Scan
       uses: blackduck-inc/black-duck-security-scan@659a0742e793a093377fab3117b0d90f23b04bfa # v2.9.0
       with:
@@ -50,7 +47,8 @@ runs:
         github_token: ${{ inputs.github_token }}
         detect_args: >
           --detect.project.name=com.sap.cds.feature.attachments
-          --detect.project.version.name=${{ steps.get-revision.outputs.REVISION }}
+          --detect.project.version.name=${{ inputs.version }}
+          --detect.project.group.name=CDSJAVA-OPEN-SOURCE
           --detect.included.detector.types=MAVEN
           --detect.excluded.directories=**/*test*,**/samples/**
           --detect.maven.included.modules=cds-feature-attachments,cds-feature-attachments-oss,cds-feature-attachments-fs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           blackduck_token: ${{ secrets.BLACK_DUCK_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           maven-version: ${{ env.MAVEN_VERSION }}
+          version: ${{ github.event.release.tag_name }}
 
   update-version:
     needs: requires-approval


### PR DESCRIPTION
# Fix Broken Release Pipeline

🐛 **Bug Fix:** Resolved issues in the release pipeline related to BlackDuck scanning and the build process.

### Changes

* `.github/actions/build/action.yml`: Added a step to install `@sap/cds-dk@9.9.1` globally via npm before the Maven build step.

* `.github/actions/scan-with-blackduck/action.yml`:
  - Added a new `version` input parameter to accept the project version externally (e.g., a release tag), replacing the previously inline `Get Revision` step that derived the version from Maven.
  - Removed the `Get Revision` step that used `mvn help:evaluate` to extract the revision.
  - Updated `--detect.project.version.name` to use `${{ inputs.version }}` instead of the now-removed step output.
  - Added `--detect.project.group.name=CDSJAVA-OPEN-SOURCE` to the BlackDuck detect arguments.

* `.github/workflows/release.yml`: Passes `${{ github.event.release.tag_name }}` as the `version` input to the `scan-with-blackduck` action, ensuring the release tag is used as the BlackDuck project version.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `73c79ced-02c3-45cb-8c6b-57b8f39aa2a1`
</details>
