### PR TITLE
Bugfix/broken pipeline v2

### DIFF
--- a/.github/actions/scan-with-blackduck/action.yml
+++ b/.github/actions/scan-with-blackduck/action.yml
@@ -16,10 +16,11 @@ inputs:
     description: The Maven version the build shall run with.
     required: true
   version:
-    description: The project version to report to Black Duck (e.g. release tag).
-    required: true
+    description: The project version to report to Black Duck (e.g. release tag). If empty, falls back to the Maven `revision` reduced to major-minor.
+    required: false
+    default: ''
   scan_mode:
-    description: The scan mode to use (FULL or RAPID)
+    description: The scan mode to use (FULL uploads a report to the Black Duck server; RAPID is a fast policy gate without server upload).
     default: 'FULL'
     required: false
 
@@ -38,8 +39,17 @@ runs:
       with:
         maven-version: ${{ inputs.maven-version }}
 
-    - name: Install @sap/cds-dk
-      run: npm i -g @sap/cds-dk@9.9.1
+    - name: Resolve Project Version
+      id: resolve-version
+      run: |
+        if [ -n "${{ inputs.version }}" ]; then
+          VERSION="${{ inputs.version }}"
+        else
+          REVISION=$(mvn help:evaluate -Dexpression=revision -q -DforceStdout)
+          VERSION=$(echo "$REVISION" | cut -d. -f1,2)
+        fi
+        echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "Resolved BlackDuck project version: $VERSION"
       shell: bash
 
     - name: BlackDuck Security Scan
@@ -51,11 +61,15 @@ runs:
         github_token: ${{ inputs.github_token }}
         detect_args: >
           --detect.project.name=com.sap.cds.feature.attachments
-          --detect.project.version.name=${{ inputs.version }}
+          --detect.project.version.name=${{ steps.resolve-version.outputs.VERSION }}
           --detect.project.group.name=CDSJAVA-OPEN-SOURCE
           --detect.included.detector.types=MAVEN
           --detect.excluded.directories=**/*test*,**/samples/**
           --detect.maven.included.modules=cds-feature-attachments,cds-feature-attachments-oss,cds-feature-attachments-fs
+          --detect.maven.excluded.scopes=test,provided
           --detect.tools=DETECTOR,BINARY_SCAN
+          --detect.timeout=6000
           --detect.risk.report.pdf=false
+          --blackduck.signature.scanner.memory=4096
+          --blackduck.trust.cert=true
           --logging.level.detect=INFO

--- a/.github/actions/scan-with-blackduck/action.yml
+++ b/.github/actions/scan-with-blackduck/action.yml
@@ -38,6 +38,10 @@ runs:
       with:
         maven-version: ${{ inputs.maven-version }}
 
+    - name: Install @sap/cds-dk
+      run: npm i -g @sap/cds-dk@9.9.1
+      shell: bash
+
     - name: BlackDuck Security Scan
       uses: blackduck-inc/black-duck-security-scan@659a0742e793a093377fab3117b0d90f23b04bfa # v2.9.0
       with:


### PR DESCRIPTION
# Fix BlackDuck Pipeline: Optional Version Input & Scan Improvements

### Bug Fix

🐛 Resolves a broken BlackDuck security scan pipeline by making the `version` input optional and adding automatic version resolution from Maven, along with several scan stability improvements.

### Changes

* `.github/actions/scan-with-blackduck/action.yml`:
  - Made the `version` input **optional** (previously required), defaulting to an empty string. When not provided, the version is automatically resolved from the Maven `revision` property, reduced to `major.minor` format.
  - Added a new **"Resolve Project Version"** step that handles the fallback logic using `mvn help:evaluate`.
  - Updated `--detect.project.version.name` to use the dynamically resolved version from the new step.
  - Added `--detect.maven.excluded.scopes=test,provided` to exclude test and provided dependencies from scanning.
  - Added `--detect.timeout=6000` to prevent scan timeouts.
  - Added `--blackduck.signature.scanner.memory=4096` to allocate more memory for the signature scanner.
  - Added `--blackduck.trust.cert=true` to handle certificate trust issues.
  - Improved `scan_mode` input description for clarity (FULL vs. RAPID behavior).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `ef4811c8-73c2-41fe-b660-155b125ab0b4`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
