### PR TITLE
Fix blackduck

### DIFF
--- a/.github/actions/scan-with-blackduck/action.yml
+++ b/.github/actions/scan-with-blackduck/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: The scan mode to use (FULL uploads a report to the Black Duck server; RAPID is a fast policy gate without server upload).
     default: 'FULL'
     required: false
+  rapid_compare_mode:
+    description: When set, enables Rapid Scan compare mode (e.g. BOM_COMPARE or BOM_COMPARE_STRICT). Only relevant when scan_mode is RAPID. See https://documentation.blackduck.com/bundle/detect/page/runningdetect/rapidscan.html#rapid-scan-compare-mode for details.
+    default: ''
+    required: false
 
 runs:
   using: composite
@@ -73,3 +77,4 @@ runs:
           --blackduck.signature.scanner.memory=4096
           --blackduck.trust.cert=true
           --logging.level.detect=INFO
+          ${{ inputs.rapid_compare_mode != '' && format('--detect.blackduck.rapid.compare.mode={0}', inputs.rapid_compare_mode) || '' }}

--- a/.github/actions/scan-with-blackduck/action.yml
+++ b/.github/actions/scan-with-blackduck/action.yml
@@ -5,9 +5,6 @@ inputs:
   blackduck_token:
     description: The token to use for BlackDuck authentication
     required: true
-  github_token:
-    description: The token to use for GitHub authentication
-    required: true
   java-version:
     description: The version of Java to use
     default: '17'
@@ -60,7 +57,6 @@ runs:
         blackducksca_url: https://sap.blackducksoftware.com/
         blackducksca_token: ${{ inputs.blackduck_token }}
         blackducksca_scan_full: ${{ inputs.scan_mode == 'FULL' }}
-        github_token: ${{ inputs.github_token }}
         detect_args: >
           --detect.project.name=com.sap.cds.feature.attachments
           --detect.project.version.name=${{ steps.resolve-version.outputs.VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,6 @@ jobs:
         uses: cap-java/cds-feature-attachments/.github/actions/scan-with-blackduck@main
         with:
           blackduck_token: ${{ secrets.BLACK_DUCK_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           maven-version: ${{ env.MAVEN_VERSION }}
           scan_mode: FULL
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,24 @@ on:
     types: [reopened, synchronize, opened]
 
 jobs:
+  blackduck:
+    name: Blackduck Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan With Black Duck
+        uses: cap-java/cds-feature-attachments/.github/actions/scan-with-blackduck@main
+        with:
+          blackduck_token: ${{ secrets.BLACK_DUCK_TOKEN }}
+          maven-version: ${{ env.MAVEN_VERSION }}
+          scan_mode: RAPID
+          rapid_compare_mode: BOM_COMPARE # PRs might only be blocked by things they introduce, not by pre-existing issues that could have appeared in the main branch in the meantime
+
   build-and-test:
     uses: cap-java/cds-feature-attachments/.github/workflows/pipeline.yml@main
     secrets: inherit

--- a/cds-feature-attachments/pom.xml
+++ b/cds-feature-attachments/pom.xml
@@ -34,6 +34,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
+      <artifactId>connectivity-apache-httpclient4</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.sap.cds</groupId>
       <artifactId>cds-services-utils</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
     <excluded.generation.package>com/sap/cds/feature/attachments/generated/</excluded.generation.package>
 
-    <software.amazon.awssdk-s3-version>2.42.33</software.amazon.awssdk-s3-version>
+    <software.amazon.awssdk-s3-version>2.44.11</software.amazon.awssdk-s3-version>
     <software.amazon.awssdk-crt-version>0.44.0</software.amazon.awssdk-crt-version>
 
     <!-- Latest versions of CAP Java and cds-dk used for integrations tests only -->
@@ -89,7 +89,7 @@
       <dependency>
         <groupId>com.sap.cloud.sdk</groupId>
         <artifactId>sdk-bom</artifactId>
-        <version>5.27.0</version>
+        <version>5.30.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,14 @@
       </dependency>
 
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.2.14.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>com.sap.cloud.sdk</groupId>
         <artifactId>sdk-bom</artifactId>
         <version>5.30.0</version>

--- a/storage-targets/cds-feature-attachments-oss/pom.xml
+++ b/storage-targets/cds-feature-attachments-oss/pom.xml
@@ -45,13 +45,13 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-storage-blob</artifactId>
-      <version>12.33.3</version>
+      <version>12.34.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.66.0</version>
+      <version>2.68.0</version>
     </dependency>
 
     <!-- TESTS -->


### PR DESCRIPTION
# Fix BlackDuck CI Configuration and Dependency Updates

🔧 **Chore:** Cleaned up the BlackDuck scan action by removing unnecessary `github_token` input, and updated several dependency versions in the Maven build files.

### Changes

* `.github/actions/scan-with-blackduck/action.yml`: Removed the `github_token` input parameter and its usage in the BlackDuck Security Scan step. Also fixed indentation in the `detect_args` block.
* `.github/workflows/main.yml`: Removed the `github_token` reference passed to the BlackDuck scan action.
* `pom.xml`: Updated `software.amazon.awssdk-s3-version` from `2.42.33` to `2.44.11`, bumped `com.sap.cloud.sdk:sdk-bom` from `5.27.0` to `5.30.0`
* added `io.netty:netty-bom` version `4.2.14.Final` to the dependency management section.
* `storage-targets/cds-feature-attachments-oss/pom.xml`: Updated `azure-storage-blob` from `12.33.3` to `12.34.0` and `google-cloud-storage` from `2.66.0` to `2.68.0`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.0`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `e5b1fa3d-8b5d-4d04-aa40-a7fd907e4a7d`
- Event Trigger: `pull_request.edited`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
</details>
