### PR TITLE
feature: cleanup scattered logic

### DIFF
--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/configuration/Registration.java
@@ -18,6 +18,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.Att
 import com.sap.cds.feature.attachments.handler.applicationservice.transaction.CreationChangeSetListener;
 import com.sap.cds.feature.attachments.handler.applicationservice.transaction.ListenerProvider;
 import com.sap.cds.feature.attachments.handler.common.AssociationCascader;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.feature.attachments.handler.draftservice.DraftActiveAttachmentsHandler;
 import com.sap.cds.feature.attachments.handler.draftservice.DraftCancelAttachmentsHandler;
@@ -132,9 +133,9 @@ public class Registration implements CdsRuntimeConfiguration {
         new DefaultAttachmentMalwareScanner(persistenceService, attachmentService, scanClient);
 
     EndTransactionMalwareScanProvider malwareScanEndTransactionListener =
-        (attachmentEntity, contentId, inlinePrefix) ->
+        (attachmentEntity, contentId, attachmentContext) ->
             new EndTransactionMalwareScanRunner(
-                attachmentEntity, contentId, inlinePrefix, malwareScanner, runtime);
+                attachmentEntity, contentId, attachmentContext, malwareScanner, runtime);
 
     // register event handlers for attachment service
     configurer.eventHandler(
@@ -164,7 +165,7 @@ public class Registration implements CdsRuntimeConfiguration {
       configurer.eventHandler(new DeleteAttachmentsHandler(attachmentsReader, deleteEvent));
       EndTransactionMalwareScanRunner scanRunner =
           new EndTransactionMalwareScanRunner(
-              null, null, Optional.empty(), malwareScanner, runtime);
+              null, null, new AttachmentContext.Composition(), malwareScanner, runtime);
       configurer.eventHandler(
           new ReadAttachmentsHandler(
               attachmentService,

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandler.java
@@ -10,6 +10,7 @@ import com.sap.cds.CdsDataProcessor.Converter;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.services.cds.ApplicationService;
 import com.sap.cds.services.cds.CdsDeleteEventContext;
@@ -19,7 +20,6 @@ import com.sap.cds.services.handler.annotations.HandlerOrder;
 import com.sap.cds.services.handler.annotations.ServiceName;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,19 +54,19 @@ public class DeleteAttachmentsHandler implements EventHandler {
 
     Converter converter =
         (path, element, value) -> {
-          Optional<String> inlinePrefix =
-              ApplicationHandlerHelper.getInlineAttachmentPrefix(
-                  path.target().entity(), element.getName());
-          // For inline attachments, extract the prefixed fields to get proper contentId
+          AttachmentContext attachmentCtx =
+              AttachmentContext.from(path.target().type(), element);
           Attachments attachment;
-          if (inlinePrefix.isPresent()) {
+          if (attachmentCtx.isInline()) {
             attachment =
                 ApplicationHandlerHelper.extractInlineAttachment(
-                    path.target().values(), inlinePrefix.get());
+                    path.target().values(),
+                    ((AttachmentContext.Inline) attachmentCtx).prefix());
           } else {
             attachment = Attachments.of(path.target().values());
           }
-          return deleteEvent.processEvent(path, (InputStream) value, attachment, context);
+          return deleteEvent.processEvent(
+              path, (InputStream) value, attachment, context, attachmentCtx);
         };
 
     CdsDataProcessor.create()

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandler.java
@@ -54,14 +54,12 @@ public class DeleteAttachmentsHandler implements EventHandler {
 
     Converter converter =
         (path, element, value) -> {
-          AttachmentContext attachmentCtx =
-              AttachmentContext.from(path.target().type(), element);
+          AttachmentContext attachmentCtx = AttachmentContext.from(path.target().type(), element);
           Attachments attachment;
           if (attachmentCtx.isInline()) {
             attachment =
                 ApplicationHandlerHelper.extractInlineAttachment(
-                    path.target().values(),
-                    ((AttachmentContext.Inline) attachmentCtx).prefix());
+                    path.target().values(), ((AttachmentContext.Inline) attachmentCtx).prefix());
           } else {
             attachment = Attachments.of(path.target().values());
           }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
@@ -40,7 +40,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,14 +118,12 @@ public class ReadAttachmentsHandler implements EventHandler {
 
       Converter converter =
           (path, element, value) -> {
-            AttachmentContext attachmentCtx =
-                AttachmentContext.from(path.target().type(), element);
+            AttachmentContext attachmentCtx = AttachmentContext.from(path.target().type(), element);
             Attachments attachment;
             if (attachmentCtx.isInline()) {
               attachment =
                   ApplicationHandlerHelper.extractInlineAttachment(
-                      path.target().values(),
-                      ((AttachmentContext.Inline) attachmentCtx).prefix());
+                      path.target().values(), ((AttachmentContext.Inline) attachmentCtx).prefix());
             } else {
               attachment = Attachments.of(path.target().values());
             }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandler.java
@@ -16,6 +16,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.Bef
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.LazyProxyInputStream;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
 import com.sap.cds.feature.attachments.handler.common.AssociationCascader;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.AsyncMalwareScanExecutor;
 import com.sap.cds.ql.CQL;
@@ -118,21 +119,20 @@ public class ReadAttachmentsHandler implements EventHandler {
 
       Converter converter =
           (path, element, value) -> {
+            AttachmentContext attachmentCtx =
+                AttachmentContext.from(path.target().type(), element);
             Attachments attachment;
-            // Check if this is an inline attachment field
-            Optional<String> inlinePrefix =
-                ApplicationHandlerHelper.getInlineAttachmentPrefix(
-                    path.target().type(), element.getName());
-            if (inlinePrefix.isPresent()) {
+            if (attachmentCtx.isInline()) {
               attachment =
                   ApplicationHandlerHelper.extractInlineAttachment(
-                      path.target().values(), inlinePrefix.get());
+                      path.target().values(),
+                      ((AttachmentContext.Inline) attachmentCtx).prefix());
             } else {
               attachment = Attachments.of(path.target().values());
             }
             InputStream content = attachment.getContent();
             if (nonNull(attachment.getContentId())) {
-              verifyStatus(path, attachment);
+              verifyStatus(path, attachment, attachmentCtx);
               Supplier<InputStream> supplier =
                   nonNull(content)
                       ? () -> content
@@ -149,10 +149,8 @@ public class ReadAttachmentsHandler implements EventHandler {
     }
   }
 
-  private void verifyStatus(Path path, Attachments attachment) {
-    Optional<String> inlinePrefix =
-        Optional.ofNullable((String) attachment.get(ApplicationHandlerHelper.INLINE_PREFIX_MARKER));
-    if (areKeysEmpty(path.target().keys()) || inlinePrefix.isPresent()) {
+  private void verifyStatus(Path path, Attachments attachment, AttachmentContext attachmentCtx) {
+    if (areKeysEmpty(path.target().keys()) || attachmentCtx.isInline()) {
       String currentStatus = attachment.getStatus();
       logger.debug(
           "In verify status for content id {} and status {}",
@@ -160,13 +158,13 @@ public class ReadAttachmentsHandler implements EventHandler {
           currentStatus);
       if (scannerAvailable && needsScan(currentStatus, attachment.getScannedAt())) {
         if (StatusCode.CLEAN.equals(currentStatus)) {
-          transitionToScanning(path.target().entity(), attachment, inlinePrefix);
+          transitionToScanning(path.target().entity(), attachment, attachmentCtx);
         }
         logger.debug(
             "Scanning content with ID {} for malware, has current status {}",
             attachment.getContentId(),
             currentStatus);
-        scanExecutor.scanAsync(path.target().entity(), attachment.getContentId(), inlinePrefix);
+        scanExecutor.scanAsync(path.target().entity(), attachment.getContentId(), attachmentCtx);
       }
       statusValidator.verifyStatus(attachment.getStatus());
     }
@@ -186,15 +184,14 @@ public class ReadAttachmentsHandler implements EventHandler {
   }
 
   private void transitionToScanning(
-      CdsEntity entity, Attachments attachment, Optional<String> inlinePrefix) {
+      CdsEntity entity, Attachments attachment, AttachmentContext attachmentCtx) {
     logger.debug(
         "Attachment {} has stale scan (scannedAt={}), transitioning to SCANNING for rescan.",
         attachment.getContentId(),
         attachment.getScannedAt());
 
-    String contentIdCol =
-        ApplicationHandlerHelper.resolveFieldName(Attachments.CONTENT_ID, inlinePrefix);
-    String statusCol = ApplicationHandlerHelper.resolveFieldName(Attachments.STATUS, inlinePrefix);
+    String contentIdCol = attachmentCtx.fieldName(Attachments.CONTENT_ID);
+    String statusCol = attachmentCtx.fieldName(Attachments.STATUS);
 
     Attachments updateData = Attachments.create();
     updateData.put(statusCol, StatusCode.SCANNING);

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
@@ -55,8 +55,7 @@ public final class ModifyApplicationHandlerHelper {
 
     Converter converter =
         (path, element, value) -> {
-          AttachmentContext context =
-              AttachmentContext.from(path.target().type(), element);
+          AttachmentContext context = AttachmentContext.from(path.target().type(), element);
           return handleAttachmentForEntity(
               condensedExistingAttachments,
               eventFactory,
@@ -135,8 +134,7 @@ public final class ModifyApplicationHandlerHelper {
 
   private static String getValMaxValue(
       CdsEntity entity, String defaultMaxSize, AttachmentContext context) {
-    Optional<CdsElement> contentElement =
-        entity.findElement(context.fieldName("content"));
+    Optional<CdsElement> contentElement = entity.findElement(context.fieldName("content"));
     return contentElement
         .flatMap(e -> e.findAnnotation("Validation.Maximum"))
         .map(CdsAnnotation::getValue)
@@ -146,9 +144,7 @@ public final class ModifyApplicationHandlerHelper {
   }
 
   private static Attachments getExistingAttachment(
-      Map<String, Object> keys,
-      List<Attachments> existingAttachments,
-      AttachmentContext context) {
+      Map<String, Object> keys, List<Attachments> existingAttachments, AttachmentContext context) {
     return existingAttachments.stream()
         .filter(existingData -> context.matches(existingData, keys))
         .findAny()

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
@@ -93,7 +93,7 @@ public final class ModifyApplicationHandlerHelper {
       String defaultMaxSize,
       AttachmentContext context) {
     Map<String, Object> keys = ApplicationHandlerHelper.removeDraftKey(path.target().keys());
-    ReadonlyDataContextEnhancer.restoreReadonlyFields((CdsData) path.target().values());
+    ReadonlyDataContextEnhancer.restoreReadonlyFields((CdsData) path.target().values(), context);
     Attachments attachment = getExistingAttachment(keys, existingAttachments, context);
 
     String contentId =

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelper.java
@@ -11,6 +11,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.M
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEventFactory;
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.CountingInputStream;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.reflect.CdsAnnotation;
 import com.sap.cds.reflect.CdsElement;
@@ -54,9 +55,8 @@ public final class ModifyApplicationHandlerHelper {
 
     Converter converter =
         (path, element, value) -> {
-          Optional<String> inlinePrefix =
-              ApplicationHandlerHelper.getInlineAttachmentPrefix(
-                  path.target().entity(), element.getName());
+          AttachmentContext context =
+              AttachmentContext.from(path.target().type(), element);
           return handleAttachmentForEntity(
               condensedExistingAttachments,
               eventFactory,
@@ -64,7 +64,7 @@ public final class ModifyApplicationHandlerHelper {
               path,
               (InputStream) value,
               defaultMaxSize,
-              inlinePrefix);
+              context);
         };
 
     CdsDataProcessor.create()
@@ -81,7 +81,7 @@ public final class ModifyApplicationHandlerHelper {
    * @param path the {@link Path} of the attachment
    * @param content the content of the attachment
    * @param defaultMaxSize the default max size to use when no annotation is present
-   * @param inlinePrefix the inline attachment field prefix, or empty for composition-based
+   * @param context the attachment context describing how to address this attachment's fields
    * @return the processed content as an {@link InputStream}
    */
   public static InputStream handleAttachmentForEntity(
@@ -91,22 +91,16 @@ public final class ModifyApplicationHandlerHelper {
       Path path,
       InputStream content,
       String defaultMaxSize,
-      Optional<String> inlinePrefix) {
+      AttachmentContext context) {
     Map<String, Object> keys = ApplicationHandlerHelper.removeDraftKey(path.target().keys());
     ReadonlyDataContextEnhancer.restoreReadonlyFields((CdsData) path.target().values());
-    Attachments attachment = getExistingAttachment(keys, existingAttachments, inlinePrefix);
+    Attachments attachment = getExistingAttachment(keys, existingAttachments, context);
 
-    // For inline attachment fields, extract contentId using the known prefix
-    String contentId;
-    if (inlinePrefix.isPresent()) {
-      contentId =
-          (String) path.target().values().get(inlinePrefix.get() + "_" + Attachments.CONTENT_ID);
-    } else {
-      contentId = (String) path.target().values().get(Attachments.CONTENT_ID);
-    }
+    String contentId =
+        (String) path.target().values().get(context.fieldName(Attachments.CONTENT_ID));
 
     String contentLength = eventContext.getParameterInfo().getHeader("Content-Length");
-    String maxSizeStr = getValMaxValue(path.target().entity(), defaultMaxSize, inlinePrefix);
+    String maxSizeStr = getValMaxValue(path.target().entity(), defaultMaxSize, context);
     eventContext.put(
         "attachment.MaxSize",
         maxSizeStr); // make max size available in context for error handling later
@@ -130,12 +124,7 @@ public final class ModifyApplicationHandlerHelper {
     ModifyAttachmentEvent eventToProcess =
         eventFactory.getEvent(wrappedContent, contentId, attachment);
     try {
-      // Ensure the attachment carries the inline prefix marker for processEvent implementations
-      if (inlinePrefix.isPresent()
-          && attachment.get(ApplicationHandlerHelper.INLINE_PREFIX_MARKER) == null) {
-        attachment.put(ApplicationHandlerHelper.INLINE_PREFIX_MARKER, inlinePrefix.get());
-      }
-      return eventToProcess.processEvent(path, wrappedContent, attachment, eventContext);
+      return eventToProcess.processEvent(path, wrappedContent, attachment, eventContext, context);
     } catch (Exception e) {
       if (wrappedContent != null && wrappedContent.isLimitExceeded()) {
         throw tooLargeException;
@@ -145,13 +134,9 @@ public final class ModifyApplicationHandlerHelper {
   }
 
   private static String getValMaxValue(
-      CdsEntity entity, String defaultMaxSize, Optional<String> inlinePrefix) {
-    Optional<CdsElement> contentElement;
-    if (inlinePrefix.isPresent()) {
-      contentElement = entity.findElement(inlinePrefix.get() + "_content");
-    } else {
-      contentElement = entity.findElement("content");
-    }
+      CdsEntity entity, String defaultMaxSize, AttachmentContext context) {
+    Optional<CdsElement> contentElement =
+        entity.findElement(context.fieldName("content"));
     return contentElement
         .flatMap(e -> e.findAnnotation("Validation.Maximum"))
         .map(CdsAnnotation::getValue)
@@ -163,19 +148,9 @@ public final class ModifyApplicationHandlerHelper {
   private static Attachments getExistingAttachment(
       Map<String, Object> keys,
       List<Attachments> existingAttachments,
-      Optional<String> inlinePrefix) {
+      AttachmentContext context) {
     return existingAttachments.stream()
-        .filter(
-            existingData -> {
-              // For inline attachments, match by the prefix marker
-              if (inlinePrefix.isPresent()) {
-                String existingPrefix =
-                    (String) existingData.get(ApplicationHandlerHelper.INLINE_PREFIX_MARKER);
-                return inlinePrefix.get().equals(existingPrefix);
-              }
-              // For composition-based attachments, match by keys
-              return ApplicationHandlerHelper.areKeysInData(keys, existingData);
-            })
+        .filter(existingData -> context.matches(existingData, keys))
         .findAny()
         .orElse(Attachments.create());
   }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancer.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancer.java
@@ -9,10 +9,10 @@ import com.sap.cds.CdsDataProcessor.Validator;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.reflect.CdsEntity;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * The class {@link ReadonlyDataContextEnhancer} provides methods to backup and restore readonly
@@ -23,55 +23,36 @@ public final class ReadonlyDataContextEnhancer {
   private static final String DRAFT_READONLY_CONTEXT = "DRAFT_READONLY_CONTEXT";
 
   /**
-   * Preserves the readonly fields of an {@link Attachments attachment} in a custom field with the
-   * name {@value #DRAFT_READONLY_CONTEXT}. These readonly data will be removed from the data by the
-   * CAP Java runtime, but the preserved copy still exists.
+   * Preserves the readonly fields of an {@link Attachments attachment} in a custom field. These
+   * readonly data will be removed from the data by the CAP Java runtime, but the preserved copy
+   * still exists.
    *
    * @param target the target {@link CdsEntity entity}
    * @param data the list of {@link CdsData data} to enhance
    * @param isDraft <code>true</code> if the data is from a draft entity, <code>false</code>
    *     otherwise
    */
-  public static void preserveReadonlyFields(CdsEntity target, List<CdsData> data, boolean isDraft) {
+  public static void preserveReadonlyFields(
+      CdsEntity target, List<CdsData> data, boolean isDraft) {
 
     Validator validator =
         (path, element, value) -> {
+          AttachmentContext context =
+              AttachmentContext.from(path.target().type(), element);
           if (isDraft) {
-            // Determine if this is an inline attachment field
-            Optional<String> inlinePrefix =
-                ApplicationHandlerHelper.getInlineAttachmentPrefix(
-                    path.target().type(), element.getName());
-            if (inlinePrefix.isPresent()) {
-              // Inline attachment: use prefixed field names
-              String prefix = inlinePrefix.get() + "_";
-              Attachments attachment = Attachments.create();
-              attachment.setContentId(
-                  (String) path.target().values().get(prefix + Attachments.CONTENT_ID));
-              attachment.setStatus(
-                  (String) path.target().values().get(prefix + Attachments.STATUS));
-              attachment.setScannedAt(
-                  (java.time.Instant) path.target().values().get(prefix + Attachments.SCANNED_AT));
-              attachment.setFileName(
-                  (String) path.target().values().get(prefix + MediaData.FILE_NAME));
-              path.target().values().put(prefix + DRAFT_READONLY_CONTEXT, attachment);
-            } else {
-              // Composition-based attachment: use direct field names
-              Attachments values = Attachments.of(path.target().values());
-              Attachments attachment = Attachments.create();
-              attachment.setContentId(values.getContentId());
-              attachment.setStatus(values.getStatus());
-              attachment.setScannedAt(values.getScannedAt());
-              attachment.setFileName(values.getFileName());
-              path.target().values().put(DRAFT_READONLY_CONTEXT, attachment);
-            }
+            Attachments attachment = Attachments.create();
+            attachment.setContentId(
+                (String) path.target().values().get(context.fieldName(Attachments.CONTENT_ID)));
+            attachment.setStatus(
+                (String) path.target().values().get(context.fieldName(Attachments.STATUS)));
+            attachment.setScannedAt(
+                (java.time.Instant)
+                    path.target().values().get(context.fieldName(Attachments.SCANNED_AT)));
+            attachment.setFileName(
+                (String) path.target().values().get(context.fieldName(MediaData.FILE_NAME)));
+            path.target().values().put(context.fieldName(DRAFT_READONLY_CONTEXT), attachment);
           } else {
-            path.target().values().remove(DRAFT_READONLY_CONTEXT);
-            // Also remove inline prefixed draft readonly contexts
-            List<String> prefixes =
-                ApplicationHandlerHelper.getInlineAttachmentFieldNames(path.target().type());
-            for (String prefix : prefixes) {
-              path.target().values().remove(prefix + "_" + DRAFT_READONLY_CONTEXT);
-            }
+            path.target().values().remove(context.fieldName(DRAFT_READONLY_CONTEXT));
           }
         };
 
@@ -81,45 +62,23 @@ public final class ReadonlyDataContextEnhancer {
   }
 
   /**
-   * Restores the readonly fields with the backup from the data in the custom field {@value
-   * #DRAFT_READONLY_CONTEXT}. Supports both composition-based and inline attachment fields.
+   * Restores the readonly fields for the attachment described by the given context from the
+   * preserved backup in the data map.
    *
    * @param data the {@link CdsData data} to restore with readonly fields
+   * @param context the attachment context identifying which attachment's fields to restore
    */
-  public static void restoreReadonlyFields(CdsData data) {
-    // Restore composition-based readonly fields
-    CdsData readOnlyData = (CdsData) data.get(DRAFT_READONLY_CONTEXT);
+  public static void restoreReadonlyFields(CdsData data, AttachmentContext context) {
+    String readonlyKey = context.fieldName(DRAFT_READONLY_CONTEXT);
+    CdsData readOnlyData = (CdsData) data.get(readonlyKey);
     if (Objects.nonNull(readOnlyData)) {
-      data.put(Attachments.CONTENT_ID, readOnlyData.get(Attachments.CONTENT_ID));
-      data.put(Attachments.STATUS, readOnlyData.get(Attachments.STATUS));
-      data.put(Attachments.SCANNED_AT, readOnlyData.get(Attachments.SCANNED_AT));
-      // Only restore fileName if it was preserved (avoid overwriting framework-provided value)
+      data.put(context.fieldName(Attachments.CONTENT_ID), readOnlyData.get(Attachments.CONTENT_ID));
+      data.put(context.fieldName(Attachments.STATUS), readOnlyData.get(Attachments.STATUS));
+      data.put(context.fieldName(Attachments.SCANNED_AT), readOnlyData.get(Attachments.SCANNED_AT));
       if (readOnlyData.get(MediaData.FILE_NAME) != null) {
-        data.put(MediaData.FILE_NAME, readOnlyData.get(MediaData.FILE_NAME));
+        data.put(context.fieldName(MediaData.FILE_NAME), readOnlyData.get(MediaData.FILE_NAME));
       }
-      data.remove(DRAFT_READONLY_CONTEXT);
-    }
-
-    // Restore inline attachment readonly fields
-    for (String key : List.copyOf(data.keySet())) {
-      if (key.endsWith("_" + DRAFT_READONLY_CONTEXT)) {
-        String prefix = key.substring(0, key.length() - DRAFT_READONLY_CONTEXT.length() - 1);
-        CdsData inlineReadOnlyData = (CdsData) data.get(key);
-        if (Objects.nonNull(inlineReadOnlyData)) {
-          data.put(
-              prefix + "_" + Attachments.CONTENT_ID,
-              inlineReadOnlyData.get(Attachments.CONTENT_ID));
-          data.put(prefix + "_" + Attachments.STATUS, inlineReadOnlyData.get(Attachments.STATUS));
-          data.put(
-              prefix + "_" + Attachments.SCANNED_AT,
-              inlineReadOnlyData.get(Attachments.SCANNED_AT));
-          if (inlineReadOnlyData.get(MediaData.FILE_NAME) != null) {
-            data.put(
-                prefix + "_" + MediaData.FILE_NAME, inlineReadOnlyData.get(MediaData.FILE_NAME));
-          }
-          data.remove(key);
-        }
-      }
+      data.remove(readonlyKey);
     }
   }
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancer.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancer.java
@@ -32,13 +32,11 @@ public final class ReadonlyDataContextEnhancer {
    * @param isDraft <code>true</code> if the data is from a draft entity, <code>false</code>
    *     otherwise
    */
-  public static void preserveReadonlyFields(
-      CdsEntity target, List<CdsData> data, boolean isDraft) {
+  public static void preserveReadonlyFields(CdsEntity target, List<CdsData> data, boolean isDraft) {
 
     Validator validator =
         (path, element, value) -> {
-          AttachmentContext context =
-              AttachmentContext.from(path.target().type(), element);
+          AttachmentContext context = AttachmentContext.from(path.target().type(), element);
           if (isDraft) {
             Attachments attachment = Attachments.create();
             attachment.setContentId(

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEvent.java
@@ -10,6 +10,7 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachmen
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
 import com.sap.cds.feature.attachments.handler.applicationservice.transaction.ListenerProvider;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.model.service.AttachmentModificationResult;
 import com.sap.cds.feature.attachments.service.model.service.CreateAttachmentInput;
@@ -51,35 +52,31 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
 
   @Override
   public InputStream processEvent(
-      Path path, InputStream content, Attachments attachment, EventContext eventContext) {
-    Optional<String> inlinePrefix =
-        Optional.ofNullable((String) attachment.get(ApplicationHandlerHelper.INLINE_PREFIX_MARKER));
-
+      Path path,
+      InputStream content,
+      Attachments attachment,
+      EventContext eventContext,
+      AttachmentContext context) {
     logger.debug(
         "Calling attachment service with create event for entity {}",
         path.target().entity().getQualifiedName());
     Map<String, Object> values = path.target().values();
     Map<String, Object> keys = ApplicationHandlerHelper.removeDraftKey(path.target().keys());
 
-    String fileNameField =
-        ApplicationHandlerHelper.resolveFieldName(MediaData.FILE_NAME, inlinePrefix);
-    String mimeTypeField =
-        ApplicationHandlerHelper.resolveFieldName(MediaData.MIME_TYPE, inlinePrefix);
-
     Optional<String> fileNameOptional =
-        getFieldValue(MediaData.FILE_NAME, values, attachment, inlinePrefix);
+        getFieldValue(MediaData.FILE_NAME, values, attachment, context);
     Optional<String> mimeTypeOptional =
-        getFieldValue(MediaData.MIME_TYPE, values, attachment, inlinePrefix);
+        getFieldValue(MediaData.MIME_TYPE, values, attachment, context);
 
     // Fall back to HTTP headers when values are not set in payload
     if (eventContext.getParameterInfo() != null) {
       if (fileNameOptional.isEmpty()) {
         fileNameOptional = extractFileNameFromHeader(eventContext);
-        fileNameOptional.ifPresent(fn -> values.put(fileNameField, fn));
+        fileNameOptional.ifPresent(fn -> values.put(context.fieldName(MediaData.FILE_NAME), fn));
       }
       if (mimeTypeOptional.isEmpty()) {
         mimeTypeOptional = extractMimeTypeFromHeader(eventContext);
-        mimeTypeOptional.ifPresent(mt -> values.put(mimeTypeField, mt));
+        mimeTypeOptional.ifPresent(mt -> values.put(context.fieldName(MediaData.MIME_TYPE), mt));
       }
     }
 
@@ -90,24 +87,16 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
             fileNameOptional.orElse(null),
             mimeTypeOptional.orElse(null),
             content,
-            inlinePrefix);
+            context);
     AttachmentModificationResult result = attachmentService.createAttachment(createEventInput);
     ChangeSetListener createListener =
         listenerProvider.provideListener(result.contentId(), eventContext.getCdsRuntime());
 
     eventContext.getChangeSetContext().register(createListener);
-    String contentIdField =
-        ApplicationHandlerHelper.resolveFieldName(Attachments.CONTENT_ID, inlinePrefix);
-    String statusField =
-        ApplicationHandlerHelper.resolveFieldName(Attachments.STATUS, inlinePrefix);
-    path.target().values().put(contentIdField, result.contentId());
-    path.target().values().put(statusField, result.status());
+    path.target().values().put(context.fieldName(Attachments.CONTENT_ID), result.contentId());
+    path.target().values().put(context.fieldName(Attachments.STATUS), result.status());
     if (nonNull(result.scannedAt())) {
-      path.target()
-          .values()
-          .put(
-              ApplicationHandlerHelper.resolveFieldName(Attachments.SCANNED_AT, inlinePrefix),
-              result.scannedAt());
+      path.target().values().put(context.fieldName(Attachments.SCANNED_AT), result.scannedAt());
     }
     return result.isInternalStored() ? content : null;
   }
@@ -116,10 +105,9 @@ public class CreateAttachmentEvent implements ModifyAttachmentEvent {
       String fieldName,
       Map<String, Object> values,
       Attachments attachment,
-      Optional<String> inlinePrefix) {
-    if (inlinePrefix.isPresent()) {
-      Object prefixedValue =
-          values.get(ApplicationHandlerHelper.resolveFieldName(fieldName, inlinePrefix));
+      AttachmentContext context) {
+    if (context.isInline()) {
+      Object prefixedValue = values.get(context.fieldName(fieldName));
       if (nonNull(prefixedValue)) return Optional.of((String) prefixedValue);
     }
     Object annotationValue = values.get(fieldName);

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/DoNothingAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/DoNothingAttachmentEvent.java
@@ -4,6 +4,7 @@
 package com.sap.cds.feature.attachments.handler.applicationservice.modifyevents;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.services.EventContext;
 import java.io.InputStream;
@@ -20,7 +21,11 @@ public class DoNothingAttachmentEvent implements ModifyAttachmentEvent {
 
   @Override
   public InputStream processEvent(
-      Path path, InputStream content, Attachments attachment, EventContext eventContext) {
+      Path path,
+      InputStream content,
+      Attachments attachment,
+      EventContext eventContext,
+      AttachmentContext context) {
     logger.debug("Do nothing event for entity {}", path.target().entity().getQualifiedName());
 
     return content;

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/MarkAsDeletedAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/MarkAsDeletedAttachmentEvent.java
@@ -8,14 +8,13 @@ import static java.util.Objects.requireNonNull;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
-import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.services.EventContext;
 import com.sap.cds.services.draft.DraftService;
 import java.io.InputStream;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,10 +35,11 @@ public class MarkAsDeletedAttachmentEvent implements ModifyAttachmentEvent {
 
   @Override
   public InputStream processEvent(
-      Path path, InputStream content, Attachments attachment, EventContext eventContext) {
-    Optional<String> inlinePrefix =
-        Optional.ofNullable((String) attachment.get(ApplicationHandlerHelper.INLINE_PREFIX_MARKER));
-
+      Path path,
+      InputStream content,
+      Attachments attachment,
+      EventContext eventContext,
+      AttachmentContext context) {
     String qualifiedName = eventContext.getTarget().getQualifiedName();
     logger.debug(
         "Processing the event for calling attachment service with mark as delete event for entity {}",
@@ -57,28 +57,18 @@ public class MarkAsDeletedAttachmentEvent implements ModifyAttachmentEvent {
           qualifiedName);
     }
     if (nonNull(path)) {
-      String contentIdField =
-          ApplicationHandlerHelper.resolveFieldName(Attachments.CONTENT_ID, inlinePrefix);
-      String statusField =
-          ApplicationHandlerHelper.resolveFieldName(Attachments.STATUS, inlinePrefix);
-      String scannedAtField =
-          ApplicationHandlerHelper.resolveFieldName(Attachments.SCANNED_AT, inlinePrefix);
-      String mimeTypeField =
-          ApplicationHandlerHelper.resolveFieldName(MediaData.MIME_TYPE, inlinePrefix);
-      String fileNameField =
-          ApplicationHandlerHelper.resolveFieldName(MediaData.FILE_NAME, inlinePrefix);
-
-      String newContentId = (String) path.target().values().get(contentIdField);
+      String newContentId = (String) path.target().values().get(context.fieldName(Attachments.CONTENT_ID));
       boolean replacedBySameContent =
           nonNull(newContentId) && newContentId.equals(attachment.getContentId());
-      boolean noNewContentSupplied = !path.target().values().containsKey(contentIdField);
+      boolean noNewContentSupplied =
+          !path.target().values().containsKey(context.fieldName(Attachments.CONTENT_ID));
       if (replacedBySameContent || noNewContentSupplied) {
-        path.target().values().put(contentIdField, null);
-        path.target().values().put(statusField, null);
-        path.target().values().put(scannedAtField, null);
-        if (inlinePrefix.isPresent()) {
-          path.target().values().put(mimeTypeField, null);
-          path.target().values().put(fileNameField, null);
+        path.target().values().put(context.fieldName(Attachments.CONTENT_ID), null);
+        path.target().values().put(context.fieldName(Attachments.STATUS), null);
+        path.target().values().put(context.fieldName(Attachments.SCANNED_AT), null);
+        if (context.isInline()) {
+          path.target().values().put(context.fieldName(MediaData.MIME_TYPE), null);
+          path.target().values().put(context.fieldName(MediaData.FILE_NAME), null);
         }
       }
     }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/MarkAsDeletedAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/MarkAsDeletedAttachmentEvent.java
@@ -57,7 +57,8 @@ public class MarkAsDeletedAttachmentEvent implements ModifyAttachmentEvent {
           qualifiedName);
     }
     if (nonNull(path)) {
-      String newContentId = (String) path.target().values().get(context.fieldName(Attachments.CONTENT_ID));
+      String newContentId =
+          (String) path.target().values().get(context.fieldName(Attachments.CONTENT_ID));
       boolean replacedBySameContent =
           nonNull(newContentId) && newContentId.equals(attachment.getContentId());
       boolean noNewContentSupplied =

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/ModifyAttachmentEvent.java
@@ -4,6 +4,7 @@
 package com.sap.cds.feature.attachments.handler.applicationservice.modifyevents;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.services.EventContext;
@@ -22,8 +23,13 @@ public interface ModifyAttachmentEvent {
    * @param content the content of the attachment
    * @param attachment existing attachment data
    * @param eventContext the current event context
+   * @param context the attachment context describing how to address this attachment's fields
    * @return the processed content
    */
   InputStream processEvent(
-      Path path, InputStream content, Attachments attachment, EventContext eventContext);
+      Path path,
+      InputStream content,
+      Attachments attachment,
+      EventContext eventContext,
+      AttachmentContext context);
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/UpdateAttachmentEvent.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/UpdateAttachmentEvent.java
@@ -6,6 +6,7 @@ package com.sap.cds.feature.attachments.handler.applicationservice.modifyevents;
 import static java.util.Objects.requireNonNull;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.services.EventContext;
@@ -34,12 +35,16 @@ public class UpdateAttachmentEvent implements ModifyAttachmentEvent {
 
   @Override
   public InputStream processEvent(
-      Path path, InputStream content, Attachments attachment, EventContext eventContext) {
+      Path path,
+      InputStream content,
+      Attachments attachment,
+      EventContext eventContext,
+      AttachmentContext context) {
     logger.debug(
         "Processing UPDATE event by calling attachment service with create and delete event for entity {}",
         path.target().entity().getQualifiedName());
 
-    deleteEvent.processEvent(path, content, attachment, eventContext);
-    return createEvent.processEvent(path, content, attachment, eventContext);
+    deleteEvent.processEvent(path, content, attachment, eventContext, context);
+    return createEvent.processEvent(path, content, attachment, eventContext, context);
   }
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/ApplicationHandlerHelper.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/ApplicationHandlerHelper.java
@@ -34,9 +34,10 @@ public final class ApplicationHandlerHelper {
   /**
    * Internal marker key used to store the inline attachment prefix in extracted attachment data.
    * This enables correct matching of inline attachments when operating on multiple inline
-   * attachments on the same entity.
+   * attachments on the same entity. Package-private; only used by {@link AttachmentContext.Inline}
+   * for matching.
    */
-  public static final String INLINE_PREFIX_MARKER = "_inlinePrefix";
+  static final String INLINE_PREFIX_MARKER = "_inlinePrefix";
 
   /**
    * A filter for media content fields. The filter checks if the entity is a media entity and if the
@@ -275,10 +276,6 @@ public final class ApplicationHandlerHelper {
     Map<String, Object> keyMap = new HashMap<>(keys);
     keyMap.entrySet().removeIf(entry -> entry.getKey().equals(Drafts.IS_ACTIVE_ENTITY));
     return keyMap;
-  }
-
-  public static String resolveFieldName(String fieldName, Optional<String> inlinePrefix) {
-    return inlinePrefix.map(p -> p + "_" + fieldName).orElse(fieldName);
   }
 
   private ApplicationHandlerHelper() {

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AttachmentContext.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AttachmentContext.java
@@ -1,0 +1,95 @@
+/*
+ * © 2026 SAP SE or an SAP affiliate company and cds-feature-attachments contributors.
+ */
+package com.sap.cds.feature.attachments.handler.common;
+
+import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.reflect.CdsElement;
+import com.sap.cds.reflect.CdsStructuredType;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Encapsulates how to address one attachment's fields regardless of whether it resides in a
+ * composition child entity (composition-based) or is flattened into the parent entity (inline).
+ *
+ * <p>The plugin processes one attachment at a time. {@code AttachmentContext} describes how to read
+ * and write that attachment's fields in the data map, and how to match it against existing
+ * attachment data.
+ */
+public sealed interface AttachmentContext {
+
+  /**
+   * Resolves a logical attachment field name (e.g. {@code "contentId"}) to the actual key in the
+   * data map (e.g. {@code "avatar_contentId"} for inline, or {@code "contentId"} for composition).
+   */
+  String fieldName(String logicalName);
+
+  /**
+   * Returns {@code true} if the given existing attachment record corresponds to this context's
+   * attachment.
+   *
+   * @param existing the existing attachment data to check
+   * @param parentKeys the parent entity keys from the current path
+   */
+  boolean matches(Attachments existing, Map<String, Object> parentKeys);
+
+  /** Returns {@code true} if this is an inline attachment (flattened into the parent entity). */
+  boolean isInline();
+
+  /**
+   * Determines the correct {@link AttachmentContext} from a {@code CdsDataProcessor} callback.
+   *
+   * @param entity the entity type at the current processing path
+   * @param element the element that matched the media content filter
+   * @return the appropriate context implementation
+   */
+  static AttachmentContext from(CdsStructuredType entity, CdsElement element) {
+    Optional<String> prefix =
+        ApplicationHandlerHelper.getInlineAttachmentPrefix(entity, element.getName());
+    return prefix.<AttachmentContext>map(Inline::new).orElseGet(Composition::new);
+  }
+
+  /** Context for composition-based attachments where the attachment is its own entity. */
+  record Composition() implements AttachmentContext {
+
+    @Override
+    public String fieldName(String logicalName) {
+      return logicalName;
+    }
+
+    @Override
+    public boolean matches(Attachments existing, Map<String, Object> parentKeys) {
+      return ApplicationHandlerHelper.areKeysInData(parentKeys, existing);
+    }
+
+    @Override
+    public boolean isInline() {
+      return false;
+    }
+  }
+
+  /**
+   * Context for inline attachments where the structured type fields are flattened into the parent
+   * entity with a prefix (e.g. {@code "avatar_content"}, {@code "avatar_contentId"}).
+   */
+  record Inline(String prefix) implements AttachmentContext {
+
+    @Override
+    public String fieldName(String logicalName) {
+      return prefix + "_" + logicalName;
+    }
+
+    @Override
+    public boolean matches(Attachments existing, Map<String, Object> parentKeys) {
+      String existingPrefix =
+          (String) existing.get(ApplicationHandlerHelper.INLINE_PREFIX_MARKER);
+      return prefix.equals(existingPrefix);
+    }
+
+    @Override
+    public boolean isInline() {
+      return true;
+    }
+  }
+}

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AttachmentContext.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/common/AttachmentContext.java
@@ -82,8 +82,7 @@ public sealed interface AttachmentContext {
 
     @Override
     public boolean matches(Attachments existing, Map<String, Object> parentKeys) {
-      String existingPrefix =
-          (String) existing.get(ApplicationHandlerHelper.INLINE_PREFIX_MARKER);
+      String existingPrefix = (String) existing.get(ApplicationHandlerHelper.INLINE_PREFIX_MARKER);
       return prefix.equals(existingPrefix);
     }
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
@@ -17,7 +17,6 @@ import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.cqn.CqnDelete;
 import com.sap.cds.ql.cqn.Path;
-import com.sap.cds.reflect.CdsElement;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.reflect.CdsStructuredType;
 import com.sap.cds.services.draft.DraftCancelEventContext;
@@ -104,8 +103,7 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
   private Validator buildDeleteContentValidator(
       DraftCancelEventContext context, List<? extends CdsData> activeCondensedAttachments) {
     return (path, element, value) -> {
-      AttachmentContext attachmentCtx =
-          AttachmentContext.from(path.target().type(), element);
+      AttachmentContext attachmentCtx = AttachmentContext.from(path.target().type(), element);
       Attachments attachment = extractAttachmentFromPath(path, attachmentCtx);
 
       if (Boolean.FALSE.equals(attachment.get(Drafts.HAS_ACTIVE_ENTITY))) {
@@ -138,8 +136,7 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
     if (attachmentCtx.isInline()) {
       attachment =
           ApplicationHandlerHelper.extractInlineAttachment(
-              path.target().values(),
-              ((AttachmentContext.Inline) attachmentCtx).prefix());
+              path.target().values(), ((AttachmentContext.Inline) attachmentCtx).prefix());
       Object hasActiveEntity = path.target().values().get(Drafts.HAS_ACTIVE_ENTITY);
       if (hasActiveEntity != null) {
         attachment.put(Drafts.HAS_ACTIVE_ENTITY, hasActiveEntity);

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandler.java
@@ -12,6 +12,7 @@ import com.sap.cds.CdsDataProcessor.Validator;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.cqn.CqnDelete;
@@ -103,53 +104,42 @@ public class DraftCancelAttachmentsHandler implements EventHandler {
   private Validator buildDeleteContentValidator(
       DraftCancelEventContext context, List<? extends CdsData> activeCondensedAttachments) {
     return (path, element, value) -> {
-      Attachments attachment = extractAttachmentFromPath(path, element);
+      AttachmentContext attachmentCtx =
+          AttachmentContext.from(path.target().type(), element);
+      Attachments attachment = extractAttachmentFromPath(path, attachmentCtx);
 
       if (Boolean.FALSE.equals(attachment.get(Drafts.HAS_ACTIVE_ENTITY))) {
-        deleteEvent.processEvent(path, null, attachment, context);
+        deleteEvent.processEvent(path, null, attachment, context, attachmentCtx);
         return;
       }
 
-      Optional<String> inlinePrefix =
-          ApplicationHandlerHelper.getInlineAttachmentPrefix(
-              path.target().entity(), element.getName());
       Map<String, Object> keys = ApplicationHandlerHelper.removeDraftKey(path.target().keys());
       Optional<? extends CdsData> existingEntry =
           activeCondensedAttachments.stream()
-              .filter(
-                  updatedData -> {
-                    if (inlinePrefix.isPresent()) {
-                      return inlinePrefix
-                          .get()
-                          .equals(updatedData.get(ApplicationHandlerHelper.INLINE_PREFIX_MARKER));
-                    }
-                    return ApplicationHandlerHelper.areKeysInData(keys, updatedData);
-                  })
+              .filter(updatedData -> attachmentCtx.matches(Attachments.of(updatedData), keys))
               .findAny();
 
       if (existingEntry.isPresent()) {
         Object existingContentId = existingEntry.get().get(Attachments.CONTENT_ID);
         if (!Objects.equals(existingContentId, attachment.getContentId())) {
-          deleteEvent.processEvent(null, null, attachment, context);
+          deleteEvent.processEvent(null, null, attachment, context, attachmentCtx);
         }
       } else if (attachment.getContentId() != null) {
         logger.warn(
             "Draft attachment with contentId {} has no matching active entry. Deleting to prevent orphan.",
             attachment.getContentId());
-        deleteEvent.processEvent(null, null, attachment, context);
+        deleteEvent.processEvent(null, null, attachment, context, attachmentCtx);
       }
     };
   }
 
-  private Attachments extractAttachmentFromPath(Path path, CdsElement element) {
-    Optional<String> inlinePrefix =
-        ApplicationHandlerHelper.getInlineAttachmentPrefix(
-            path.target().entity(), element.getName());
+  private Attachments extractAttachmentFromPath(Path path, AttachmentContext attachmentCtx) {
     Attachments attachment;
-    if (inlinePrefix.isPresent()) {
+    if (attachmentCtx.isInline()) {
       attachment =
           ApplicationHandlerHelper.extractInlineAttachment(
-              path.target().values(), inlinePrefix.get());
+              path.target().values(),
+              ((AttachmentContext.Inline) attachmentCtx).prefix());
       Object hasActiveEntity = path.target().values().get(Drafts.HAS_ACTIVE_ENTITY);
       if (hasActiveEntity != null) {
         attachment.put(Drafts.HAS_ACTIVE_ENTITY, hasActiveEntity);

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandler.java
@@ -73,8 +73,7 @@ public class DraftPatchAttachmentsHandler implements EventHandler {
           CqnSelect select = Select.from(draftEntity).matching(path.target().keys());
           Result result = persistence.run(select);
 
-          AttachmentContext attachmentCtx =
-              AttachmentContext.from(path.target().type(), element);
+          AttachmentContext attachmentCtx = AttachmentContext.from(path.target().type(), element);
 
           List<Attachments> existingAttachments;
           if (attachmentCtx.isInline()) {

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandler.java
@@ -14,6 +14,7 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData
 import com.sap.cds.feature.attachments.handler.applicationservice.helper.ModifyApplicationHandlerHelper;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEventFactory;
 import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.Select;
 import com.sap.cds.ql.Update;
@@ -33,7 +34,6 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,22 +73,22 @@ public class DraftPatchAttachmentsHandler implements EventHandler {
           CqnSelect select = Select.from(draftEntity).matching(path.target().keys());
           Result result = persistence.run(select);
 
+          AttachmentContext attachmentCtx =
+              AttachmentContext.from(path.target().type(), element);
+
           List<Attachments> existingAttachments;
-          Optional<String> inlinePrefix =
-              ApplicationHandlerHelper.getInlineAttachmentPrefix(
-                  path.target().entity(), element.getName());
-          if (inlinePrefix.isPresent()) {
+          if (attachmentCtx.isInline()) {
             // For inline attachments, the DB result has flattened column names (e.g.
             // profileIcon_contentId).
             // Extract to unprefixed Attachments and carry over parent entity keys for matching.
+            String prefix = ((AttachmentContext.Inline) attachmentCtx).prefix();
             Map<String, Object> parentKeys = path.target().keys();
             existingAttachments =
                 result.listOf(Attachments.class).stream()
                     .map(
                         raw -> {
                           Attachments extracted =
-                              ApplicationHandlerHelper.extractInlineAttachment(
-                                  raw, inlinePrefix.get());
+                              ApplicationHandlerHelper.extractInlineAttachment(raw, prefix);
                           parentKeys.forEach(extracted::putIfAbsent);
                           return extracted;
                         })
@@ -97,17 +97,14 @@ public class DraftPatchAttachmentsHandler implements EventHandler {
             existingAttachments = result.listOf(Attachments.class);
           }
 
-          InputStream processedContent =
-              ModifyApplicationHandlerHelper.handleAttachmentForEntity(
-                  existingAttachments,
-                  eventFactory,
-                  context,
-                  path,
-                  (InputStream) value,
-                  defaultMaxSize,
-                  inlinePrefix);
-
-          return processedContent;
+          return ModifyApplicationHandlerHelper.handleAttachmentForEntity(
+              existingAttachments,
+              eventFactory,
+              context,
+              path,
+              (InputStream) value,
+              defaultMaxSize,
+              attachmentCtx);
         };
 
     CdsDataProcessor.create()

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/AttachmentsServiceImpl.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/AttachmentsServiceImpl.java
@@ -4,6 +4,7 @@
 package com.sap.cds.feature.attachments.service;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.service.model.service.AttachmentModificationResult;
 import com.sap.cds.feature.attachments.service.model.service.CreateAttachmentInput;
 import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
@@ -50,7 +51,10 @@ public class AttachmentsServiceImpl extends ServiceDelegator implements Attachme
     mediaData.setMimeType(input.mimeType());
     mediaData.setContent(input.content());
     createContext.setData(mediaData);
-    input.inlinePrefix().ifPresent(prefix -> createContext.put("attachment.inlinePrefix", prefix));
+    AttachmentContext ctx = input.attachmentContext();
+    if (ctx.isInline()) {
+      createContext.put("attachment.inlinePrefix", ((AttachmentContext.Inline) ctx).prefix());
+    }
 
     emit(createContext);
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/DefaultAttachmentsServiceHandler.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/DefaultAttachmentsServiceHandler.java
@@ -5,6 +5,7 @@ package com.sap.cds.feature.attachments.service.handler;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.StatusCode;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.handler.transaction.EndTransactionMalwareScanProvider;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
@@ -18,7 +19,6 @@ import com.sap.cds.services.handler.annotations.HandlerOrder;
 import com.sap.cds.services.handler.annotations.On;
 import com.sap.cds.services.handler.annotations.ServiceName;
 import java.util.Objects;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,10 +68,11 @@ public class DefaultAttachmentsServiceHandler implements EventHandler {
   @After
   void afterCreateAttachment(AttachmentCreateEventContext context) {
     String prefix = (String) context.get("attachment.inlinePrefix");
-    Optional<String> inlinePrefix = Optional.ofNullable(prefix);
+    AttachmentContext attachmentContext =
+        prefix != null ? new AttachmentContext.Inline(prefix) : new AttachmentContext.Composition();
     ChangeSetListener listener =
         malwareScanProvider.getChangeSetListener(
-            context.getAttachmentEntity(), context.getContentId(), inlinePrefix);
+            context.getAttachmentEntity(), context.getContentId(), attachmentContext);
     context.getChangeSetContext().register(listener);
   }
 

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/transaction/EndTransactionMalwareScanProvider.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/transaction/EndTransactionMalwareScanProvider.java
@@ -3,9 +3,9 @@
  */
 package com.sap.cds.feature.attachments.service.handler.transaction;
 
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.services.changeset.ChangeSetListener;
-import java.util.Optional;
 
 /**
  * This interface provides a {@link ChangeSetListener} for the malware scan after the transaction is
@@ -18,10 +18,9 @@ public interface EndTransactionMalwareScanProvider {
    *
    * @param attachmentEntity The entity containing the attachment to scan
    * @param contentId The ID of the attachment content
-   * @param inlinePrefix For inline attachments, the field name prefix; empty for composition-based
-   *     attachments
+   * @param attachmentContext The context describing how to address the attachment's fields
    * @return The {@link ChangeSetListener} for the malware scan after the transaction is completed
    */
   ChangeSetListener getChangeSetListener(
-      CdsEntity attachmentEntity, String contentId, Optional<String> inlinePrefix);
+      CdsEntity attachmentEntity, String contentId, AttachmentContext attachmentContext);
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/transaction/EndTransactionMalwareScanRunner.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/handler/transaction/EndTransactionMalwareScanRunner.java
@@ -3,6 +3,7 @@
  */
 package com.sap.cds.feature.attachments.service.handler.transaction;
 
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.service.malware.AsyncMalwareScanExecutor;
 import com.sap.cds.feature.attachments.service.malware.AttachmentMalwareScanner;
 import com.sap.cds.reflect.CdsEntity;
@@ -10,7 +11,6 @@ import com.sap.cds.services.changeset.ChangeSetListener;
 import com.sap.cds.services.runtime.CdsRuntime;
 import com.sap.cds.services.runtime.RequestContextRunner;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -23,14 +23,14 @@ import org.slf4j.LoggerFactory;
  *
  * @param attachmentEntity The attachment entity to be scanned
  * @param contentId The content ID of the attachment
- * @param inlinePrefix For inline attachments, the field name prefix; empty for composition-based
+ * @param attachmentContext The context describing how to address the attachment's fields
  * @param attachmentMalwareScanner The attachment malware scanner to be used for scanning
  * @param runtime The runtime instance to be used for creating the request context
  */
 public record EndTransactionMalwareScanRunner(
     CdsEntity attachmentEntity,
     String contentId,
-    Optional<String> inlinePrefix,
+    AttachmentContext attachmentContext,
     AttachmentMalwareScanner attachmentMalwareScanner,
     CdsRuntime runtime)
     implements ChangeSetListener, AsyncMalwareScanExecutor {
@@ -41,18 +41,18 @@ public record EndTransactionMalwareScanRunner(
   @Override
   public void afterClose(boolean completed) {
     if (completed) {
-      startScanning(attachmentEntity, contentId, inlinePrefix);
+      startScanning(attachmentEntity, contentId, attachmentContext);
     }
   }
 
   @Override
   public void scanAsync(
-      CdsEntity attachmentEntity, String contentId, Optional<String> inlinePrefix) {
-    startScanning(attachmentEntity, contentId, inlinePrefix);
+      CdsEntity attachmentEntity, String contentId, AttachmentContext attachmentContext) {
+    startScanning(attachmentEntity, contentId, attachmentContext);
   }
 
   private void startScanning(
-      CdsEntity attachmentEntityToScan, String contentId, Optional<String> prefix) {
+      CdsEntity attachmentEntityToScan, String contentId, AttachmentContext context) {
     // get current request context
     RequestContextRunner runner = runtime.requestContext();
 
@@ -76,7 +76,7 @@ public record EndTransactionMalwareScanRunner(
                               contentId,
                               attachmentEntityToScan.getQualifiedName());
                           attachmentMalwareScanner.scanAttachment(
-                              attachmentEntityToScan, contentId, prefix);
+                              attachmentEntityToScan, contentId, context);
                         });
               });
           return null;

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/AsyncMalwareScanExecutor.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/AsyncMalwareScanExecutor.java
@@ -3,8 +3,8 @@
  */
 package com.sap.cds.feature.attachments.service.malware;
 
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.reflect.CdsEntity;
-import java.util.Optional;
 
 /** Supports asynchronous malware scanning of attachments. */
 public interface AsyncMalwareScanExecutor {
@@ -14,8 +14,7 @@ public interface AsyncMalwareScanExecutor {
    *
    * @param attachmentEntity The entity containing the attachment to scan
    * @param contentId The content id of the attachment entity
-   * @param inlinePrefix For inline attachments, the field name prefix; empty for composition-based
-   *     attachments
+   * @param attachmentContext The context describing how to address the attachment's fields
    */
-  void scanAsync(CdsEntity attachmentEntity, String contentId, Optional<String> inlinePrefix);
+  void scanAsync(CdsEntity attachmentEntity, String contentId, AttachmentContext attachmentContext);
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/AttachmentMalwareScanner.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/AttachmentMalwareScanner.java
@@ -3,9 +3,9 @@
  */
 package com.sap.cds.feature.attachments.service.malware;
 
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.services.ServiceException;
-import java.util.Optional;
 
 /**
  * The {@link AttachmentMalwareScanner} is the connection to the malware scan service. It reads the
@@ -19,9 +19,9 @@ public interface AttachmentMalwareScanner {
    *
    * @param attachmentEntity The entity containing the attachment to scan
    * @param contentId The content id of the attachment entity
-   * @param inlinePrefix For inline attachments, the field name prefix (e.g. "profileIcon"); empty
-   *     for composition-based attachments
+   * @param attachmentContext The context describing how to address the attachment's fields
    * @throws ServiceException Exception to be thrown in case of errors during scanning the content
    */
-  void scanAttachment(CdsEntity attachmentEntity, String contentId, Optional<String> inlinePrefix);
+  void scanAttachment(
+      CdsEntity attachmentEntity, String contentId, AttachmentContext attachmentContext);
 }

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/DefaultAttachmentMalwareScanner.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/malware/DefaultAttachmentMalwareScanner.java
@@ -9,7 +9,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.sap.cds.Result;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.StatusCode;
-import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.client.MalwareScanClient;
 import com.sap.cds.feature.attachments.service.malware.client.MalwareScanResultStatus;
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,16 +71,17 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
 
   @Override
   public void scanAttachment(
-      CdsEntity attachmentEntity, String contentId, Optional<String> inlinePrefix) {
+      CdsEntity attachmentEntity, String contentId, AttachmentContext attachmentContext) {
     logger.debug(
         "Started scanning attachment {} of entity {}.",
         contentId,
         attachmentEntity.getQualifiedName());
 
-    List<SelectionResult> selectionResults = selectData(attachmentEntity, contentId, inlinePrefix);
+    List<SelectionResult> selectionResults =
+        selectData(attachmentEntity, contentId, attachmentContext);
 
     MalwareScanResultStatus status =
-        findAndScanAttachments(selectionResults, contentId, inlinePrefix);
+        findAndScanAttachments(selectionResults, contentId, attachmentContext);
 
     if (status == null) {
       logger.debug("Attachment {} not found in any entity, skipping update.", contentId);
@@ -92,18 +92,21 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
     // even if the attachment moved between draft and active tables during the scan.
     for (SelectionResult selectionResult : selectionResults) {
       Map<String, Object> keys = extractKeys(selectionResult.result(), selectionResult.entity());
-      updateData(selectionResult.entity(), contentId, status, inlinePrefix, keys);
+      updateData(selectionResult.entity(), contentId, status, attachmentContext, keys);
     }
   }
 
   private MalwareScanResultStatus findAndScanAttachments(
-      List<SelectionResult> selectionResults, String contentId, Optional<String> inlinePrefix) {
+      List<SelectionResult> selectionResults,
+      String contentId,
+      AttachmentContext attachmentContext) {
     return selectionResults.stream()
         .filter(result -> validateAndFilter(result, contentId))
         .findFirst()
         .map(
             result ->
-                scanDocument(extractAttachment(result.result(), inlinePrefix), result.entity()))
+                scanDocument(
+                    extractAttachment(result.result(), attachmentContext), result.entity()))
         .orElse(null);
   }
 
@@ -129,11 +132,11 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
     return true;
   }
 
-  private Attachments extractAttachment(Result queryResult, Optional<String> inlinePrefix) {
-    if (inlinePrefix.isEmpty()) {
+  private Attachments extractAttachment(Result queryResult, AttachmentContext attachmentContext) {
+    if (!attachmentContext.isInline()) {
       return queryResult.single(Attachments.class);
     }
-    String prefix = inlinePrefix.get() + "_";
+    String prefix = ((AttachmentContext.Inline) attachmentContext).prefix() + "_";
     var row = queryResult.single();
     Attachments attachment = Attachments.create();
     attachment.setContentId((String) row.get(prefix + Attachments.CONTENT_ID));
@@ -143,16 +146,16 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
   }
 
   private List<SelectionResult> selectData(
-      CdsEntity attachmentEntity, String contentId, Optional<String> inlinePrefix) {
+      CdsEntity attachmentEntity, String contentId, AttachmentContext attachmentContext) {
     List<SelectionResult> result = new ArrayList<>();
     try {
       CdsEntity entity = (CdsEntity) attachmentEntity.getTargetOf(Drafts.SIBLING_ENTITY);
-      Result selectionResult = readData(contentId, entity, inlinePrefix);
+      Result selectionResult = readData(contentId, entity, attachmentContext);
       result.add(new SelectionResult(entity, selectionResult));
     } catch (CdsElementNotFoundException ignored) {
       // no sibling found nothing to select
     }
-    Result selectionResult = readData(contentId, attachmentEntity, inlinePrefix);
+    Result selectionResult = readData(contentId, attachmentEntity, attachmentContext);
     result.add(new SelectionResult(attachmentEntity, selectionResult));
 
     return result;
@@ -177,12 +180,10 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
     return keys;
   }
 
-  private Result readData(String contentId, CdsEntity entity, Optional<String> inlinePrefix) {
-    String contentIdCol =
-        ApplicationHandlerHelper.resolveFieldName(Attachments.CONTENT_ID, inlinePrefix);
-    String contentCol =
-        ApplicationHandlerHelper.resolveFieldName(Attachments.CONTENT, inlinePrefix);
-    String statusCol = ApplicationHandlerHelper.resolveFieldName(Attachments.STATUS, inlinePrefix);
+  private Result readData(String contentId, CdsEntity entity, AttachmentContext attachmentContext) {
+    String contentIdCol = attachmentContext.fieldName(Attachments.CONTENT_ID);
+    String contentCol = attachmentContext.fieldName(Attachments.CONTENT);
+    String statusCol = attachmentContext.fieldName(Attachments.STATUS);
 
     List<String> columns = new ArrayList<>();
     columns.add(contentIdCol);
@@ -233,13 +234,11 @@ public class DefaultAttachmentMalwareScanner implements AttachmentMalwareScanner
       CdsEntity attachmentEntity,
       String contentId,
       MalwareScanResultStatus status,
-      Optional<String> inlinePrefix,
+      AttachmentContext attachmentContext,
       Map<String, Object> entityKeys) {
-    String contentIdCol =
-        ApplicationHandlerHelper.resolveFieldName(Attachments.CONTENT_ID, inlinePrefix);
-    String statusCol = ApplicationHandlerHelper.resolveFieldName(Attachments.STATUS, inlinePrefix);
-    String scannedAtCol =
-        ApplicationHandlerHelper.resolveFieldName(Attachments.SCANNED_AT, inlinePrefix);
+    String contentIdCol = attachmentContext.fieldName(Attachments.CONTENT_ID);
+    String statusCol = attachmentContext.fieldName(Attachments.STATUS);
+    String scannedAtCol = attachmentContext.fieldName(Attachments.SCANNED_AT);
 
     String mappedStatus = mapStatus(status);
     Instant scannedAt = Instant.now();

--- a/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/model/service/CreateAttachmentInput.java
+++ b/cds-feature-attachments/src/main/java/com/sap/cds/feature/attachments/service/model/service/CreateAttachmentInput.java
@@ -3,10 +3,10 @@
  */
 package com.sap.cds.feature.attachments.service.model.service;
 
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.reflect.CdsEntity;
 import java.io.InputStream;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * The class {@link CreateAttachmentInput} is used to store the input for creating an attachment.
@@ -16,7 +16,7 @@ import java.util.Optional;
  * @param fileName The file name of the content
  * @param mimeType The mime type of the content
  * @param content The input stream of the content
- * @param inlinePrefix For inline attachments, the field name prefix; empty for composition-based
+ * @param attachmentContext The context describing how to address this attachment's fields
  */
 public record CreateAttachmentInput(
     Map<String, Object> attachmentIds,
@@ -24,4 +24,4 @@ public record CreateAttachmentInput(
     String fileName,
     String mimeType,
     InputStream content,
-    Optional<String> inlinePrefix) {}
+    AttachmentContext attachmentContext) {}

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/CreateAttachmentsHandlerTest.java
@@ -219,7 +219,7 @@ class CreateAttachmentsHandlerTest {
     attachment.setFileName("test.txt");
     attachment.setContent(null);
     when(eventFactory.getEvent(any(), any(), any())).thenReturn(event);
-    when(event.processEvent(any(), any(), any(), any())).thenThrow(new ServiceException(""));
+    when(event.processEvent(any(), any(), any(), any(), any())).thenThrow(new ServiceException(""));
 
     List<CdsData> input = List.of(attachment);
     assertThrows(ServiceException.class, () -> cut.processBefore(createContext, input));

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/DeleteAttachmentsHandlerTest.java
@@ -18,6 +18,7 @@ import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Roots_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.ql.cqn.Path;
@@ -80,7 +81,8 @@ class DeleteAttachmentsHandlerTest {
 
     cut.processBefore(context);
 
-    verify(modifyAttachmentEvent).processEvent(any(), eq(inputStream), eq(data), eq(context));
+    verify(modifyAttachmentEvent)
+        .processEvent(any(), eq(inputStream), eq(data), eq(context), any(AttachmentContext.class));
     assertThat(data.getContent()).isNull();
   }
 
@@ -104,10 +106,18 @@ class DeleteAttachmentsHandlerTest {
 
     verify(modifyAttachmentEvent)
         .processEvent(
-            any(Path.class), eq(inputStream), eq(Attachments.of(attachment1)), eq(context));
+            any(Path.class),
+            eq(inputStream),
+            eq(Attachments.of(attachment1)),
+            eq(context),
+            any(AttachmentContext.class));
     verify(modifyAttachmentEvent)
         .processEvent(
-            any(Path.class), eq(inputStream), eq(Attachments.of(attachment2)), eq(context));
+            any(Path.class),
+            eq(inputStream),
+            eq(Attachments.of(attachment2)),
+            eq(context),
+            any(AttachmentContext.class));
     assertThat(attachment1.getContent()).isNull();
     assertThat(attachment2.getContent()).isNull();
   }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/ReadAttachmentsHandlerTest.java
@@ -27,6 +27,7 @@ import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.Att
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.AttachmentStatusValidator;
 import com.sap.cds.feature.attachments.handler.applicationservice.readhelper.LazyProxyInputStream;
 import com.sap.cds.feature.attachments.handler.common.AssociationCascader;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.AsyncMalwareScanExecutor;
@@ -42,7 +43,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -232,7 +232,10 @@ class ReadAttachmentsHandlerTest {
     cut.processAfter(readEventContext, List.of(attachment));
 
     verify(asyncMalwareScanExecutor)
-        .scanAsync(readEventContext.getTarget(), attachment.getContentId(), Optional.empty());
+        .scanAsync(
+            readEventContext.getTarget(),
+            attachment.getContentId(),
+            new AttachmentContext.Composition());
   }
 
   @Test
@@ -246,7 +249,10 @@ class ReadAttachmentsHandlerTest {
     cut.processAfter(readEventContext, List.of(attachment));
 
     verify(asyncMalwareScanExecutor)
-        .scanAsync(readEventContext.getTarget(), attachment.getContentId(), Optional.empty());
+        .scanAsync(
+            readEventContext.getTarget(),
+            attachment.getContentId(),
+            new AttachmentContext.Composition());
   }
 
   @Test
@@ -280,7 +286,10 @@ class ReadAttachmentsHandlerTest {
 
     verify(persistenceService).run(any(com.sap.cds.ql.cqn.CqnUpdate.class));
     verify(asyncMalwareScanExecutor)
-        .scanAsync(readEventContext.getTarget(), attachment.getContentId(), Optional.empty());
+        .scanAsync(
+            readEventContext.getTarget(),
+            attachment.getContentId(),
+            new AttachmentContext.Composition());
     assertThat(attachment.getStatus()).isEqualTo(StatusCode.SCANNING);
   }
 
@@ -302,7 +311,10 @@ class ReadAttachmentsHandlerTest {
 
     verify(persistenceService).run(any(com.sap.cds.ql.cqn.CqnUpdate.class));
     verify(asyncMalwareScanExecutor)
-        .scanAsync(readEventContext.getTarget(), attachment.getContentId(), Optional.empty());
+        .scanAsync(
+            readEventContext.getTarget(),
+            attachment.getContentId(),
+            new AttachmentContext.Composition());
     assertThat(attachment.getStatus()).isEqualTo(StatusCode.SCANNING);
   }
 
@@ -349,7 +361,10 @@ class ReadAttachmentsHandlerTest {
     cut.processAfter(readEventContext, List.of(attachment));
 
     verify(asyncMalwareScanExecutor)
-        .scanAsync(readEventContext.getTarget(), attachment.getContentId(), Optional.empty());
+        .scanAsync(
+            readEventContext.getTarget(),
+            attachment.getContentId(),
+            new AttachmentContext.Composition());
     verify(attachmentStatusValidator).verifyStatus(StatusCode.UNSCANNED);
     verifyNoInteractions(persistenceService);
   }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/UpdateAttachmentsHandlerTest.java
@@ -247,7 +247,7 @@ class UpdateAttachmentsHandlerTest {
     attachment.setFileName("test.txt");
     attachment.setContent(null);
     attachment.setId(id);
-    when(event.processEvent(any(), any(), any(), any())).thenThrow(new ServiceException(""));
+    when(event.processEvent(any(), any(), any(), any(), any())).thenThrow(new ServiceException(""));
     when(attachmentsReader.readAttachments(any(), any(), any(CqnFilterableStatement.class)))
         .thenReturn(List.of(attachment));
 
@@ -284,7 +284,11 @@ class UpdateAttachmentsHandlerTest {
     ArgumentCaptor<InputStream> eventStreamCaptor = ArgumentCaptor.forClass(InputStream.class);
     verify(event)
         .processEvent(
-            any(), eventStreamCaptor.capture(), cdsDataArgumentCaptor.capture(), eq(updateContext));
+            any(),
+            eventStreamCaptor.capture(),
+            cdsDataArgumentCaptor.capture(),
+            eq(updateContext),
+            any());
     InputStream eventCaptured = eventStreamCaptor.getValue();
     assertThat(eventCaptured).isInstanceOf(CountingInputStream.class);
     assertThat(((CountingInputStream) eventCaptured).getDelegate()).isSameAs(testStream);

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelperTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ModifyApplicationHandlerHelperTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEvent;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.ModifyAttachmentEventFactory;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.ql.cqn.ResolvedSegment;
@@ -26,7 +27,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,7 +94,7 @@ class ModifyApplicationHandlerHelperTest {
                     path,
                     attachment.getContent(),
                     ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER,
-                    Optional.empty()));
+                    new AttachmentContext.Composition()));
 
     assertThat(exception.getErrorStatus()).isEqualTo(ExtendedErrorStatuses.CONTENT_TOO_LARGE);
   }
@@ -121,7 +121,7 @@ class ModifyApplicationHandlerHelperTest {
     when(parameterInfo.getHeader("Content-Length")).thenReturn(null);
 
     // Make event.processEvent() read from the stream, triggering the limit check
-    when(event.processEvent(any(), any(), any(), any()))
+    when(event.processEvent(any(), any(), any(), any(), any()))
         .thenAnswer(
             invocation -> {
               InputStream wrappedContent = invocation.getArgument(1);
@@ -149,7 +149,7 @@ class ModifyApplicationHandlerHelperTest {
                     path,
                     content,
                     ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER,
-                    Optional.empty()));
+                    new AttachmentContext.Composition()));
 
     assertThat(exception.getErrorStatus()).isEqualTo(ExtendedErrorStatuses.CONTENT_TOO_LARGE);
   }
@@ -182,7 +182,7 @@ class ModifyApplicationHandlerHelperTest {
                 path,
                 content,
                 ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER,
-                Optional.empty()));
+                new AttachmentContext.Composition()));
   }
 
   @Test
@@ -215,7 +215,7 @@ class ModifyApplicationHandlerHelperTest {
                     path,
                     content,
                     ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER,
-                    Optional.empty()));
+                    new AttachmentContext.Composition()));
 
     assertThat(exception.getErrorStatus()).isEqualTo(ErrorStatuses.BAD_REQUEST);
   }
@@ -249,7 +249,7 @@ class ModifyApplicationHandlerHelperTest {
                     path,
                     (InputStream) data.get("avatar_content"),
                     ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER,
-                    Optional.of("avatar")));
+                    new AttachmentContext.Inline("avatar")));
 
     assertThat(exception.getErrorStatus()).isEqualTo(ExtendedErrorStatuses.CONTENT_TOO_LARGE);
   }
@@ -282,7 +282,7 @@ class ModifyApplicationHandlerHelperTest {
                 path,
                 content,
                 ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER,
-                Optional.of("avatar")));
+                new AttachmentContext.Inline("avatar")));
   }
 
   @Test
@@ -302,7 +302,7 @@ class ModifyApplicationHandlerHelperTest {
     when(target.keys()).thenReturn(Map.of("ID", data.getId()));
     when(parameterInfo.getHeader("Content-Length")).thenReturn(null);
 
-    when(event.processEvent(any(), any(), any(), any()))
+    when(event.processEvent(any(), any(), any(), any(), any()))
         .thenAnswer(
             invocation -> {
               InputStream wrappedContent = invocation.getArgument(1);
@@ -326,7 +326,7 @@ class ModifyApplicationHandlerHelperTest {
                     path,
                     content,
                     ModifyApplicationHandlerHelper.DEFAULT_SIZE_WITH_SCANNER,
-                    Optional.of("avatar")));
+                    new AttachmentContext.Inline("avatar")));
 
     assertThat(exception.getErrorStatus()).isEqualTo(ExtendedErrorStatuses.CONTENT_TOO_LARGE);
   }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/helper/ReadonlyDataContextEnhancerTest.java
@@ -11,6 +11,7 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Events_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.Attachment_;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.services.runtime.CdsRuntime;
@@ -86,7 +87,7 @@ class ReadonlyDataContextEnhancerTest {
     backup.setScannedAt(scannedAt);
     data.put(DRAFT_READONLY_CONTEXT, backup);
 
-    ReadonlyDataContextEnhancer.restoreReadonlyFields(data);
+    ReadonlyDataContextEnhancer.restoreReadonlyFields(data, new AttachmentContext.Composition());
 
     assertThat(data.get(Attachments.CONTENT_ID)).isEqualTo("cid-restored");
     assertThat(data.get(Attachments.STATUS)).isEqualTo("Scanning");
@@ -99,7 +100,7 @@ class ReadonlyDataContextEnhancerTest {
     CdsData data = CdsData.create();
     data.put("ID", "123");
 
-    ReadonlyDataContextEnhancer.restoreReadonlyFields(data);
+    ReadonlyDataContextEnhancer.restoreReadonlyFields(data, new AttachmentContext.Composition());
 
     assertThat(data.get("ID")).isEqualTo("123");
     assertThat(data).hasSize(1);
@@ -128,7 +129,7 @@ class ReadonlyDataContextEnhancerTest {
     // STATUS and SCANNED_AT intentionally absent from backup
     data.put(DRAFT_READONLY_CONTEXT, backup);
 
-    ReadonlyDataContextEnhancer.restoreReadonlyFields(data);
+    ReadonlyDataContextEnhancer.restoreReadonlyFields(data, new AttachmentContext.Composition());
 
     assertThat(data.get(Attachments.CONTENT_ID)).isEqualTo("restored-id");
     assertThat(data.get(Attachments.STATUS)).isNull();
@@ -180,7 +181,8 @@ class ReadonlyDataContextEnhancerTest {
     backup.setScannedAt(scannedAt);
     data.put("profilePicture_" + DRAFT_READONLY_CONTEXT, backup);
 
-    ReadonlyDataContextEnhancer.restoreReadonlyFields(data);
+    ReadonlyDataContextEnhancer.restoreReadonlyFields(
+        data, new AttachmentContext.Inline("profilePicture"));
 
     assertThat(data.get("profilePicture_contentId")).isEqualTo("inline-restored-cid");
     assertThat(data.get("profilePicture_status")).isEqualTo("Scanning");
@@ -197,7 +199,8 @@ class ReadonlyDataContextEnhancerTest {
     backup.setFileName("preserved-file.pdf");
     data.put("profilePicture_" + DRAFT_READONLY_CONTEXT, backup);
 
-    ReadonlyDataContextEnhancer.restoreReadonlyFields(data);
+    ReadonlyDataContextEnhancer.restoreReadonlyFields(
+        data, new AttachmentContext.Inline("profilePicture"));
 
     assertThat(data.get("profilePicture_contentId")).isEqualTo("inline-cid");
     assertThat(data.get("profilePicture_fileName")).isEqualTo("preserved-file.pdf");

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEventTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/CreateAttachmentEventTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
 import com.sap.cds.feature.attachments.handler.applicationservice.transaction.ListenerProvider;
-import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.model.service.AttachmentModificationResult;
 import com.sap.cds.feature.attachments.service.model.service.CreateAttachmentInput;
@@ -104,7 +104,12 @@ class CreateAttachmentEventTest {
     existingData.setFileName("some file name");
     existingData.setMimeType("some mime type");
 
-    cut.processEvent(path, attachment.getContent(), existingData, eventContext);
+    cut.processEvent(
+        path,
+        attachment.getContent(),
+        existingData,
+        eventContext,
+        new AttachmentContext.Composition());
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     var createInput = contextArgumentCaptor.getValue();
@@ -127,7 +132,12 @@ class CreateAttachmentEventTest {
     when(attachmentService.createAttachment(any())).thenReturn(attachmentServiceResult);
     when(target.values()).thenReturn(attachment);
 
-    cut.processEvent(path, attachment.getContent(), Attachments.create(), eventContext);
+    cut.processEvent(
+        path,
+        attachment.getContent(),
+        Attachments.create(),
+        eventContext,
+        new AttachmentContext.Composition());
 
     assertThat(attachment.getContentId()).isEqualTo(attachmentServiceResult.contentId());
     assertThat(attachment.getStatus()).isEqualTo(attachmentServiceResult.status());
@@ -143,7 +153,8 @@ class CreateAttachmentEventTest {
     when(attachmentService.createAttachment(any()))
         .thenReturn(new AttachmentModificationResult(false, contentId, "test", null));
 
-    cut.processEvent(path, null, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     verify(changeSetContext).register(listener);
   }
@@ -164,7 +175,12 @@ class CreateAttachmentEventTest {
         .thenReturn(new AttachmentModificationResult(isExternalStored, "id", "test", null));
 
     var result =
-        cut.processEvent(path, attachment.getContent(), Attachments.create(), eventContext);
+        cut.processEvent(
+            path,
+            attachment.getContent(),
+            Attachments.create(),
+            eventContext,
+            new AttachmentContext.Composition());
 
     var expectedContent = isExternalStored ? attachment.getContent() : null;
     assertThat(result).isEqualTo(expectedContent);
@@ -183,7 +199,12 @@ class CreateAttachmentEventTest {
     when(attachmentService.createAttachment(any()))
         .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
 
-    cut.processEvent(path, attachment.getContent(), Attachments.create(), eventContext);
+    cut.processEvent(
+        path,
+        attachment.getContent(),
+        Attachments.create(),
+        eventContext,
+        new AttachmentContext.Composition());
     return attachment;
   }
 
@@ -198,7 +219,8 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("Content-Disposition"))
         .thenReturn("attachment; filename*=UTF-8''my%20file%20name.pdf");
 
-    cut.processEvent(path, null, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     assertThat(contextArgumentCaptor.getValue().fileName()).isEqualTo("my file name.pdf");
@@ -216,7 +238,8 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("Content-Disposition"))
         .thenReturn("attachment; filename*=UTF-8''my%20file.pdf; size=1234");
 
-    cut.processEvent(path, null, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     assertThat(contextArgumentCaptor.getValue().fileName()).isEqualTo("my file.pdf");
@@ -234,7 +257,8 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("Content-Disposition"))
         .thenReturn("attachment; filename=\"report.pdf\"");
 
-    cut.processEvent(path, null, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     assertThat(contextArgumentCaptor.getValue().fileName()).isEqualTo("report.pdf");
@@ -251,7 +275,8 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("Content-Disposition"))
         .thenReturn("attachment; filename=report.pdf");
 
-    cut.processEvent(path, null, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     assertThat(contextArgumentCaptor.getValue().fileName()).isEqualTo("report.pdf");
@@ -268,7 +293,8 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("Content-Disposition")).thenReturn(null);
     when(parameterInfo.getHeader("slug")).thenReturn("document.docx");
 
-    cut.processEvent(path, null, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     assertThat(contextArgumentCaptor.getValue().fileName()).isEqualTo("document.docx");
@@ -286,7 +312,8 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("Content-Disposition"))
         .thenReturn("attachment; filename=\"header-name.pdf\"");
 
-    cut.processEvent(path, null, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     assertThat(contextArgumentCaptor.getValue().fileName()).isEqualTo("payload-name.pdf");
@@ -302,7 +329,8 @@ class CreateAttachmentEventTest {
         .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
     when(parameterInfo.getHeader("Content-Type")).thenReturn("image/jpeg; charset=utf-8");
 
-    cut.processEvent(path, null, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     assertThat(contextArgumentCaptor.getValue().mimeType()).isEqualTo("image/jpeg");
@@ -320,7 +348,8 @@ class CreateAttachmentEventTest {
         .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
     when(parameterInfo.getHeader("Content-Type")).thenReturn("application/pdf");
 
-    cut.processEvent(path, null, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     assertThat(contextArgumentCaptor.getValue().mimeType()).isEqualTo("text/plain");
@@ -337,7 +366,8 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("Content-Disposition")).thenReturn("inline");
     when(parameterInfo.getHeader("slug")).thenReturn(null);
 
-    cut.processEvent(path, null, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     assertThat(contextArgumentCaptor.getValue().fileName()).isNull();
@@ -353,7 +383,8 @@ class CreateAttachmentEventTest {
         .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
     when(parameterInfo.getHeader("Content-Type")).thenReturn("text/csv");
 
-    cut.processEvent(path, null, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     assertThat(contextArgumentCaptor.getValue().mimeType()).isEqualTo("text/csv");
@@ -369,7 +400,8 @@ class CreateAttachmentEventTest {
         .thenReturn(new AttachmentModificationResult(false, "id", "test", null));
     when(eventContext.getParameterInfo()).thenReturn(null);
 
-    cut.processEvent(path, null, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, null, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     assertThat(contextArgumentCaptor.getValue().fileName()).isNull();
@@ -393,7 +425,12 @@ class CreateAttachmentEventTest {
     when(attachmentService.createAttachment(any()))
         .thenReturn(new AttachmentModificationResult(false, "doc-123", "Clean", null));
 
-    cut.processEvent(path, content, inlineAttachment("profilePicture"), eventContext);
+    cut.processEvent(
+        path,
+        content,
+        inlineAttachment("profilePicture"),
+        eventContext,
+        new AttachmentContext.Inline("profilePicture"));
 
     assertThat(values).containsEntry("profilePicture_contentId", "doc-123");
     assertThat(values).containsEntry("profilePicture_status", "Clean");
@@ -414,7 +451,12 @@ class CreateAttachmentEventTest {
     when(attachmentService.createAttachment(any()))
         .thenReturn(new AttachmentModificationResult(false, "id", "ok", null));
 
-    cut.processEvent(path, content, inlineAttachment("profilePicture"), eventContext);
+    cut.processEvent(
+        path,
+        content,
+        inlineAttachment("profilePicture"),
+        eventContext,
+        new AttachmentContext.Inline("profilePicture"));
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     var input = contextArgumentCaptor.getValue();
@@ -439,9 +481,10 @@ class CreateAttachmentEventTest {
     var existingData = Attachments.create();
     existingData.setFileName("fallback.txt");
     existingData.setMimeType("text/plain");
-    existingData.put(ApplicationHandlerHelper.INLINE_PREFIX_MARKER, "profilePicture");
+    existingData.put("_inlinePrefix", "profilePicture");
 
-    cut.processEvent(path, content, existingData, eventContext);
+    cut.processEvent(
+        path, content, existingData, eventContext, new AttachmentContext.Inline("profilePicture"));
 
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
     var input = contextArgumentCaptor.getValue();
@@ -464,7 +507,8 @@ class CreateAttachmentEventTest {
     when(attachmentService.createAttachment(any()))
         .thenReturn(new AttachmentModificationResult(false, "doc-999", "ok", null));
 
-    cut.processEvent(path, content, Attachments.create(), eventContext);
+    cut.processEvent(
+        path, content, Attachments.create(), eventContext, new AttachmentContext.Composition());
 
     assertThat(values).containsEntry(Attachments.CONTENT_ID, "doc-999");
     assertThat(values).containsEntry(Attachments.STATUS, "ok");
@@ -486,7 +530,12 @@ class CreateAttachmentEventTest {
     when(attachmentService.createAttachment(any()))
         .thenReturn(new AttachmentModificationResult(false, "doc-scan", "Clean", scannedAt));
 
-    cut.processEvent(path, content, inlineAttachment("profilePicture"), eventContext);
+    cut.processEvent(
+        path,
+        content,
+        inlineAttachment("profilePicture"),
+        eventContext,
+        new AttachmentContext.Inline("profilePicture"));
 
     assertThat(values).containsEntry("profilePicture_contentId", "doc-scan");
     assertThat(values).containsEntry("profilePicture_status", "Clean");
@@ -514,7 +563,11 @@ class CreateAttachmentEventTest {
         .thenReturn("attachment; filename*=UTF-8''my%20file.txt");
 
     cut.processEvent(
-        path, mock(InputStream.class), inlineAttachment("profilePicture"), eventContext);
+        path,
+        mock(InputStream.class),
+        inlineAttachment("profilePicture"),
+        eventContext,
+        new AttachmentContext.Inline("profilePicture"));
 
     assertThat(values).containsEntry("profilePicture_fileName", "my file.txt");
     assertThat(values).doesNotContainKey(MediaData.FILE_NAME);
@@ -529,7 +582,11 @@ class CreateAttachmentEventTest {
         .thenReturn("attachment; filename=\"report.pdf\"");
 
     cut.processEvent(
-        path, mock(InputStream.class), inlineAttachment("profilePicture"), eventContext);
+        path,
+        mock(InputStream.class),
+        inlineAttachment("profilePicture"),
+        eventContext,
+        new AttachmentContext.Inline("profilePicture"));
 
     assertThat(values).containsEntry("profilePicture_fileName", "report.pdf");
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
@@ -543,7 +600,11 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("slug")).thenReturn("slug-file.png");
 
     cut.processEvent(
-        path, mock(InputStream.class), inlineAttachment("profilePicture"), eventContext);
+        path,
+        mock(InputStream.class),
+        inlineAttachment("profilePicture"),
+        eventContext,
+        new AttachmentContext.Inline("profilePicture"));
 
     assertThat(values).containsEntry("profilePicture_fileName", "slug-file.png");
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
@@ -557,7 +618,11 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("slug")).thenReturn(null);
 
     cut.processEvent(
-        path, mock(InputStream.class), inlineAttachment("profilePicture"), eventContext);
+        path,
+        mock(InputStream.class),
+        inlineAttachment("profilePicture"),
+        eventContext,
+        new AttachmentContext.Inline("profilePicture"));
 
     assertThat(values).doesNotContainKey("profilePicture_fileName");
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
@@ -570,7 +635,11 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("Content-Type")).thenReturn("image/jpeg; charset=utf-8");
 
     cut.processEvent(
-        path, mock(InputStream.class), inlineAttachment("profilePicture"), eventContext);
+        path,
+        mock(InputStream.class),
+        inlineAttachment("profilePicture"),
+        eventContext,
+        new AttachmentContext.Inline("profilePicture"));
 
     assertThat(values).containsEntry("profilePicture_mimeType", "image/jpeg");
     assertThat(values).doesNotContainKey(MediaData.MIME_TYPE);
@@ -585,7 +654,11 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("Content-Type")).thenReturn("image/png");
 
     cut.processEvent(
-        path, mock(InputStream.class), inlineAttachment("profilePicture"), eventContext);
+        path,
+        mock(InputStream.class),
+        inlineAttachment("profilePicture"),
+        eventContext,
+        new AttachmentContext.Inline("profilePicture"));
 
     assertThat(values).containsEntry("profilePicture_mimeType", "application/octet-stream");
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
@@ -598,7 +671,11 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("Content-Type")).thenReturn(null);
 
     cut.processEvent(
-        path, mock(InputStream.class), inlineAttachment("profilePicture"), eventContext);
+        path,
+        mock(InputStream.class),
+        inlineAttachment("profilePicture"),
+        eventContext,
+        new AttachmentContext.Inline("profilePicture"));
 
     assertThat(values).doesNotContainKey("profilePicture_mimeType");
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
@@ -611,7 +688,11 @@ class CreateAttachmentEventTest {
     when(parameterInfo.getHeader("Content-Type")).thenReturn("application/octet-stream");
 
     cut.processEvent(
-        path, mock(InputStream.class), inlineAttachment("profilePicture"), eventContext);
+        path,
+        mock(InputStream.class),
+        inlineAttachment("profilePicture"),
+        eventContext,
+        new AttachmentContext.Inline("profilePicture"));
 
     assertThat(values).containsEntry("profilePicture_mimeType", "application/octet-stream");
     verify(attachmentService).createAttachment(contextArgumentCaptor.capture());
@@ -624,7 +705,11 @@ class CreateAttachmentEventTest {
     values.put("profilePicture_fileName", "already-set.pdf");
 
     cut.processEvent(
-        path, mock(InputStream.class), inlineAttachment("profilePicture"), eventContext);
+        path,
+        mock(InputStream.class),
+        inlineAttachment("profilePicture"),
+        eventContext,
+        new AttachmentContext.Inline("profilePicture"));
 
     verify(parameterInfo, never()).getHeader("Content-Disposition");
     assertThat(values).containsEntry("profilePicture_fileName", "already-set.pdf");
@@ -632,7 +717,7 @@ class CreateAttachmentEventTest {
 
   private static Attachments inlineAttachment(String prefix) {
     Attachments attachment = Attachments.create();
-    attachment.put(ApplicationHandlerHelper.INLINE_PREFIX_MARKER, prefix);
+    attachment.put("_inlinePrefix", prefix);
     return attachment;
   }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/DoNothingAttachmentEventTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/DoNothingAttachmentEventTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.ql.cqn.ResolvedSegment;
 import com.sap.cds.reflect.CdsElement;
@@ -49,7 +50,9 @@ class DoNothingAttachmentEventTest {
     when(target.entity()).thenReturn(entity);
     when(entity.getQualifiedName()).thenReturn("some.qualified.name");
 
-    var result = cut.processEvent(path, streamInput, data, mock(EventContext.class));
+    var result =
+        cut.processEvent(
+            path, streamInput, data, mock(EventContext.class), new AttachmentContext.Composition());
 
     assertThat(result).isEqualTo(streamInput);
     verifyNoInteractions(element, data);

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/MarkAsDeletedAttachmentEventTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/MarkAsDeletedAttachmentEventTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.when;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
-import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
@@ -69,7 +69,8 @@ class MarkAsDeletedAttachmentEventTest {
     var data = Attachments.create();
     data.setContentId(contentId);
 
-    var expectedValue = cut.processEvent(path, value, data, context);
+    var expectedValue =
+        cut.processEvent(path, value, data, context, new AttachmentContext.Composition());
 
     assertThat(expectedValue).isEqualTo(value);
     assertThat(data.getContentId()).isEqualTo(contentId);
@@ -90,7 +91,8 @@ class MarkAsDeletedAttachmentEventTest {
     var value = new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8));
     var data = Attachments.create();
 
-    var expectedValue = cut.processEvent(path, value, data, context);
+    var expectedValue =
+        cut.processEvent(path, value, data, context, new AttachmentContext.Composition());
 
     assertThat(expectedValue).isEqualTo(value);
     assertThat(data.getContentId()).isNull();
@@ -109,7 +111,8 @@ class MarkAsDeletedAttachmentEventTest {
     data.setContentId(contentId);
     when(context.getEvent()).thenReturn(DraftService.EVENT_DRAFT_PATCH);
 
-    var expectedValue = cut.processEvent(path, value, data, context);
+    var expectedValue =
+        cut.processEvent(path, value, data, context, new AttachmentContext.Composition());
 
     assertThat(expectedValue).isEqualTo(value);
     assertThat(data.getContentId()).isEqualTo(contentId);
@@ -127,7 +130,8 @@ class MarkAsDeletedAttachmentEventTest {
     var data = Attachments.create();
     data.setContentId(contentId);
 
-    var expectedValue = cut.processEvent(null, value, data, context);
+    var expectedValue =
+        cut.processEvent(null, value, data, context, new AttachmentContext.Composition());
 
     assertThat(expectedValue).isEqualTo(value);
     // Attachment service should still be called to mark as deleted
@@ -148,7 +152,8 @@ class MarkAsDeletedAttachmentEventTest {
     // Set a different contentId in the path values
     currentData.put(Attachments.CONTENT_ID, newContentId);
 
-    var expectedValue = cut.processEvent(path, value, data, context);
+    var expectedValue =
+        cut.processEvent(path, value, data, context, new AttachmentContext.Composition());
 
     assertThat(expectedValue).isEqualTo(value);
     // Attachment service should be called to mark old content as deleted
@@ -179,10 +184,10 @@ class MarkAsDeletedAttachmentEventTest {
 
     var data = Attachments.create();
     data.setContentId("old-content-id");
-    data.put(ApplicationHandlerHelper.INLINE_PREFIX_MARKER, "profilePicture");
+    data.put("_inlinePrefix", "profilePicture");
     when(context.getEvent()).thenReturn(DraftService.EVENT_DRAFT_PATCH);
 
-    cut.processEvent(path, null, data, context);
+    cut.processEvent(path, null, data, context, new AttachmentContext.Inline("profilePicture"));
 
     // All prefixed fields should be cleared
     assertThat(values)
@@ -209,9 +214,9 @@ class MarkAsDeletedAttachmentEventTest {
 
     var data = Attachments.create();
     data.setContentId("old-content-id");
-    data.put(ApplicationHandlerHelper.INLINE_PREFIX_MARKER, "profilePicture");
+    data.put("_inlinePrefix", "profilePicture");
 
-    cut.processEvent(path, null, data, context);
+    cut.processEvent(path, null, data, context, new AttachmentContext.Inline("profilePicture"));
 
     // contentId differs from attachment's contentId, so fields should NOT be cleared
     assertThat(values).containsEntry("profilePicture_contentId", "different-new-content-id");

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/UpdateAttachmentEventTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/applicationservice/modifyevents/UpdateAttachmentEventTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.ql.cqn.Path;
 import com.sap.cds.ql.cqn.ResolvedSegment;
 import com.sap.cds.reflect.CdsEntity;
@@ -44,9 +45,22 @@ class UpdateAttachmentEventTest {
     var existingData = Attachments.create();
     var eventContext = mock(EventContext.class);
 
-    cut.processEvent(path, testContentStream, existingData, eventContext);
+    cut.processEvent(
+        path, testContentStream, existingData, eventContext, new AttachmentContext.Composition());
 
-    verify(createEvent).processEvent(path, testContentStream, existingData, eventContext);
-    verify(deleteEvent).processEvent(path, testContentStream, existingData, eventContext);
+    verify(createEvent)
+        .processEvent(
+            path,
+            testContentStream,
+            existingData,
+            eventContext,
+            new AttachmentContext.Composition());
+    verify(deleteEvent)
+        .processEvent(
+            path,
+            testContentStream,
+            existingData,
+            eventContext,
+            new AttachmentContext.Composition());
   }
 }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftCancelAttachmentsHandlerTest.java
@@ -16,7 +16,7 @@ import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservic
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.testservice.RootTable_;
 import com.sap.cds.feature.attachments.handler.applicationservice.modifyevents.MarkAsDeletedAttachmentEvent;
-import com.sap.cds.feature.attachments.handler.common.ApplicationHandlerHelper;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.handler.common.AttachmentsReader;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.ql.Delete;
@@ -187,7 +187,12 @@ class DraftCancelAttachmentsHandlerTest {
     cut.processBeforeDraftCancel(eventContext);
 
     verify(deleteContentAttachmentEvent)
-        .processEvent(any(), eq(null), dataArgumentCaptor.capture(), eq(eventContext));
+        .processEvent(
+            any(),
+            eq(null),
+            dataArgumentCaptor.capture(),
+            eq(eventContext),
+            any(AttachmentContext.class));
     assertThat(dataArgumentCaptor.getValue()).isEqualTo(attachment);
   }
 
@@ -206,7 +211,12 @@ class DraftCancelAttachmentsHandlerTest {
     cut.processBeforeDraftCancel(eventContext);
 
     verify(deleteContentAttachmentEvent)
-        .processEvent(any(), eq(null), dataArgumentCaptor.capture(), eq(eventContext));
+        .processEvent(
+            any(),
+            eq(null),
+            dataArgumentCaptor.capture(),
+            eq(eventContext),
+            any(AttachmentContext.class));
     assertThat(dataArgumentCaptor.getValue()).isEqualTo(draftAttachment);
   }
 
@@ -273,7 +283,8 @@ class DraftCancelAttachmentsHandlerTest {
     cut.processBeforeDraftCancel(eventContext);
 
     // Orphan prevention: draft has contentId but no matching active entry, so delete it
-    verify(deleteContentAttachmentEvent).processEvent(isNull(), isNull(), any(), eq(eventContext));
+    verify(deleteContentAttachmentEvent)
+        .processEvent(isNull(), isNull(), any(), eq(eventContext), any(AttachmentContext.class));
   }
 
   @Test
@@ -298,10 +309,14 @@ class DraftCancelAttachmentsHandlerTest {
     cut.processBeforeDraftCancel(eventContext);
 
     verify(deleteContentAttachmentEvent)
-        .processEvent(any(), eq(null), dataArgumentCaptor.capture(), eq(eventContext));
+        .processEvent(
+            any(),
+            eq(null),
+            dataArgumentCaptor.capture(),
+            eq(eventContext),
+            any(AttachmentContext.class));
     assertThat(dataArgumentCaptor.getValue().getContentId()).isEqualTo("new-content-id");
-    assertThat(dataArgumentCaptor.getValue().get(ApplicationHandlerHelper.INLINE_PREFIX_MARKER))
-        .isEqualTo("profilePicture");
+    assertThat(dataArgumentCaptor.getValue().get("_inlinePrefix")).isEqualTo("profilePicture");
   }
 
   @Test
@@ -331,7 +346,12 @@ class DraftCancelAttachmentsHandlerTest {
     cut.processBeforeDraftCancel(eventContext);
 
     verify(deleteContentAttachmentEvent)
-        .processEvent(any(), eq(null), dataArgumentCaptor.capture(), eq(eventContext));
+        .processEvent(
+            any(),
+            eq(null),
+            dataArgumentCaptor.capture(),
+            eq(eventContext),
+            any(AttachmentContext.class));
     assertThat(dataArgumentCaptor.getValue().getContentId()).isEqualTo("new-content-id");
   }
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/handler/draftservice/DraftPatchAttachmentsHandlerTest.java
@@ -148,7 +148,7 @@ class DraftPatchAttachmentsHandlerTest {
     InputStream captured = streamCaptor.getValue();
     assertThat(captured).isInstanceOf(CountingInputStream.class);
     assertThat(((CountingInputStream) captured).getDelegate()).isSameAs(content);
-    verify(event).processEvent(any(), eq(captured), eq(attachment), eq(eventContext));
+    verify(event).processEvent(any(), eq(captured), eq(attachment), eq(eventContext), any());
   }
 
   @Test

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/AttachmentsServiceImplTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/AttachmentsServiceImplTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.service.model.service.CreateAttachmentInput;
 import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
@@ -26,7 +27,6 @@ import com.sap.cds.services.runtime.CdsRuntime;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,7 +99,12 @@ class AttachmentsServiceImplTest {
     Map<String, Object> ids = Map.of("ID1", "value1", "id2", "Value2");
     var input =
         new CreateAttachmentInput(
-            ids, mock(CdsEntity.class), "fileName", "mimeType", stream, Optional.empty());
+            ids,
+            mock(CdsEntity.class),
+            "fileName",
+            "mimeType",
+            stream,
+            new AttachmentContext.Composition());
 
     var result = cut.createAttachment(input);
 
@@ -132,7 +137,7 @@ class AttachmentsServiceImplTest {
             "fileName",
             "mimeType",
             mock(InputStream.class),
-            Optional.empty());
+            new AttachmentContext.Composition());
 
     var result = cut.createAttachment(input);
 

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/AttachmentsServiceImplHandlerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/AttachmentsServiceImplHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.StatusCode;
 import com.sap.cds.feature.attachments.generated.test.cds4j.sap.attachments.Attachments;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.service.handler.transaction.EndTransactionMalwareScanProvider;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentMarkAsDeletedEventContext;
@@ -24,7 +25,6 @@ import com.sap.cds.services.impl.changeset.ChangeSetContextImpl;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -94,7 +94,8 @@ class AttachmentsServiceImplHandlerTest {
   void malwareScannerRegisteredForEndOfTransaction() {
     var listener = mock(ChangeSetListener.class);
     var entity = mock(CdsEntity.class);
-    when(malwareScanProvider.getChangeSetListener(entity, "contentId", Optional.empty()))
+    when(malwareScanProvider.getChangeSetListener(
+            entity, "contentId", new AttachmentContext.Composition()))
         .thenReturn(listener);
     var createContext = AttachmentCreateEventContext.create();
     createContext.setAttachmentIds(Map.of(Attachments.ID, "contentId"));
@@ -105,7 +106,8 @@ class AttachmentsServiceImplHandlerTest {
     cut.createAttachment(createContext);
     cut.afterCreateAttachment(createContext);
 
-    verify(malwareScanProvider).getChangeSetListener(entity, "contentId", Optional.empty());
+    verify(malwareScanProvider)
+        .getChangeSetListener(entity, "contentId", new AttachmentContext.Composition());
   }
 
   @Test

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/transaction/EndTransactionMalwareScanRunnerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/handler/transaction/EndTransactionMalwareScanRunnerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.helper.LogObserver;
 import com.sap.cds.feature.attachments.service.malware.AttachmentMalwareScanner;
 import com.sap.cds.reflect.CdsEntity;
@@ -20,7 +21,6 @@ import com.sap.cds.services.request.RequestContext;
 import com.sap.cds.services.runtime.CdsRuntime;
 import com.sap.cds.services.runtime.ChangeSetContextRunner;
 import com.sap.cds.services.runtime.RequestContextRunner;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -71,7 +71,11 @@ class EndTransactionMalwareScanRunnerTest {
     attachmentMalwareScanner = mock(AttachmentMalwareScanner.class);
     cut =
         new EndTransactionMalwareScanRunner(
-            attachmentEntity, contentId, Optional.empty(), attachmentMalwareScanner, runtime);
+            attachmentEntity,
+            contentId,
+            new AttachmentContext.Composition(),
+            attachmentMalwareScanner,
+            runtime);
     observer = LogObserver.create(cut.getClass().getName());
   }
 
@@ -89,7 +93,7 @@ class EndTransactionMalwareScanRunnerTest {
               return null;
             })
         .when(attachmentMalwareScanner)
-        .scanAttachment(attachmentEntity, contentId, Optional.empty());
+        .scanAttachment(attachmentEntity, contentId, new AttachmentContext.Composition());
 
     cut.afterClose(false);
 
@@ -112,12 +116,13 @@ class EndTransactionMalwareScanRunnerTest {
               return null;
             })
         .when(attachmentMalwareScanner)
-        .scanAttachment(attachmentEntity, contentId, Optional.empty());
+        .scanAttachment(attachmentEntity, contentId, new AttachmentContext.Composition());
 
     cut.afterClose(true);
 
     Awaitility.await().until(executionDone::get);
-    verify(attachmentMalwareScanner).scanAttachment(attachmentEntity, contentId, Optional.empty());
+    verify(attachmentMalwareScanner)
+        .scanAttachment(attachmentEntity, contentId, new AttachmentContext.Composition());
     assertThat(usedThread.get()).isNotEmpty().isNotEqualTo(Thread.currentThread().getName());
   }
 
@@ -128,7 +133,7 @@ class EndTransactionMalwareScanRunnerTest {
               throw new RuntimeException("Some exception");
             })
         .when(attachmentMalwareScanner)
-        .scanAttachment(attachmentEntity, contentId, Optional.empty());
+        .scanAttachment(attachmentEntity, contentId, new AttachmentContext.Composition());
     observer.start();
 
     cut.afterClose(true);
@@ -147,12 +152,13 @@ class EndTransactionMalwareScanRunnerTest {
               return null;
             })
         .when(attachmentMalwareScanner)
-        .scanAttachment(attachmentEntity, contentId, Optional.empty());
+        .scanAttachment(attachmentEntity, contentId, new AttachmentContext.Composition());
 
-    cut.scanAsync(attachmentEntity, contentId, Optional.empty());
+    cut.scanAsync(attachmentEntity, contentId, new AttachmentContext.Composition());
 
     Awaitility.await().until(executionDone::get);
-    verify(attachmentMalwareScanner).scanAttachment(attachmentEntity, contentId, Optional.empty());
+    verify(attachmentMalwareScanner)
+        .scanAttachment(attachmentEntity, contentId, new AttachmentContext.Composition());
     assertThat(usedThread.get()).isNotEmpty().isNotEqualTo(Thread.currentThread().getName());
   }
 
@@ -163,10 +169,10 @@ class EndTransactionMalwareScanRunnerTest {
               throw new RuntimeException("Some exception");
             })
         .when(attachmentMalwareScanner)
-        .scanAttachment(attachmentEntity, contentId, Optional.empty());
+        .scanAttachment(attachmentEntity, contentId, new AttachmentContext.Composition());
     observer.start();
 
-    cut.scanAsync(attachmentEntity, contentId, Optional.empty());
+    cut.scanAsync(attachmentEntity, contentId, new AttachmentContext.Composition());
 
     verifyLogIsWritten();
   }

--- a/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/DefaultAttachmentMalwareScannerTest.java
+++ b/cds-feature-attachments/src/test/java/com/sap/cds/feature/attachments/service/malware/DefaultAttachmentMalwareScannerTest.java
@@ -18,6 +18,7 @@ import com.sap.cds.Row;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.Attachments;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.StatusCode;
 import com.sap.cds.feature.attachments.generated.test.cds4j.unit.test.Attachment_;
+import com.sap.cds.feature.attachments.handler.common.AttachmentContext;
 import com.sap.cds.feature.attachments.handler.helper.RuntimeHelper;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.feature.attachments.service.malware.client.MalwareScanClient;
@@ -28,7 +29,6 @@ import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.persistence.PersistenceService;
 import com.sap.cds.services.runtime.CdsRuntime;
 import java.io.InputStream;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,7 +73,7 @@ class DefaultAttachmentMalwareScannerTest {
     var entity = runtime.getCdsModel().findEntity(Attachment_.CDS_NAME);
     when(persistenceService.run(any(CqnSelect.class))).thenReturn(result);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", new AttachmentContext.Composition());
 
     verify(persistenceService).run(selectCaptor.capture());
     var select = selectCaptor.getValue();
@@ -86,7 +86,7 @@ class DefaultAttachmentMalwareScannerTest {
     var entity = runtime.getCdsModel().findEntity(getTestServiceAttachmentName());
     mockSelectResult(Attachments.create(), MalwareScanResultStatus.CLEAN);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", new AttachmentContext.Composition());
 
     verify(persistenceService, times(2)).run(selectCaptor.capture());
     var selects = selectCaptor.getAllValues();
@@ -116,7 +116,7 @@ class DefaultAttachmentMalwareScannerTest {
     when(result.single()).thenReturn(row);
     when(malwareScanClient.scanContent(any())).thenReturn(MalwareScanResultStatus.CLEAN);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", new AttachmentContext.Composition());
 
     verify(malwareScanClient).scanContent(content);
     verify(persistenceService, times(2)).run(selectCaptor.capture());
@@ -136,7 +136,8 @@ class DefaultAttachmentMalwareScannerTest {
     when(result.rowCount()).thenReturn(2L);
 
     assertThrows(
-        IllegalStateException.class, () -> cut.scanAttachment(entity, "", Optional.empty()));
+        IllegalStateException.class,
+        () -> cut.scanAttachment(entity, "", new AttachmentContext.Composition()));
   }
 
   @ParameterizedTest
@@ -145,7 +146,7 @@ class DefaultAttachmentMalwareScannerTest {
     var entity = runtime.getCdsModel().findEntity(getTestServiceAttachmentName());
     mockSelectResult(Attachments.create(), status);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", new AttachmentContext.Composition());
 
     verifyPersistenceServiceCalledCorrectlyForReadAndUpdate(status);
   }
@@ -164,7 +165,7 @@ class DefaultAttachmentMalwareScannerTest {
     when(malwareScanClient.scanContent(any()))
         .thenThrow(new ServiceException("Error reading attachment"));
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", new AttachmentContext.Composition());
 
     verifyPersistenceServiceCalledCorrectlyForReadAndUpdate(MalwareScanResultStatus.FAILED);
   }
@@ -183,7 +184,7 @@ class DefaultAttachmentMalwareScannerTest {
     when(attachmentService.readAttachment(any()))
         .thenThrow(new ServiceException("Error reading attachment"));
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", new AttachmentContext.Composition());
 
     verifyPersistenceServiceCalledCorrectlyForReadAndUpdate(MalwareScanResultStatus.FAILED);
   }
@@ -196,7 +197,7 @@ class DefaultAttachmentMalwareScannerTest {
     data.put("content", content);
     mockSelectResult(data, MalwareScanResultStatus.CLEAN);
 
-    cut.scanAttachment(entity.orElseThrow(), "", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "", new AttachmentContext.Composition());
 
     verify(malwareScanClient, times(1)).scanContent(content);
     verifyNoInteractions(attachmentService);
@@ -212,7 +213,7 @@ class DefaultAttachmentMalwareScannerTest {
     var content = mock(InputStream.class);
     when(attachmentService.readAttachment(contentId)).thenReturn(content);
 
-    cut.scanAttachment(entity.orElseThrow(), "", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "", new AttachmentContext.Composition());
 
     verify(attachmentService, times(1)).readAttachment(contentId);
     verify(malwareScanClient, times(1)).scanContent(content);
@@ -228,7 +229,7 @@ class DefaultAttachmentMalwareScannerTest {
     var content = mock(InputStream.class);
     when(attachmentService.readAttachment(contentId)).thenReturn(content);
 
-    cut.scanAttachment(entity.orElseThrow(), "", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "", new AttachmentContext.Composition());
 
     verify(attachmentService, times(1)).readAttachment(contentId);
     verify(malwareScanClient, times(1)).scanContent(content);
@@ -251,7 +252,7 @@ class DefaultAttachmentMalwareScannerTest {
     when(result.single()).thenReturn(row);
     when(malwareScanClient.scanContent(any())).thenReturn(MalwareScanResultStatus.CLEAN);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", new AttachmentContext.Composition());
 
     verify(persistenceService, times(2)).run(updateCaptor.capture());
     var updateList = updateCaptor.getAllValues();
@@ -274,7 +275,7 @@ class DefaultAttachmentMalwareScannerTest {
     when(row.get("ID")).thenReturn("test-key-id");
     when(result.single()).thenReturn(row);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", new AttachmentContext.Composition());
 
     verifyNoInteractions(malwareScanClient);
     verify(persistenceService, times(2)).run(updateCaptor.capture());
@@ -313,7 +314,7 @@ class DefaultAttachmentMalwareScannerTest {
         .thenReturn(draftUpdateResult)
         .thenReturn(activeUpdateResult);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", new AttachmentContext.Composition());
 
     // Scan should happen once from draft content
     verify(malwareScanClient).scanContent(content);
@@ -335,7 +336,7 @@ class DefaultAttachmentMalwareScannerTest {
     when(emptyResult.rowCount()).thenReturn(0L);
     when(persistenceService.run(any(CqnSelect.class))).thenReturn(emptyResult);
 
-    cut.scanAttachment(entity.orElseThrow(), "ID", Optional.empty());
+    cut.scanAttachment(entity.orElseThrow(), "ID", new AttachmentContext.Composition());
 
     verifyNoInteractions(malwareScanClient);
     verify(persistenceService, times(0)).run(any(CqnUpdate.class));
@@ -360,7 +361,7 @@ class DefaultAttachmentMalwareScannerTest {
     when(result.single()).thenReturn(row);
     when(malwareScanClient.scanContent(any())).thenReturn(MalwareScanResultStatus.CLEAN);
 
-    cut.scanAttachment(entity, "inline-cid", Optional.of("avatar"));
+    cut.scanAttachment(entity, "inline-cid", new AttachmentContext.Inline("avatar"));
 
     verify(malwareScanClient).scanContent(content);
     verify(persistenceService, times(2)).run(updateCaptor.capture());


### PR DESCRIPTION
# Refactor: Introduce `AttachmentContext` to Consolidate Scattered Inline/Composition Logic

♻️ **Refactor**: Replaces scattered `Optional<String> inlinePrefix` pattern with a new sealed `AttachmentContext` interface, encapsulating how attachment fields are addressed regardless of whether they are composition-based or inlined into a parent entity.

### Changes

A new `AttachmentContext` sealed interface is introduced with two implementations — `Composition` (for composition-based attachments) and `Inline(String prefix)` (for flattened/inline attachments). This object is now propagated through the entire attachment processing pipeline, replacing repeated ad-hoc prefix resolution logic spread across many classes.

* `AttachmentContext.java` *(new)*: Sealed interface with `Composition` and `Inline` record implementations. Provides `fieldName()`, `matches()`, and `isInline()` methods used throughout the pipeline.
* `ApplicationHandlerHelper.java`: `INLINE_PREFIX_MARKER` visibility reduced to package-private; `resolveFieldName()` helper removed (replaced by `AttachmentContext.fieldName()`).
* `ModifyAttachmentEvent.java` / `CreateAttachmentEvent.java` / `UpdateAttachmentEvent.java` / `DoNothingAttachmentEvent.java` / `MarkAsDeletedAttachmentEvent.java`: `processEvent()` signature updated to accept `AttachmentContext` instead of reading the inline prefix from a marker field in the attachment data.
* `ModifyApplicationHandlerHelper.java`: All internal helpers (`getValMaxValue`, `getExistingAttachment`, `handleAttachmentForEntity`) updated to use `AttachmentContext` instead of `Optional<String>`.
* `ReadonlyDataContextEnhancer.java`: `preserveReadonlyFields` and `restoreReadonlyFields` now use `AttachmentContext` for context-aware key resolution, removing duplicated inline/composition branching.
* `ReadAttachmentsHandler.java` / `DeleteAttachmentsHandler.java` / `DraftCancelAttachmentsHandler.java` / `DraftPatchAttachmentsHandler.java`: All handler internals updated to build `AttachmentContext.from(...)` from the `CdsDataProcessor` callback and pass it downstream.
* `DefaultAttachmentsServiceHandler.java`: `afterCreateAttachment` reconstructs `AttachmentContext` from the stored inline prefix string.
* `EndTransactionMalwareScanProvider.java` / `EndTransactionMalwareScanRunner.java`: `Optional<String> inlinePrefix` parameter replaced with `AttachmentContext`.
* `AsyncMalwareScanExecutor.java` / `AttachmentMalwareScanner.java` / `DefaultAttachmentMalwareScanner.java`: Same interface/parameter update; inline extraction logic cleaned up using `AttachmentContext`.
* `CreateAttachmentInput.java` / `AttachmentsServiceImpl.java`: `inlinePrefix` field replaced with `AttachmentContext`.
* `Registration.java`: Updated instantiation sites to use `new AttachmentContext.Composition()` instead of `Optional.empty()`.
* All test classes updated accordingly to use the new `AttachmentContext` types in place of `Optional<String>` or `any()` matchers.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.0`

- Event Trigger: `pull_request.opened`
- Correlation ID: `3208c1df-aeff-48a2-aa13-5e437a0470e2`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
