### PR TITLE
fix: avoid script injection in scan-with-blackduck action

### DIFF
--- a/.github/actions/scan-with-blackduck/action.yml
+++ b/.github/actions/scan-with-blackduck/action.yml
@@ -41,9 +41,11 @@ runs:
 
     - name: Resolve Project Version
       id: resolve-version
+      env:
+        VERSION_INPUT: ${{ inputs.version }}
       run: |
-        if [ -n "${{ inputs.version }}" ]; then
-          VERSION="${{ inputs.version }}"
+        if [ -n "$VERSION_INPUT" ]; then
+          VERSION="$VERSION_INPUT"
         else
           REVISION=$(mvn help:evaluate -Dexpression=revision -q -DforceStdout)
           VERSION=$(echo "$REVISION" | cut -d. -f1,2)


### PR DESCRIPTION
## Summary
- SonarQube flagged `inputs.version` being interpolated directly into a `run:` block.
- Bind it to an `env:` var and reference as a quoted shell variable instead.

## Test plan
- [ ] SonarQube no longer flags this finding.