### PR TITLE
Changed pinned version from main to commit sha for actions from https://github.com/cap-java/.github

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   label-issue:
-    uses: cap-java/.github/.github/workflows/issue.yml@main
+    uses: cap-java/.github/.github/workflows/issue.yml@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Scan With Black Duck
-        uses: cap-java/.github/actions/scan-with-blackduck@main
+        uses: cap-java/.github/actions/scan-with-blackduck@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main
         with:
           blackduck_token: ${{ secrets.BLACK_DUCK_TOKEN }}
           maven-version: ${{ env.MAVEN_VERSION }}
@@ -29,7 +29,7 @@ jobs:
           scan_mode: FULL
 
   build-and-test:
-    uses: cap-java/cds-feature-attachments/.github/workflows/pipeline.yml@main
+    uses: cap-java/cds-feature-attachments/.github/workflows/pipeline.yml@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Bind CF Services
-        uses: cap-java/cds-feature-attachments/.github/actions/cf-bind@main
+        uses: cap-java/cds-feature-attachments/.github/actions/cf-bind@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main
         with:
           cf-api: ${{ secrets[format('CF_API_{0}', matrix.hyperscaler)] }}
           cf-username: ${{ secrets.CF_USERNAME }}
@@ -92,7 +92,7 @@ jobs:
           auth-method: ${{ matrix.auth-method }}
 
       - name: Integration Tests
-        uses: cap-java/cds-feature-attachments/.github/actions/integration-tests@main
+        uses: cap-java/cds-feature-attachments/.github/actions/integration-tests@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main
         with:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ env.MAVEN_VERSION }}
@@ -110,7 +110,7 @@ jobs:
           fetch-depth: 0
 
       - name: Bind CF Services
-        uses: cap-java/cds-feature-attachments/.github/actions/cf-bind@main
+        uses: cap-java/cds-feature-attachments/.github/actions/cf-bind@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main
         with:
           cf-api: ${{ secrets.CF_API_AWS }}
           cf-username: ${{ secrets.CF_USERNAME }}
@@ -120,7 +120,7 @@ jobs:
           auth-method: basic
 
       - name: SonarQube Scan
-        uses: cap-java/.github/actions/scan-with-sonar@main
+        uses: cap-java/.github/actions/scan-with-sonar@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main
         with:
           java-version: 17
           maven-version: ${{ env.MAVEN_VERSION }}
@@ -149,7 +149,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: CodeQL Analysis
-        uses: cap-java/.github/actions/scan-with-codeql@main
+        uses: cap-java/.github/actions/scan-with-codeql@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main
         with:
           java-version: 17
           maven-version: ${{ env.MAVEN_VERSION }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Scan With Black Duck
-        uses: cap-java/.github/actions/scan-with-blackduck@main
+        uses: cap-java/.github/actions/scan-with-blackduck@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main
         with:
           blackduck_token: ${{ secrets.BLACK_DUCK_TOKEN }}
           maven-version: ${{ env.MAVEN_VERSION }}
@@ -34,5 +34,5 @@ jobs:
           rapid_compare_mode: BOM_COMPARE # PRs might only be blocked by things they introduce, not by pre-existing issues that could have appeared in the main branch in the meantime
 
   build-and-test:
-    uses: cap-java/cds-feature-attachments/.github/workflows/pipeline.yml@main
+    uses: cap-java/cds-feature-attachments/.github/workflows/pipeline.yml@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main
     secrets: inherit

--- a/.github/workflows/prevent-issue-labeling.yml
+++ b/.github/workflows/prevent-issue-labeling.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   prevent-issue-labeling:
-    uses: cap-java/.github/.github/workflows/prevent-issue-labeling.yml@main
+    uses: cap-java/.github/.github/workflows/prevent-issue-labeling.yml@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Scan With Black Duck
-        uses: cap-java/.github/actions/scan-with-blackduck@main
+        uses: cap-java/.github/actions/scan-with-blackduck@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main
         with:
           blackduck_token: ${{ secrets.BLACK_DUCK_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -93,7 +93,7 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Build
-        uses: cap-java/.github/actions/build@main
+        uses: cap-java/.github/actions/build@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main
         with:
           java-version: ${{ env.JAVA_VERSION }}
           maven-version: ${{ env.MAVEN_VERSION }}
@@ -113,7 +113,7 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Deploy
-        uses: cap-java/.github/actions/deploy-release@main
+        uses: cap-java/.github/actions/deploy-release@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main
         with:
           user: ${{ secrets.CENTRAL_REPOSITORY_USER }}
           password: ${{ secrets.CENTRAL_REPOSITORY_PASS }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   stale:
-    uses: cap-java/.github/.github/workflows/stale.yml@main
+    uses: cap-java/.github/.github/workflows/stale.yml@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main


### PR DESCRIPTION
# Pin GitHub Actions to Commit SHA Instead of `main` Branch

### Chore

🔧 Updated all GitHub Actions workflow references from the mutable `@main` branch tag to a pinned commit SHA (`296573b55e906f5c77a1855bcfe4285cbbc5cac4`), with `#main` retained as a comment for readability. This improves security and reproducibility by ensuring workflows use a specific, immutable version of the shared actions rather than a floating branch reference.

### Changes

* `.github/workflows/issue.yml`: Pinned reusable workflow reference from `@main` to `@296573b55e906f5c77a1855bcfe4285cbbc5cac4 #main`.
* `.github/workflows/main.yml`: Pinned references for `scan-with-blackduck` action and `pipeline.yml` reusable workflow.
* `.github/workflows/pipeline.yml`: Pinned references for `cf-bind`, `integration-tests`, `scan-with-sonar`, and `scan-with-codeql` actions.
* `.github/workflows/pr.yml`: Pinned references for `scan-with-blackduck` action and `pipeline.yml` reusable workflow.
* `.github/workflows/prevent-issue-labeling.yml`: Pinned reusable workflow reference.
* `.github/workflows/release.yml`: Pinned references for `scan-with-blackduck`, `build`, and `deploy-release` actions.
* `.github/workflows/stale.yml`: Pinned reusable workflow reference.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.1`

- Correlation ID: `2b85514d-75a9-490b-97fe-e1e873d76a39`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
