### PR TITLE
fix: install @sap/cds-dk in deploy-release action

### DIFF
--- a/.github/actions/deploy-release/action.yml
+++ b/.github/actions/deploy-release/action.yml
@@ -42,6 +42,10 @@ runs:
       with:
         maven-version: ${{ inputs.maven-version }}
 
+    - name: Install @sap/cds-dk
+      run: npm i -g @sap/cds-dk@9.9.1
+      shell: bash
+
     - name: Import GPG Key
       run: |
         echo "${{ inputs.pgp-private-key }}" | gpg --batch --passphrase "$PASSPHRASE" --import
@@ -54,6 +58,7 @@ runs:
         mvn -B -ntp --show-version
         -Dmaven.install.skip=true
         -Dmaven.test.skip=true
+        -Dcds.install-node.skip
         -Dgpg.passphrase="$GPG_PASSPHRASE"
         -Dgpg.keyname="$GPG_PUB_KEY"
         clean deploy -P deploy-release

--- a/.github/actions/scan-with-blackduck/action.yml
+++ b/.github/actions/scan-with-blackduck/action.yml
@@ -41,9 +41,11 @@ runs:
 
     - name: Resolve Project Version
       id: resolve-version
+      env:
+        VERSION_INPUT: ${{ inputs.version }}
       run: |
-        if [ -n "${{ inputs.version }}" ]; then
-          VERSION="${{ inputs.version }}"
+        if [ -n "$VERSION_INPUT" ]; then
+          VERSION="$VERSION_INPUT"
         else
           REVISION=$(mvn help:evaluate -Dexpression=revision -q -DforceStdout)
           VERSION=$(echo "$REVISION" | cut -d. -f1,2)


### PR DESCRIPTION
## Summary
- Release pipeline failed with `CdsMojo: sh: 1: cds: not found` because `deploy-release` action ran `mvn clean deploy` without `@sap/cds-dk` on PATH
- Mirror the `build` action: install `@sap/cds-dk@9.9.1` globally and pass `-Dcds.install-node.skip`

## Test plan
- [ ] Re-run the release workflow and confirm `cds.build` goal succeeds