### PR TITLE
chore: fix pipeline

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,4 +35,9 @@ jobs:
 
   build-and-test:
     uses: cap-java/cds-feature-attachments/.github/workflows/pipeline.yml@main
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
     secrets: inherit


### PR DESCRIPTION
# Fix Pipeline: Add Missing Permissions to Build-and-Test Job

### Bug Fix

🐛 Added missing permissions to the `build-and-test` workflow job in the PR pipeline configuration to ensure it runs with the correct access rights.

### Changes

* `.github/workflows/pr.yml`: Added explicit permissions block to the `build-and-test` job, granting `read` access to `actions`, `contents`, and `packages`, and `write` access to `security-events`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.0`

- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `c794a83c-0d4b-41dc-97f5-3c676edda410`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
</details>
